### PR TITLE
fix a bug when in WriteAny<T> methods when any is null

### DIFF
--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterAnyExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterAnyExtensions.cs
@@ -51,6 +51,7 @@ namespace Microsoft.OpenApi.Writers
             if (any == null)
             {
                 writer.WriteNull();
+                return;
             }
 
             switch (any.AnyKind)


### PR DESCRIPTION
Fix a bug in WriteAny<T>(...) method by returning directly when `any` is null.