### PR TITLE
Fix line break issues in unit tests when built in a different environment

### DIFF
--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiContactTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiContactTests.cs
@@ -31,13 +31,15 @@ namespace Microsoft.OpenApi.Tests.Models
         [InlineData(OpenApiSpecVersion.OpenApi3_0, OpenApiFormat.Yaml, "")]
         [InlineData(OpenApiSpecVersion.OpenApi2_0, OpenApiFormat.Yaml, "")]
         public void SerializeBasicContactWorks(OpenApiSpecVersion version,
-            OpenApiFormat format, string expect)
+            OpenApiFormat format, string expected)
         {
             // Arrange & Act
             string actual = BasicContact.Serialize(version, format);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         [Theory]
@@ -46,7 +48,7 @@ namespace Microsoft.OpenApi.Tests.Models
         public void SerializeAdvanceContactAsJsonWorks(OpenApiSpecVersion version)
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"{
   ""name"": ""API Support"",
   ""url"": ""http://www.example.com/support"",
@@ -58,7 +60,9 @@ namespace Microsoft.OpenApi.Tests.Models
             string actual = AdvanceContact.SerializeAsJson(version);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         [Theory]
@@ -67,7 +71,7 @@ namespace Microsoft.OpenApi.Tests.Models
         public void SerializeAdvanceContactAsYamlWorks(OpenApiSpecVersion version)
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"name: API Support
 url: http://www.example.com/support
 email: support@example.com
@@ -77,7 +81,9 @@ x-internal-id: 42";
             string actual = AdvanceContact.SerializeAsYaml(version);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiEncodingTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiEncodingTests.cs
@@ -22,20 +22,22 @@ namespace Microsoft.OpenApi.Tests.Models
         [Theory]
         [InlineData(OpenApiFormat.Json, "{ }")]
         [InlineData(OpenApiFormat.Yaml, "")]
-        public void SerializeBasicEncodingAsV3Works(OpenApiFormat format, string expect)
+        public void SerializeBasicEncodingAsV3Works(OpenApiFormat format, string expected)
         {
             // Arrange & Act
             string actual = BasicEncoding.Serialize(OpenApiSpecVersion.OpenApi3_0, format);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void SerializeAdvanceEncodingAsV3JsonWorks()
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"{
   ""contentType"": ""image/png, image/jpeg"",
   ""style"": ""simple"",
@@ -47,14 +49,16 @@ namespace Microsoft.OpenApi.Tests.Models
             string actual = AdvanceEncoding.SerializeAsJson();
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void SerializeAdvanceEncodingAsV3YamlWorks()
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"contentType: image/png, image/jpeg
 style: simple
 explode: true
@@ -64,7 +68,9 @@ allowReserved: true";
             string actual = AdvanceEncoding.SerializeAsYaml();
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiExternalDocsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiExternalDocsTests.cs
@@ -22,20 +22,22 @@ namespace Microsoft.OpenApi.Tests.Models
         [Theory]
         [InlineData(OpenApiFormat.Json, "{ }")]
         [InlineData(OpenApiFormat.Yaml, "")]
-        public void SerializeBasicExternalDocsAsV3Works(OpenApiFormat format, string expect)
+        public void SerializeBasicExternalDocsAsV3Works(OpenApiFormat format, string expected)
         {
             // Arrange & Act
             string actual = BasicExDocs.Serialize(OpenApiSpecVersion.OpenApi3_0, format);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void SerializeAdvanceExDocsAsV3JsonWorks()
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"{
   ""description"": ""Find more info here"",
   ""url"": ""https://example.com""
@@ -45,14 +47,16 @@ namespace Microsoft.OpenApi.Tests.Models
             string actual = AdvanceExDocs.SerializeAsJson();
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void SerializeAdvanceExDocsAsV3YamlWorks()
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"description: Find more info here
 url: https://example.com";
 
@@ -60,7 +64,9 @@ url: https://example.com";
             string actual = AdvanceExDocs.SerializeAsYaml();
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         #endregion

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiInfoTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiInfoTests.cs
@@ -46,13 +46,15 @@ namespace Microsoft.OpenApi.Tests.Models
 
         [Theory]
         [MemberData(nameof(BasicInfoJsonExpect))]
-        public void SerializeBasicInfoAsJsonWorks(OpenApiSpecVersion version, string expect)
+        public void SerializeBasicInfoAsJsonWorks(OpenApiSpecVersion version, string expected)
         {
             // Arrange & Act
             string actual = BasicInfo.SerializeAsJson(version);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         public static IEnumerable<object[]> BasicInfoYamlExpect()
@@ -71,13 +73,15 @@ version: 1.0"
 
         [Theory]
         [MemberData(nameof(BasicInfoYamlExpect))]
-        public void SerializeBasicInfoAsYamlWorks(OpenApiSpecVersion version, string expect)
+        public void SerializeBasicInfoAsYamlWorks(OpenApiSpecVersion version, string expected)
         {
             // Arrange & Act
             string actual = BasicInfo.SerializeAsYaml(version);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         public static IEnumerable<object[]> AdvanceInfoJsonExpect()
@@ -112,13 +116,15 @@ version: 1.0"
 
         [Theory]
         [MemberData(nameof(AdvanceInfoJsonExpect))]
-        public void SerializeAdvanceInfoAsJsonWorks(OpenApiSpecVersion version, string expect)
+        public void SerializeAdvanceInfoAsJsonWorks(OpenApiSpecVersion version, string expected)
         {
             // Arrange & Act
             string actual = AdvanceInfo.SerializeAsJson(version);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         public static IEnumerable<object[]> AdvanceInfoYamlExpect()
@@ -149,13 +155,15 @@ x-updated: metadata"
 
         [Theory]
         [MemberData(nameof(AdvanceInfoYamlExpect))]
-        public void SerializeAdvanceInfoAsYamlWorks(OpenApiSpecVersion version, string expect)
+        public void SerializeAdvanceInfoAsYamlWorks(OpenApiSpecVersion version, string expected)
         {
             // Arrange & Act
             string actual = AdvanceInfo.SerializeAsYaml(version);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiLicenseTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiLicenseTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.OpenApi.Tests.Models
         public void SerializeBasicLicenseAsJsonWorks(OpenApiSpecVersion version)
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"{
   ""name"": ""Default Name""
 }";
@@ -39,7 +39,9 @@ namespace Microsoft.OpenApi.Tests.Models
             string actual = BasicLicense.SerializeAsJson(version);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         [Theory]
@@ -47,11 +49,16 @@ namespace Microsoft.OpenApi.Tests.Models
         [InlineData(OpenApiSpecVersion.OpenApi2_0)]
         public void SerializeBasicLicenseAsYamlWorks(OpenApiSpecVersion version)
         {
-            // Arrange & Act
+            // Arrange
+            string expected = "name: Default Name";
+
+            // Act
             string actual = BasicLicense.SerializeAsYaml(version);
 
             // Assert
-            Assert.Equal("name: Default Name", actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         [Theory]
@@ -60,7 +67,7 @@ namespace Microsoft.OpenApi.Tests.Models
         public void SerializeAdvanceLicenseAsJsonWorks(OpenApiSpecVersion version)
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"{
   ""name"": ""Apache 2.0"",
   ""url"": ""http://www.apache.org/licenses/LICENSE-2.0.html"",
@@ -71,7 +78,9 @@ namespace Microsoft.OpenApi.Tests.Models
             string actual = AdvanceLicense.SerializeAsJson(version);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         [Theory]
@@ -80,7 +89,7 @@ namespace Microsoft.OpenApi.Tests.Models
         public void SerializeAdvanceLicenseAsYamlWorks(OpenApiSpecVersion version)
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"name: Apache 2.0
 url: http://www.apache.org/licenses/LICENSE-2.0.html
 x-copyright: Abc";
@@ -89,7 +98,9 @@ x-copyright: Abc";
             string actual = AdvanceLicense.SerializeAsYaml(version);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiMediaTypeTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiMediaTypeTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.OpenApi.Tests.Models
         public void SerializeAdvanceMediaTypeAsV3JsonWorks()
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"{
   ""example"": 42,
   ""encoding"": {
@@ -55,14 +55,16 @@ namespace Microsoft.OpenApi.Tests.Models
             string actual = AdvanceMediaType.SerializeAsJson();
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
         public void SerializeAdvanceMediaTypeAsV3YamlWorks()
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"example: 42
 encoding:
   testEncoding:
@@ -75,7 +77,9 @@ encoding:
             string actual = AdvanceMediaType.SerializeAsYaml();
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiOAuthFlowTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiOAuthFlowTests.cs
@@ -58,6 +58,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = BasicOAuthFlow.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -72,6 +74,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = BasicOAuthFlow.SerializeAsYaml();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -92,6 +96,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = PartialOAuthFlow.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -114,6 +120,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = CompleteOAuthFlow.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
     }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiOAuthFlowsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiOAuthFlowsTests.cs
@@ -70,6 +70,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = BasicOAuthFlows.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -84,6 +86,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = BasicOAuthFlows.SerializeAsYaml();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -106,6 +110,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = OAuthFlowsWithSingleFlow.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -136,6 +142,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = OAuthFlowsWithMultipleFlows.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
     }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
@@ -64,6 +64,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = BasicParameter.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -94,6 +96,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = AdvancedPathParameterWithSchema.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
     }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -153,6 +153,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = BasicSchema.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -178,6 +180,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = AdvancedSchemaNumber.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -225,6 +229,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = AdvancedSchemaObject.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -275,6 +281,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = AdvancedSchemaWithAllOf.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
     }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSecurityRequirementTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSecurityRequirementTests.cs
@@ -64,6 +64,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = BasicSecurityRequirement.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -89,6 +91,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = AdvancedSecurityRequirement.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
     }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSecuritySchemeTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSecuritySchemeTests.cs
@@ -124,6 +124,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = ApiKeySecurityScheme.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -141,6 +143,8 @@ in: query";
             var actual = ApiKeySecurityScheme.SerializeAsYaml();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -159,6 +163,8 @@ in: query";
             var actual = HttpBasicSecurityScheme.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -178,6 +184,8 @@ in: query";
             var actual = HttpBearerSecurityScheme.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -204,6 +212,8 @@ in: query";
             var actual = OAuth2SingleFlowSecurityScheme.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -246,6 +256,8 @@ in: query";
             var actual = OAuth2MultipleFlowSecurityScheme.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -264,6 +276,8 @@ in: query";
             var actual = OpenIdConnectSecurityScheme.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
     }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSerializerTestHelper.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSerializerTestHelper.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.Tests.Models
             stream.Position = 0;
             var value = new StreamReader(stream).ReadToEnd();
 
-            return value.MakeLineBreaksEnvironmentNeutral();
+            return value;
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiServerTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiServerTests.cs
@@ -60,6 +60,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = BasicServer.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
 
@@ -94,6 +96,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = AdvancedServer.SerializeAsJson();
 
             // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
     }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiServerVariableTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiServerVariableTests.cs
@@ -27,20 +27,22 @@ namespace Microsoft.OpenApi.Tests.Models
         [Theory]
         [InlineData(OpenApiFormat.Json, "{ }")]
         [InlineData(OpenApiFormat.Yaml, "")]
-        public void SerializeBasicServerVariableAsV3Works(OpenApiFormat format, string expect)
+        public void SerializeBasicServerVariableAsV3Works(OpenApiFormat format, string expected)
         {
             // Arrange & Act
             string actual = BasicServerVariable.Serialize(OpenApiSpecVersion.OpenApi3_0, format);
 
             // Assert
-            actual.Should().Be(expect);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
         }
 
         [Fact]
         public void SerializeAdvancedServerVariableAsV3JsonWorks()
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"{
   ""default"": ""8443"",
   ""description"": ""test description"",
@@ -54,14 +56,16 @@ namespace Microsoft.OpenApi.Tests.Models
             string actual = AdvancedServerVariable.SerializeAsJson();
 
             // Assert
-            actual.Should().Be(expect);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
         }
 
         [Fact]
         public void SerializeAdvancedServerVariableAsV3YamlWorks()
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"default: 8443
 description: test description
 enum:
@@ -72,7 +76,9 @@ enum:
             string actual = AdvancedServerVariable.SerializeAsYaml();
 
             // Assert
-            actual.Should().Be(expect);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiTagTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiTagTests.cs
@@ -30,13 +30,15 @@ namespace Microsoft.OpenApi.Tests.Models
         [InlineData(OpenApiSpecVersion.OpenApi3_0, OpenApiFormat.Yaml, "")]
         [InlineData(OpenApiSpecVersion.OpenApi2_0, OpenApiFormat.Yaml, "")]
         public void SerializeBasicTagWorks(OpenApiSpecVersion version,
-            OpenApiFormat format, string expect)
+            OpenApiFormat format, string expected)
         {
-            // Arrange & Act
+            // Act
             string actual = BasicTag.Serialize(version, format);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         [Theory]
@@ -45,7 +47,7 @@ namespace Microsoft.OpenApi.Tests.Models
         public void SerializeAdvanceTagAsJsonWorks(OpenApiSpecVersion version)
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"{
   ""name"": ""pet"",
   ""description"": ""Pets operations"",
@@ -60,7 +62,9 @@ namespace Microsoft.OpenApi.Tests.Models
             string actual = AdvanceTag.SerializeAsJson(version);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
 
         [Theory]
@@ -69,7 +73,7 @@ namespace Microsoft.OpenApi.Tests.Models
         public void SerializeAdvanceTagAsYamlWorks(OpenApiSpecVersion version)
         {
             // Arrange
-            string expect = 
+            string expected = 
 @"name: pet
 description: Pets operations
 externalDocs:
@@ -81,7 +85,9 @@ x-tag-extension: ";
             string actual = AdvanceTag.SerializeAsYaml(version);
 
             // Assert
-            Assert.Equal(expect, actual);
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
     }
 }


### PR DESCRIPTION
- Always call `MakeLineBreaksEnvironmentNeutral` before comparing actual and expected strings.

- Change `expect` to `expected` in all places in unit tests