### PR TITLE
Change Info.Version to string to support various date formats

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiInfoDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiInfoDeserializer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "version", (o, n) =>
                 {
-                    o.Version = new Version(n.GetScalarValue());
+                    o.Version = n.GetScalarValue();
                 }
             }
         };

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiInfoDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiInfoDeserializer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "version", (o, n) =>
                 {
-                    o.Version = new Version(n.GetScalarValue());
+                    o.Version = n.GetScalarValue();
                 }
             },
             {

--- a/src/Microsoft.OpenApi/Models/OpenApiInfo.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiInfo.cs
@@ -29,7 +29,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// REQUIRED. The version of the OpenAPI document.
         /// </summary>
-        public Version Version { get; set; } = new Version(1, 0);
+        public string Version { get; set; } = "1.0";
 
         /// <summary>
         /// A URL to the Terms of Service for the API. MUST be in the format of a URL.

--- a/test/Microsoft.OpenApi.Tests/ExampleTests.cs
+++ b/test/Microsoft.OpenApi.Tests/ExampleTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.Tests
                 Info = new OpenApiInfo()
                 {
                     Title = "test",
-                    Version = new Version(1, 0)
+                    Version = "1.0"
                 }
             };
 

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiInfoTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiInfoTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.OpenApi.Tests.Models
             TermsOfService = new Uri("http://example.com/terms/"),
             Contact = OpenApiContactTests.AdvanceContact,
             License = OpenApiLicenseTests.AdvanceLicense,
-            Version = new Version(1, 1, 1),
+            Version = "1.1.1",
             Extensions = new Dictionary<string, IOpenApiAny>
             {
                 { "x-updated", new OpenApiString("metadata") }
@@ -165,6 +165,24 @@ x-updated: metadata"
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void InfoVersionShouldAcceptDateStyledAsVersions()
+        {
+            var info = new OpenApiInfo() {
+                Version = "2017-03-01"
+            };
+
+            var actual = info.Serialize(OpenApiSpecVersion.OpenApi3_0, OpenApiFormat.Yaml).MakeLineBreaksEnvironmentNeutral();
+
+            var expected = 
+@"title: Default Title
+version: 2017-03-01"
+.MakeLineBreaksEnvironmentNeutral();
+
+            actual.Should().Be(expected);
+
         }
     }
 }


### PR DESCRIPTION
The current model assumes that info.version is a major.minor.patch formatted version.  The spec only says that version should be a string https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#info-object
It is common practice for people to create descriptions using dates as a version.