### PR TITLE
Implementation for the Open API validation

### DIFF
--- a/src/Microsoft.OpenApi/Properties/SRResource.Designer.cs
+++ b/src/Microsoft.OpenApi/Properties/SRResource.Designer.cs
@@ -239,5 +239,23 @@ namespace Microsoft.OpenApi.Properties {
                 return ResourceManager.GetString("SourceExpressionHasInvalidFormat", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The path item name &apos;{0}&apos; MUST begin with a slash..
+        /// </summary>
+        internal static string Validation_PathItemMustBeginWithSlash {
+            get {
+                return ResourceManager.GetString("Validation_PathItemMustBeginWithSlash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The string &apos;{0}&apos; MUST be in the format of an email address..
+        /// </summary>
+        internal static string Validation_StringMustBeEmailAddress {
+            get {
+                return ResourceManager.GetString("Validation_StringMustBeEmailAddress", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.OpenApi/Properties/SRResource.Designer.cs
+++ b/src/Microsoft.OpenApi/Properties/SRResource.Designer.cs
@@ -250,11 +250,47 @@ namespace Microsoft.OpenApi.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The key &apos;{0}&apos; in &apos;{1}&apos; of components MUST match the regular expression &apos;{2}&apos;..
+        /// </summary>
+        internal static string Validation_ComponentsKeyMustMatchRegularExpr {
+            get {
+                return ResourceManager.GetString("Validation_ComponentsKeyMustMatchRegularExpr", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The extension name &apos;{0}&apos; in &apos;{1}&apos; object MUST begin with &apos;x-&apos;..
+        /// </summary>
+        internal static string Validation_ExtensionNameMustBeginWithXDash {
+            get {
+                return ResourceManager.GetString("Validation_ExtensionNameMustBeginWithXDash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field &apos;{0}&apos; in &apos;{1}&apos; object is REQUIRED..
+        /// </summary>
+        internal static string Validation_FieldIsRequired {
+            get {
+                return ResourceManager.GetString("Validation_FieldIsRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The path item name &apos;{0}&apos; MUST begin with a slash..
         /// </summary>
         internal static string Validation_PathItemMustBeginWithSlash {
             get {
                 return ResourceManager.GetString("Validation_PathItemMustBeginWithSlash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The same rule cannot be in the same rule set twice..
+        /// </summary>
+        internal static string Validation_RuleAddTwice {
+            get {
+                return ResourceManager.GetString("Validation_RuleAddTwice", resourceCulture);
             }
         }
         

--- a/src/Microsoft.OpenApi/Properties/SRResource.Designer.cs
+++ b/src/Microsoft.OpenApi/Properties/SRResource.Designer.cs
@@ -97,6 +97,15 @@ namespace Microsoft.OpenApi.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The input item should be in type of &apos;{0}&apos;..
+        /// </summary>
+        internal static string InputItemShouldBeType {
+            get {
+                return ResourceManager.GetString("InputItemShouldBeType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The active scope must be an object scope for property name &apos;{0}&apos; to be written..
         /// </summary>
         internal static string ObjectScopeNeededForPropertyNameWriting {

--- a/src/Microsoft.OpenApi/Properties/SRResource.Designer.cs
+++ b/src/Microsoft.OpenApi/Properties/SRResource.Designer.cs
@@ -241,6 +241,15 @@ namespace Microsoft.OpenApi.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Can not find visitor type registered for type &apos;{0}&apos;..
+        /// </summary>
+        internal static string UnknownVisitorType {
+            get {
+                return ResourceManager.GetString("UnknownVisitorType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The path item name &apos;{0}&apos; MUST begin with a slash..
         /// </summary>
         internal static string Validation_PathItemMustBeginWithSlash {

--- a/src/Microsoft.OpenApi/Properties/SRResource.resx
+++ b/src/Microsoft.OpenApi/Properties/SRResource.resx
@@ -177,4 +177,10 @@
   <data name="SourceExpressionHasInvalidFormat" xml:space="preserve">
     <value>The source expression '{0}' has invalid format.</value>
   </data>
+  <data name="Validation_PathItemMustBeginWithSlash" xml:space="preserve">
+    <value>The path item name '{0}' MUST begin with a slash.</value>
+  </data>
+  <data name="Validation_StringMustBeEmailAddress" xml:space="preserve">
+    <value>The string '{0}' MUST be in the format of an email address.</value>
+  </data>
 </root>

--- a/src/Microsoft.OpenApi/Properties/SRResource.resx
+++ b/src/Microsoft.OpenApi/Properties/SRResource.resx
@@ -177,6 +177,9 @@
   <data name="SourceExpressionHasInvalidFormat" xml:space="preserve">
     <value>The source expression '{0}' has invalid format.</value>
   </data>
+  <data name="UnknownVisitorType" xml:space="preserve">
+    <value>Can not find visitor type registered for type '{0}'.</value>
+  </data>
   <data name="Validation_PathItemMustBeginWithSlash" xml:space="preserve">
     <value>The path item name '{0}' MUST begin with a slash.</value>
   </data>

--- a/src/Microsoft.OpenApi/Properties/SRResource.resx
+++ b/src/Microsoft.OpenApi/Properties/SRResource.resx
@@ -180,8 +180,20 @@
   <data name="UnknownVisitorType" xml:space="preserve">
     <value>Can not find visitor type registered for type '{0}'.</value>
   </data>
+  <data name="Validation_ComponentsKeyMustMatchRegularExpr" xml:space="preserve">
+    <value>The key '{0}' in '{1}' of components MUST match the regular expression '{2}'.</value>
+  </data>
+  <data name="Validation_ExtensionNameMustBeginWithXDash" xml:space="preserve">
+    <value>The extension name '{0}' in '{1}' object MUST begin with 'x-'.</value>
+  </data>
+  <data name="Validation_FieldIsRequired" xml:space="preserve">
+    <value>The field '{0}' in '{1}' object is REQUIRED.</value>
+  </data>
   <data name="Validation_PathItemMustBeginWithSlash" xml:space="preserve">
     <value>The path item name '{0}' MUST begin with a slash.</value>
+  </data>
+  <data name="Validation_RuleAddTwice" xml:space="preserve">
+    <value>The same rule cannot be in the same rule set twice.</value>
   </data>
   <data name="Validation_StringMustBeEmailAddress" xml:space="preserve">
     <value>The string '{0}' MUST be in the format of an email address.</value>

--- a/src/Microsoft.OpenApi/Properties/SRResource.resx
+++ b/src/Microsoft.OpenApi/Properties/SRResource.resx
@@ -129,6 +129,9 @@
   <data name="IndentationLevelInvalid" xml:space="preserve">
     <value>Indentation level cannot be lower than 0.</value>
   </data>
+  <data name="InputItemShouldBeType" xml:space="preserve">
+    <value>The input item should be in type of '{0}'.</value>
+  </data>
   <data name="ObjectScopeNeededForPropertyNameWriting" xml:space="preserve">
     <value>The active scope must be an object scope for property name '{0}' to be written.</value>
   </data>

--- a/src/Microsoft.OpenApi/Validations/OpenApiElementValidator.cs
+++ b/src/Microsoft.OpenApi/Validations/OpenApiElementValidator.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.OpenApi/Validations/OpenApiElementValidator.cs
+++ b/src/Microsoft.OpenApi/Validations/OpenApiElementValidator.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OpenApi.Validations
         }
 
         /// <summary>
-        /// Validate the Open API element.
+        /// Validate the Open API element and output the whole validation errors.
         /// </summary>
         /// <typeparam name="T">The Open API element type.</typeparam>
         /// <param name="element">The Open API element.</param>
@@ -40,7 +40,7 @@ namespace Microsoft.OpenApi.Validations
         }
 
         /// <summary>
-        ///  Validate the Open API element.
+        ///  Validate the Open API element with the given rule set and output the whole validation errors.
         /// </summary>
         /// <typeparam name="T">The Open API element type.</typeparam>
         /// <param name="element">The Open API element.</param>

--- a/src/Microsoft.OpenApi/Validations/OpenApiElementValidator.cs
+++ b/src/Microsoft.OpenApi/Validations/OpenApiElementValidator.cs
@@ -1,0 +1,75 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Validations.Rules;
+
+namespace Microsoft.OpenApi.Validations
+{
+    /// <summary>
+    /// The public APIs to validate the Open API element.
+    /// </summary>
+    public static class OpenApiElementValidator
+    {
+        /// <summary>
+        /// Validate the Open API element.
+        /// </summary>
+        /// <typeparam name="T">The Open API element type.</typeparam>
+        /// <param name="element">The Open API element.</param>
+        /// <returns>True means no errors, otherwise with errors.</returns>
+        public static bool Validate<T>(this T element) where T : IOpenApiElement
+        {
+            IEnumerable<ValidationError> errors;
+            return element.Validate(out errors);
+        }
+
+        /// <summary>
+        /// Validate the Open API element.
+        /// </summary>
+        /// <typeparam name="T">The Open API element type.</typeparam>
+        /// <param name="element">The Open API element.</param>
+        /// <param name="errors">The output errors.</param>
+        /// <returns>True means no errors, otherwise with errors.</returns>
+        public static bool Validate<T>(this T element, out IEnumerable<ValidationError> errors)
+            where T : IOpenApiElement
+        {
+            ValidationRuleSet ruleSet = ValidationRuleSet.DefaultRuleSet;
+            return element.Validate(ruleSet, out errors);
+        }
+
+        /// <summary>
+        ///  Validate the Open API element.
+        /// </summary>
+        /// <typeparam name="T">The Open API element type.</typeparam>
+        /// <param name="element">The Open API element.</param>
+        /// <param name="ruleSet">The input rule set.</param>
+        /// <param name="errors">The output errors.</param>
+        /// <returns>True means no errors, otherwise with errors.</returns>
+        public static bool Validate<T>(this T element, ValidationRuleSet ruleSet, out IEnumerable<ValidationError> errors)
+            where T : IOpenApiElement
+        {
+            errors = null;
+            if (element == null)
+            {
+                return true;
+            }
+
+            if (ruleSet == null)
+            {
+                ruleSet = ValidationRuleSet.DefaultRuleSet;
+            }
+
+            ValidationContext context = new ValidationContext(ruleSet);
+
+            context.Validate(element);
+
+            errors = context.Errors;
+
+            return !errors.Any();
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiComponentsRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiComponentsRules.cs
@@ -11,6 +11,7 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiComponents"/>.
     /// </summary>
+    [OpenApiRule]
     public static class OpenApiComponentsRules
     {
         /// <summary>
@@ -22,7 +23,7 @@ namespace Microsoft.OpenApi.Validations.Rules
         /// All the fixed fields declared above are objects
         /// that MUST use keys that match the regular expression: ^[a-zA-Z0-9\.\-_]+$.
         /// </summary>
-        public static readonly ValidationRule<OpenApiComponents> KeyMustBeRegularExpression =
+        public static ValidationRule<OpenApiComponents> KeyMustBeRegularExpression =>
             new ValidationRule<OpenApiComponents>(
                 (context, components) =>
                 {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiComponentsRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiComponentsRules.cs
@@ -1,0 +1,16 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiComponents"/>.
+    /// </summary>
+    public static class OpenApiComponentsRules
+    {
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiComponentsRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiComponentsRules.cs
@@ -1,9 +1,10 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
 
 namespace Microsoft.OpenApi.Validations.Rules
 {
@@ -12,5 +13,54 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// </summary>
     public static class OpenApiComponentsRules
     {
+        /// <summary>
+        /// The key regex.
+        /// </summary>
+        public static Regex KeyRegex = new Regex(@"^[a-zA-Z0-9\.\-_]+$");
+
+        /// <summary>
+        /// All the fixed fields declared above are objects
+        /// that MUST use keys that match the regular expression: ^[a-zA-Z0-9\.\-_]+$.
+        /// </summary>
+        public static readonly ValidationRule<OpenApiComponents> KeyMustBeRegularExpression =
+            new ValidationRule<OpenApiComponents>(
+                (context, components) =>
+                {
+                    ValidateKeys(context, components.Schemas?.Keys, "schemas");
+
+                    ValidateKeys(context, components.Responses?.Keys, "responses");
+
+                    ValidateKeys(context, components.Parameters?.Keys, "parameters");
+
+                    ValidateKeys(context, components.Examples?.Keys, "examples");
+
+                    ValidateKeys(context, components.RequestBodies?.Keys, "requestBodies");
+
+                    ValidateKeys(context, components.Headers?.Keys, "headers");
+
+                    ValidateKeys(context, components.SecuritySchemes?.Keys, "securitySchemes");
+
+                    ValidateKeys(context, components.Links?.Keys, "links");
+
+                    ValidateKeys(context, components.Callbacks?.Keys, "callbacks");
+                });
+
+        private static void ValidateKeys(ValidationContext context, IEnumerable<string> keys, string component)
+        {
+            if (keys == null)
+            {
+                return;
+            }
+
+            foreach (var key in keys)
+            {
+                if (!KeyRegex.IsMatch(key))
+                {
+                    ValidationError error = new ValidationError(ErrorReason.Format, context.PathString,
+                        string.Format(SRResource.Validation_ComponentsKeyMustMatchRegularExpr, key, component, KeyRegex.ToString()));
+                    context.AddError(error);
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiContactRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiContactRules.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System;
 using Microsoft.OpenApi.Models;
@@ -26,7 +24,7 @@ namespace Microsoft.OpenApi.Validations.Rules
                     {
                         if (!item.Email.IsEmailAddress())
                         {
-                            ValidationError error = new ValidationError(ErrorReason.EmailFormat, context.PathString,
+                            ValidationError error = new ValidationError(ErrorReason.Format, context.PathString,
                                 String.Format(SRResource.Validation_StringMustBeEmailAddress, item.Email));
                             context.AddError(error);
                         }

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiContactRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiContactRules.cs
@@ -10,12 +10,13 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiContact"/>.
     /// </summary>
+    [OpenApiRule]
     internal static class OpenApiContactRules
     {
         /// <summary>
         /// Email field MUST be email address.
         /// </summary>
-        public static readonly ValidationRule<OpenApiContact> EmailMustBeEmailFormat =
+        public static ValidationRule<OpenApiContact> EmailMustBeEmailFormat =>
             new ValidationRule<OpenApiContact>(
                 (context, item) =>
                 {
@@ -35,7 +36,7 @@ namespace Microsoft.OpenApi.Validations.Rules
         /// <summary>
         /// Url field MUST be url format.
         /// </summary>
-        public static readonly ValidationRule<OpenApiContact> UrlMustBeUrlFormat =
+        public static ValidationRule<OpenApiContact> UrlMustBeUrlFormat =>
             new ValidationRule<OpenApiContact>(
                 (context, item) =>
                 {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiContactRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiContactRules.cs
@@ -1,0 +1,52 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiContact"/>.
+    /// </summary>
+    internal static class OpenApiContactRules
+    {
+        /// <summary>
+        /// Email field MUST be email address.
+        /// </summary>
+        public static readonly ValidationRule<OpenApiContact> EmailMustBeEmailFormat =
+            new ValidationRule<OpenApiContact>(
+                (context, item) =>
+                {
+                    context.Push("email");
+                    if (item != null && item.Email != null)
+                    {
+                        if (!item.Email.IsEmailAddress())
+                        {
+                            ValidationError error = new ValidationError(ErrorReason.EmailFormat, context.PathString,
+                                String.Format(SRResource.Validation_StringMustBeEmailAddress, item.Email));
+                            context.AddError(error);
+                        }
+                    }
+                    context.Pop();
+                });
+
+        /// <summary>
+        /// Url field MUST be url format.
+        /// </summary>
+        public static readonly ValidationRule<OpenApiContact> UrlMustBeUrlFormat =
+            new ValidationRule<OpenApiContact>(
+                (context, item) =>
+                {
+                    context.Push("url");
+                    if (item != null && item.Url != null)
+                    {
+                        // TODO:
+                    }
+                    context.Pop();
+                });
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
@@ -1,9 +1,9 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
+using System;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
 
 namespace Microsoft.OpenApi.Validations.Rules
 {
@@ -15,27 +15,29 @@ namespace Microsoft.OpenApi.Validations.Rules
         /// <summary>
         /// The Info field is required.
         /// </summary>
-        public static readonly ValidationRule<OpenApiDocument> InfoIsRequired =
+        public static readonly ValidationRule<OpenApiDocument> FieldIsRequired =
             new ValidationRule<OpenApiDocument>(
                 (context, item) =>
                 {
+                    // info
+                    context.Push("info");
                     if (item.Info == null)
                     {
-                        //context.AddError();
+                        ValidationError error = new ValidationError(ErrorReason.Required, context.PathString,
+                            String.Format(SRResource.Validation_FieldIsRequired, "info", "document"));
+                        context.AddError(error);
                     }
-                });
+                    context.Pop();
 
-        /// <summary>
-        /// The Paths field is required.
-        /// </summary>
-        public static readonly ValidationRule<OpenApiDocument> PathsIsRequired =
-            new ValidationRule<OpenApiDocument>(
-                (context, item) =>
-                {
+                    // paths
+                    context.Push("paths");
                     if (item.Paths == null)
                     {
-                        //context.AddError();
+                        ValidationError error = new ValidationError(ErrorReason.Required, context.PathString,
+                            String.Format(SRResource.Validation_FieldIsRequired, "paths", "document"));
+                        context.AddError(error);
                     }
+                    context.Pop();
                 });
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
@@ -10,12 +10,13 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiDocument"/>.
     /// </summary>
+    [OpenApiRule]
     internal static class OpenApiDocumentRules
     {
         /// <summary>
         /// The Info field is required.
         /// </summary>
-        public static readonly ValidationRule<OpenApiDocument> FieldIsRequired =
+        public static ValidationRule<OpenApiDocument> FieldIsRequired =>
             new ValidationRule<OpenApiDocument>(
                 (context, item) =>
                 {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
@@ -1,0 +1,41 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiDocument"/>.
+    /// </summary>
+    internal static class OpenApiDocumentRules
+    {
+        /// <summary>
+        /// The Info field is required.
+        /// </summary>
+        public static readonly ValidationRule<OpenApiDocument> InfoIsRequired =
+            new ValidationRule<OpenApiDocument>(
+                (context, item) =>
+                {
+                    if (item.Info == null)
+                    {
+                        //context.AddError();
+                    }
+                });
+
+        /// <summary>
+        /// The Paths field is required.
+        /// </summary>
+        public static readonly ValidationRule<OpenApiDocument> PathsIsRequired =
+            new ValidationRule<OpenApiDocument>(
+                (context, item) =>
+                {
+                    if (item.Paths == null)
+                    {
+                        //context.AddError();
+                    }
+                });
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiExtensionRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiExtensionRules.cs
@@ -10,12 +10,13 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="IOpenApiExtensible"/>.
     /// </summary>
+    [OpenApiRule]
     public static class OpenApiExtensibleRules
     {
         /// <summary>
         /// Extension name MUST start with "x-".
         /// </summary>
-        public static readonly ValidationRule<IOpenApiExtensible> ExtensionNameMustStartWithXDash =
+        public static ValidationRule<IOpenApiExtensible> ExtensionNameMustStartWithXDash =>
             new ValidationRule<IOpenApiExtensible>(
                 (context, item) =>
                 {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiExtensionRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiExtensionRules.cs
@@ -1,0 +1,28 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Interfaces;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="IOpenApiExtensible"/>.
+    /// </summary>
+    public static class OpenApiExtensibleRules
+    {
+        /// <summary>
+        /// Extension name MUST start with "x-".
+        /// </summary>
+        private static readonly ValidationRule<IOpenApiExtensible> ExtensionNameMustStartWithXDollar =
+            new ValidationRule<IOpenApiExtensible>(
+                (context, item) =>
+                {
+                    foreach (var extensible in item.Extensions)
+                    {
+
+                    }
+                });
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiExtensionRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiExtensionRules.cs
@@ -1,9 +1,9 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
+using System;
 using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Properties;
 
 namespace Microsoft.OpenApi.Validations.Rules
 {
@@ -15,14 +15,21 @@ namespace Microsoft.OpenApi.Validations.Rules
         /// <summary>
         /// Extension name MUST start with "x-".
         /// </summary>
-        private static readonly ValidationRule<IOpenApiExtensible> ExtensionNameMustStartWithXDollar =
+        public static readonly ValidationRule<IOpenApiExtensible> ExtensionNameMustStartWithXDash =
             new ValidationRule<IOpenApiExtensible>(
                 (context, item) =>
                 {
+                    context.Push("extensions");
                     foreach (var extensible in item.Extensions)
                     {
-
+                        if (!extensible.Key.StartsWith("x-"))
+                        {
+                            ValidationError error = new ValidationError(ErrorReason.Format, context.PathString,
+                                String.Format(SRResource.Validation_ExtensionNameMustBeginWithXDash, extensible.Key, context.PathString));
+                            context.AddError(error);
+                        }
                     }
+                    context.Pop();
                 });
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiExternalDocsRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiExternalDocsRules.cs
@@ -10,12 +10,13 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiExternalDocs"/>.
     /// </summary>
+    [OpenApiRule]
     internal static class OpenApiExternalDocsRules
     {
         /// <summary>
         /// Validate the field is required.
         /// </summary>
-        public static readonly ValidationRule<OpenApiExternalDocs> FieldIsRequired =
+        public static ValidationRule<OpenApiExternalDocs> FieldIsRequired =>
             new ValidationRule<OpenApiExternalDocs>(
                 (context, item) =>
                 {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiExternalDocsRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiExternalDocsRules.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiExternalDocs"/>.
+    /// </summary>
+    internal static class OpenApiExternalDocsRules
+    {
+        /// <summary>
+        /// Validate the field is required.
+        /// </summary>
+        public static readonly ValidationRule<OpenApiExternalDocs> FieldIsRequired =
+            new ValidationRule<OpenApiExternalDocs>(
+                (context, item) =>
+                {
+                    // title
+                    context.Push("url");
+                    if (item.Url == null)
+                    {
+                        ValidationError error = new ValidationError(ErrorReason.Required, context.PathString,
+                            String.Format(SRResource.Validation_FieldIsRequired, "url", "External Documentation"));
+                        context.AddError(error);
+                    }
+                    context.Pop();
+                });
+
+        // add more rule.
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiExternalDocsRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiExternalDocsRules.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             new ValidationRule<OpenApiExternalDocs>(
                 (context, item) =>
                 {
-                    // title
+                    // url
                     context.Push("url");
                     if (item.Url == null)
                     {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiInfoRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiInfoRules.cs
@@ -1,10 +1,9 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
 
 namespace Microsoft.OpenApi.Validations.Rules
 {
@@ -14,16 +13,31 @@ namespace Microsoft.OpenApi.Validations.Rules
     internal static class OpenApiInfoRules
     {
         /// <summary>
-        /// The title of the application is required.
+        /// Validate the field is required.
         /// </summary>
-        public static readonly ValidationRule<OpenApiInfo> TitleIsRequired =
+        public static readonly ValidationRule<OpenApiInfo> FieldIsRequired =
             new ValidationRule<OpenApiInfo>(
                 (context, item) =>
                 {
+                    // title
+                    context.Push("title");
                     if (String.IsNullOrEmpty(item.Title))
                     {
-                        // add error.
+                        ValidationError error = new ValidationError(ErrorReason.Required, context.PathString,
+                            String.Format(SRResource.Validation_FieldIsRequired, "url", "info"));
+                        context.AddError(error);
                     }
+                    context.Pop();
+
+                    // version
+                    context.Push("version");
+                    if (String.IsNullOrEmpty(item.Version))
+                    {
+                        ValidationError error = new ValidationError(ErrorReason.Required, context.PathString,
+                            String.Format(SRResource.Validation_FieldIsRequired, "version", "info"));
+                        context.AddError(error);
+                    }
+                    context.Pop();
                 });
 
         // add more rule.

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiInfoRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiInfoRules.cs
@@ -10,12 +10,13 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiInfo"/>.
     /// </summary>
+    [OpenApiRule]
     internal static class OpenApiInfoRules
     {
         /// <summary>
         /// Validate the field is required.
         /// </summary>
-        public static readonly ValidationRule<OpenApiInfo> FieldIsRequired =
+        public static ValidationRule<OpenApiInfo> FieldIsRequired =>
             new ValidationRule<OpenApiInfo>(
                 (context, item) =>
                 {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiInfoRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiInfoRules.cs
@@ -1,0 +1,31 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiInfo"/>.
+    /// </summary>
+    internal static class OpenApiInfoRules
+    {
+        /// <summary>
+        /// The title of the application is required.
+        /// </summary>
+        public static readonly ValidationRule<OpenApiInfo> TitleIsRequired =
+            new ValidationRule<OpenApiInfo>(
+                (context, item) =>
+                {
+                    if (String.IsNullOrEmpty(item.Title))
+                    {
+                        // add error.
+                    }
+                });
+
+        // add more rule.
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiLicenseRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiLicenseRules.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiLicense"/>.
+    /// </summary>
+    public static class OpenApiLicenseRules
+    {
+        /// <summary>
+        /// REQUIRED.
+        /// </summary>
+        public static readonly ValidationRule<OpenApiLicense> FieldIsRequired =
+            new ValidationRule<OpenApiLicense>(
+                (context, license) =>
+                {
+                    context.Push("name");
+                    if (String.IsNullOrEmpty(license.Name))
+                    {
+                        ValidationError error = new ValidationError(ErrorReason.Required, context.PathString,
+                            String.Format(SRResource.Validation_FieldIsRequired, "name", "license"));
+                        context.AddError(error);
+                    }
+                    context.Pop();
+                });
+
+        // add more rules
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiLicenseRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiLicenseRules.cs
@@ -10,12 +10,13 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiLicense"/>.
     /// </summary>
+    [OpenApiRule]
     public static class OpenApiLicenseRules
     {
         /// <summary>
         /// REQUIRED.
         /// </summary>
-        public static readonly ValidationRule<OpenApiLicense> FieldIsRequired =
+        public static ValidationRule<OpenApiLicense> FieldIsRequired =>
             new ValidationRule<OpenApiLicense>(
                 (context, license) =>
                 {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiOAuthFlowRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiOAuthFlowRules.cs
@@ -10,12 +10,13 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiOAuthFlow"/>.
     /// </summary>
+    [OpenApiRule]
     internal static class OpenApiOAuthFlowRules
     {
         /// <summary>
         /// Validate the field is required.
         /// </summary>
-        public static readonly ValidationRule<OpenApiOAuthFlow> FieldIsRequired =
+        public static ValidationRule<OpenApiOAuthFlow> FieldIsRequired =>
             new ValidationRule<OpenApiOAuthFlow>(
                 (context, flow) =>
                 {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiOAuthFlowRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiOAuthFlowRules.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiOAuthFlow"/>.
+    /// </summary>
+    internal static class OpenApiOAuthFlowRules
+    {
+        /// <summary>
+        /// Validate the field is required.
+        /// </summary>
+        public static readonly ValidationRule<OpenApiOAuthFlow> FieldIsRequired =
+            new ValidationRule<OpenApiOAuthFlow>(
+                (context, flow) =>
+                {
+                    // authorizationUrl
+                    context.Push("authorizationUrl");
+                    if (flow.AuthorizationUrl == null)
+                    {
+                        ValidationError error = new ValidationError(ErrorReason.Required, context.PathString,
+                            String.Format(SRResource.Validation_FieldIsRequired, "authorizationUrl", "OAuth Flow"));
+                        context.AddError(error);
+                    }
+                    context.Pop();
+
+                    // tokenUrl
+                    context.Push("tokenUrl");
+                    if (flow.TokenUrl == null)
+                    {
+                        ValidationError error = new ValidationError(ErrorReason.Required, context.PathString,
+                            String.Format(SRResource.Validation_FieldIsRequired, "tokenUrl", "OAuth Flow"));
+                        context.AddError(error);
+                    }
+                    context.Pop();
+
+                    // scopes
+                    context.Push("scopes");
+                    if (flow.Scopes == null)
+                    {
+                        ValidationError error = new ValidationError(ErrorReason.Required, context.PathString,
+                            String.Format(SRResource.Validation_FieldIsRequired, "scopes", "OAuth Flow"));
+                        context.AddError(error);
+                    }
+                    context.Pop();
+                });
+
+        // add more rule.
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiPathsRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiPathsRules.cs
@@ -1,0 +1,46 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiPaths"/>.
+    /// </summary>
+    public static class OpenApiPathsRules
+    {
+        /// <summary>
+        /// A relative path to an individual endpoint. The field name MUST begin with a slash. 
+        /// </summary>
+        public static readonly ValidationRule<OpenApiPaths> PathNameMustBeginWithSlash =
+            new ValidationRule<OpenApiPaths>(
+                (context, item) =>
+                {
+                    foreach (var pathName in item.Keys)
+                    {
+                        context.Push(pathName);
+
+                        if (string.IsNullOrEmpty(pathName))
+                        {
+                            // Add the error message
+                            // context.Add(...);
+                        }
+
+                        if (!pathName.StartsWith("/"))
+                        {
+                            ValidationError error = new ValidationError(ErrorReason.Format, context.PathString,
+                                string.Format(SRResource.Validation_PathItemMustBeginWithSlash, pathName));
+                            context.AddError(error);
+                        }
+
+                        context.Pop();
+                    }
+                });
+
+        // add more rules
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiPathsRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiPathsRules.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Properties;

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiPathsRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiPathsRules.cs
@@ -9,12 +9,13 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiPaths"/>.
     /// </summary>
+    [OpenApiRule]
     public static class OpenApiPathsRules
     {
         /// <summary>
         /// A relative path to an individual endpoint. The field name MUST begin with a slash. 
         /// </summary>
-        public static readonly ValidationRule<OpenApiPaths> PathNameMustBeginWithSlash =
+        public static ValidationRule<OpenApiPaths> PathNameMustBeginWithSlash =>
             new ValidationRule<OpenApiPaths>(
                 (context, item) =>
                 {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiPathsRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiPathsRules.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OpenApi.Validations.Rules
     public static class OpenApiPathsRules
     {
         /// <summary>
-        /// A relative path to an individual endpoint. The field name MUST begin with a slash. 
+        /// A relative path to an individual endpoint. The field name MUST begin with a slash.
         /// </summary>
         public static ValidationRule<OpenApiPaths> PathNameMustBeginWithSlash =>
             new ValidationRule<OpenApiPaths>(

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiResponseRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiResponseRules.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             new ValidationRule<OpenApiResponse>(
                 (context, response) =>
                 {
-                    // title
+                    // description
                     context.Push("description");
                     if (String.IsNullOrEmpty(response.Description))
                     {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiResponseRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiResponseRules.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiResponse"/>.
+    /// </summary>
+    internal static class OpenApiResponseRules
+    {
+        /// <summary>
+        /// Validate the field is required.
+        /// </summary>
+        public static readonly ValidationRule<OpenApiResponse> FieldIsRequired =
+            new ValidationRule<OpenApiResponse>(
+                (context, response) =>
+                {
+                    // title
+                    context.Push("description");
+                    if (String.IsNullOrEmpty(response.Description))
+                    {
+                        ValidationError error = new ValidationError(ErrorReason.Required, context.PathString,
+                            String.Format(SRResource.Validation_FieldIsRequired, "description", "response"));
+                        context.AddError(error);
+                    }
+                    context.Pop();
+                });
+
+        // add more rule.
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiResponseRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiResponseRules.cs
@@ -10,12 +10,13 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiResponse"/>.
     /// </summary>
+    [OpenApiRule]
     internal static class OpenApiResponseRules
     {
         /// <summary>
         /// Validate the field is required.
         /// </summary>
-        public static readonly ValidationRule<OpenApiResponse> FieldIsRequired =
+        public static ValidationRule<OpenApiResponse> FieldIsRequired =>
             new ValidationRule<OpenApiResponse>(
                 (context, response) =>
                 {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiRuleAttribute.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiRuleAttribute.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The Validator attribute.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    internal class OpenApiRuleAttribute : Attribute
+    {
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiServerRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiServerRules.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiServer"/>.
+    /// </summary>
+    public static class OpenApiServerRules
+    {
+        /// <summary>
+        /// REQUIRED.
+        /// </summary>
+        public static readonly ValidationRule<OpenApiServer> FieldIsRequired =
+            new ValidationRule<OpenApiServer>(
+                (context, server) =>
+                {
+                    context.Push("url");
+                    if (String.IsNullOrEmpty(server.Url))
+                    {
+                        ValidationError error = new ValidationError(ErrorReason.Required, context.PathString,
+                            String.Format(SRResource.Validation_FieldIsRequired, "url", "server"));
+                        context.AddError(error);
+                    }
+                    context.Pop();
+                });
+
+        // add more rules
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiServerRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiServerRules.cs
@@ -10,12 +10,13 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiServer"/>.
     /// </summary>
+    [OpenApiRule]
     public static class OpenApiServerRules
     {
         /// <summary>
         /// REQUIRED.
         /// </summary>
-        public static readonly ValidationRule<OpenApiServer> FieldIsRequired =
+        public static ValidationRule<OpenApiServer> FieldIsRequired =>
             new ValidationRule<OpenApiServer>(
                 (context, server) =>
                 {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiServerRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiServerRules.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OpenApi.Validations.Rules
     public static class OpenApiServerRules
     {
         /// <summary>
-        /// REQUIRED.
+        /// Validate the field is required.
         /// </summary>
         public static ValidationRule<OpenApiServer> FieldIsRequired =>
             new ValidationRule<OpenApiServer>(

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiTagRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiTagRules.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiTag"/>.
+    /// </summary>
+    public static class OpenApiTagRules
+    {
+        /// <summary>
+        /// REQUIRED.
+        /// </summary>
+        public static readonly ValidationRule<OpenApiTag> FieldIsRequired =
+            new ValidationRule<OpenApiTag>(
+                (context, tag) =>
+                {
+                    context.Push("name");
+                    if (String.IsNullOrEmpty(tag.Name))
+                    {
+                        ValidationError error = new ValidationError(ErrorReason.Required, context.PathString,
+                            String.Format(SRResource.Validation_FieldIsRequired, "name", "Tag"));
+                        context.AddError(error);
+                    }
+                    context.Pop();
+                });
+
+        // add more rules
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiTagRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiTagRules.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OpenApi.Validations.Rules
     public static class OpenApiTagRules
     {
         /// <summary>
-        /// REQUIRED.
+        /// Validate the field is required.
         /// </summary>
         public static ValidationRule<OpenApiTag> FieldIsRequired =>
             new ValidationRule<OpenApiTag>(

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiTagRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiTagRules.cs
@@ -10,12 +10,13 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiTag"/>.
     /// </summary>
+    [OpenApiRule]
     public static class OpenApiTagRules
     {
         /// <summary>
         /// REQUIRED.
         /// </summary>
-        public static readonly ValidationRule<OpenApiTag> FieldIsRequired =
+        public static ValidationRule<OpenApiTag> FieldIsRequired =>
             new ValidationRule<OpenApiTag>(
                 (context, tag) =>
                 {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiTagRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiTagRules.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OpenApi.Validations.Rules
                     if (String.IsNullOrEmpty(tag.Name))
                     {
                         ValidationError error = new ValidationError(ErrorReason.Required, context.PathString,
-                            String.Format(SRResource.Validation_FieldIsRequired, "name", "Tag"));
+                            String.Format(SRResource.Validation_FieldIsRequired, "name", "tag"));
                         context.AddError(error);
                     }
                     context.Pop();

--- a/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenApi.Validations.Rules
         /// Input string must be in the format of an email address
         /// </summary>
         /// <param name="input">The input string.</param>
-        /// <returns></returns>
+        /// <returns>True if it's an email address. Otherwise False.</returns>
         public static bool IsEmailAddress(this string input)
         {
             if (String.IsNullOrEmpty(input))

--- a/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
@@ -1,0 +1,40 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    internal static class RuleHelpers
+    {
+        /// <summary>
+        /// Input string must be in the format of an email address
+        /// </summary>
+        /// <param name="input">The input string.</param>
+        /// <returns></returns>
+        public static bool IsEmailAddress(this string input)
+        {
+            if (String.IsNullOrEmpty(input))
+            {
+                return false;
+            }
+
+            var splits = input.Split('@');
+            if (splits.Length != 2)
+            {
+                return false;
+            }
+
+            if (String.IsNullOrEmpty(splits[0]) || String.IsNullOrEmpty(splits[1]))
+            {
+                return false;
+            }
+
+            // Add more rules.
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System;
 

--- a/src/Microsoft.OpenApi/Validations/Rules/ValidationRule.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/ValidationRule.cs
@@ -1,0 +1,48 @@
+﻿
+using System;
+using System.Diagnostics;
+using Microsoft.OpenApi.Interfaces;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// Class containing validation rule logic.
+    /// </summary>
+    public abstract class ValidationRule
+    {
+        internal abstract Type ValidatedType { get; }
+
+        internal abstract void Evaluate(ValidationContext context, object item);
+    }
+
+    /// <summary>
+    /// Class containing validation rule logic for <see cref="IOpenApiElement"/>.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class ValidationRule<T> : ValidationRule
+        where T: IOpenApiElement
+    {
+        private readonly Action<ValidationContext, T> _validate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidationRule"/> class.
+        /// </summary>
+        /// <param name="validate">Action to perform the validation.</param>
+        public ValidationRule(Action<ValidationContext, T> validate)
+        {
+            this._validate = validate;
+        }
+
+        internal override Type ValidatedType
+        {
+            get { return typeof(T); }
+        }
+
+        internal override void Evaluate(ValidationContext context, object item)
+        {
+            Debug.Assert(item is T, "item should be " + typeof(T));
+            T typedItem = (T)item;
+            this._validate(context, typedItem);
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/ValidationRuleSet.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/ValidationRuleSet.cs
@@ -1,0 +1,114 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.OpenApi.Exceptions;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public sealed class ValidationRuleSet : IEnumerable<ValidationRule>
+    {
+        private IDictionary<Type, IList<ValidationRule>> _rules = new Dictionary<Type, IList<ValidationRule>>();
+
+        /// <summary>
+        /// The default rule set.
+        /// </summary>
+        public static ValidationRuleSet DefaultRuleSet = new ValidationRuleSet
+        {
+            OpenApiDocumentRules.InfoIsRequired,
+            OpenApiDocumentRules.PathsIsRequired,
+
+            OpenApiInfoRules.TitleIsRequired,
+
+            OpenApiContactRules.EmailMustBeEmailFormat,
+
+            // add more default rules.
+        };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidationRuleSet"/> class.
+        /// </summary>
+        public ValidationRuleSet()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValidationRuleSet"/> class.
+        /// </summary>
+        /// <param name="rules">Rules to be contained in this ruleset.</param>
+        public ValidationRuleSet(IEnumerable<ValidationRule> rules)
+        {
+            if (rules != null)
+            {
+                foreach (ValidationRule rule in rules)
+                {
+                    Add(rule);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the rules in this rule set.
+        /// </summary>
+        public IEnumerable<ValidationRule> Rules
+        {
+            get
+            {
+                return _rules.Values.SelectMany(v => v);
+            }
+        }
+
+        /// <summary>
+        /// Add the new rule into rule set.
+        /// </summary>
+        /// <param name="rule">The rule.</param>
+        public void Add(ValidationRule rule)
+        {
+            IList<ValidationRule> typeRules;
+            if (!_rules.TryGetValue(rule.ValidatedType, out typeRules))
+            {
+                typeRules = new List<ValidationRule>();
+                _rules[rule.ValidatedType] = typeRules;
+            }
+
+            if (typeRules.Contains(rule))
+            {
+                throw new OpenApiException("The same rule cannot be in the same rule set twice.");
+            }
+
+            typeRules.Add(rule);
+        }
+
+        /// <summary>
+        /// Get the enumerator.
+        /// </summary>
+        /// <returns>The enumerator.</returns>
+        public IEnumerator<ValidationRule> GetEnumerator()
+        {
+            foreach (List<ValidationRule> ruleList in _rules.Values)
+            {
+                foreach (var rule in ruleList)
+                {
+                    yield return rule;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get the enumerator.
+        /// </summary>
+        /// <returns>The enumerator.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/ValidationContext.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationContext.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System;
 using System.Collections.Generic;
@@ -72,7 +70,7 @@ namespace Microsoft.OpenApi.Validations
         {
             get
             {
-                return String.Join("/", _path);
+                return "#/" + String.Join("/", _path);
             }
         }
         #endregion

--- a/src/Microsoft.OpenApi/Validations/ValidationContext.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationContext.cs
@@ -1,0 +1,80 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.OpenApi.Validations.Rules;
+
+namespace Microsoft.OpenApi.Validations
+{
+    /// <summary>
+    /// The validation context.
+    /// </summary>
+    public class ValidationContext
+    {
+        private readonly IList<ValidationError> _errors = new List<ValidationError>();
+
+        /// <summary>
+        /// Initializes the <see cref="ValidationContext"/> class.
+        /// </summary>
+        /// <param name="ruleSet"></param>
+        public ValidationContext(ValidationRuleSet ruleSet)
+        {
+            RuleSet = ruleSet ?? throw Error.ArgumentNull(nameof(ruleSet));
+        }
+
+        /// <summary>
+        /// Gets the rule set.
+        /// </summary>
+        public ValidationRuleSet RuleSet { get; }
+
+        /// <summary>
+        /// Gets the validation errors.
+        /// </summary>
+        public IEnumerable<ValidationError> Errors
+        {
+            get
+            {
+                return _errors;
+            }
+        }
+
+        /// <summary>
+        /// Register an error with the validation context.
+        /// </summary>
+        /// <param name="error">Error to register.</param>
+        public void AddError(ValidationError error)
+        {
+            if (error == null)
+            {
+                throw Error.ArgumentNull(nameof(error));
+            }
+
+            _errors.Add(error);
+        }
+
+        #region Visit Path
+        private readonly Stack<string> _path = new Stack<string>();
+
+        internal void Push(string segment)
+        {
+            this._path.Push(segment);
+        }
+
+        internal void Pop()
+        {
+            this._path.Pop();
+        }
+
+        internal string PathString
+        {
+            get
+            {
+                return String.Join("/", _path);
+            }
+        }
+        #endregion
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/ValidationContextExtensions.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationContextExtensions.cs
@@ -3,9 +3,9 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
+using System.Collections.Generic;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Validations.Visitors;
-using System.Collections.Generic;
 
 namespace Microsoft.OpenApi.Validations
 {
@@ -53,6 +53,29 @@ namespace Microsoft.OpenApi.Validations
                 foreach (var element in collection)
                 {
                     context.Validate(element);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Validate the map of Open API element.
+        /// </summary>
+        /// <typeparam name="T">The Open API element.</typeparam>
+        /// <param name="context">The validation cotext.</param>
+        /// <param name="elements">The map of Open API element.</param>
+        public static void ValidateMap<T>(this ValidationContext context, IDictionary<string, T> elements)
+            where T : IOpenApiElement
+        {
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (elements != null)
+            {
+                foreach (var element in elements)
+                {
+                    context.Validate(element.Value);
                 }
             }
         }

--- a/src/Microsoft.OpenApi/Validations/ValidationContextExtensions.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationContextExtensions.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Collections.Generic;
 using Microsoft.OpenApi.Interfaces;

--- a/src/Microsoft.OpenApi/Validations/ValidationContextExtensions.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationContextExtensions.cs
@@ -1,0 +1,60 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Validations.Visitors;
+using System.Collections.Generic;
+
+namespace Microsoft.OpenApi.Validations
+{
+    internal static class ValidationContextExtensions
+    {
+        /// <summary>
+        /// Validate the Open API element.
+        /// </summary>
+        /// <typeparam name="T">The Open API element.</typeparam>
+        /// <param name="context">The validation cotext.</param>
+        /// <param name="element">The Open API element.</param>
+        public static void Validate<T>(this ValidationContext context, T element) where T : IOpenApiElement
+        {
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (element != null)
+            {
+                IVisitor visitor = OpenApiVisitorSet.GetVisitor(typeof(T));
+                if (visitor != null)
+                {
+                    visitor.Visit(context, element);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Validate the collection of Open API element.
+        /// </summary>
+        /// <typeparam name="T">The Open API element.</typeparam>
+        /// <param name="context">The validation cotext.</param>
+        /// <param name="collection">The collection of Open API element</param>
+        public static void ValidateCollection<T>(this ValidationContext context, IEnumerable<T> collection)
+            where T : IOpenApiElement
+        {
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (collection != null)
+            {
+                foreach (var element in collection)
+                {
+                    context.Validate(element);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/ValidationError.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationError.cs
@@ -1,0 +1,78 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.OpenApi.Validations
+{
+    /// <summary>
+    /// Error reason.
+    /// </summary>
+    public enum ErrorReason
+    {
+        /// <summary>
+        /// Field is required.
+        /// </summary>
+        FieldIsRequired,
+
+        /// <summary>
+        /// Format error.
+        /// </summary>
+        Format,
+
+        /// <summary>
+        /// Must be email format.
+        /// </summary>
+        EmailFormat,
+
+        /// <summary>
+        /// Must be Url format.
+        /// </summary>
+        UrlFormat,
+
+        // Add more.
+    }
+
+    /// <summary>
+    /// The validation error class.
+    /// </summary>
+    public sealed class ValidationError
+    {
+        /// <summary>
+        /// Initializes the <see cref="ValidationError"/> class.
+        /// </summary>
+        /// <param name="reason">The error reason.</param>
+        /// <param name="path">The visit path.</param>
+        /// <param name="message">The error message.</param>
+        public ValidationError(ErrorReason reason, string path, string message)
+        {
+            ErrorCode = reason;
+            ErrorPath = path;
+            ErrorMessage = message;
+        }
+
+        /// <summary>
+        /// Gets the path of the error in the Open API in which it occurred.
+        /// </summary>
+        public string ErrorPath { get; private set; }
+
+        /// <summary>
+        /// Gets an integer code representing the error.
+        /// </summary>
+        public ErrorReason ErrorCode { get; private set; }
+
+        /// <summary>
+        /// Gets a human readable string describing the error.
+        /// </summary>
+        public string ErrorMessage { get; private set; }
+
+        /// <summary>
+        /// Returns the whole error message.
+        /// </summary>
+        /// <returns>The error string.</returns>
+        public override string ToString()
+        {
+            return "ErroCode: " + ErrorCode + ", " + ErrorPath + " | " + ErrorMessage;
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/ValidationError.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationError.cs
@@ -58,7 +58,7 @@ namespace Microsoft.OpenApi.Validations
         /// <returns>The error string.</returns>
         public override string ToString()
         {
-            return "ErroCode: " + ErrorCode + ", " + ErrorPath + " | " + ErrorMessage;
+            return "ErrorCode: " + ErrorCode + ", " + ErrorPath + " | " + ErrorMessage;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/ValidationError.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationError.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 namespace Microsoft.OpenApi.Validations
 {
@@ -13,24 +11,12 @@ namespace Microsoft.OpenApi.Validations
         /// <summary>
         /// Field is required.
         /// </summary>
-        FieldIsRequired,
+        Required,
 
         /// <summary>
         /// Format error.
         /// </summary>
         Format,
-
-        /// <summary>
-        /// Must be email format.
-        /// </summary>
-        EmailFormat,
-
-        /// <summary>
-        /// Must be Url format.
-        /// </summary>
-        UrlFormat,
-
-        // Add more.
     }
 
     /// <summary>

--- a/src/Microsoft.OpenApi/Validations/ValidationRule.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationRule.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics;
 using Microsoft.OpenApi.Interfaces;
 
-namespace Microsoft.OpenApi.Validations.Rules
+namespace Microsoft.OpenApi.Validations
 {
     /// <summary>
     /// Class containing validation rule logic.

--- a/src/Microsoft.OpenApi/Validations/ValidationRule.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationRule.cs
@@ -1,4 +1,6 @@
-﻿
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
 using System;
 using System.Diagnostics;
 using Microsoft.OpenApi.Interfaces;
@@ -10,8 +12,16 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// </summary>
     public abstract class ValidationRule
     {
-        internal abstract Type ValidatedType { get; }
+        /// <summary>
+        /// Element Type.
+        /// </summary>
+        internal abstract Type ElementType { get; }
 
+        /// <summary>
+        /// Validate the object.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="item">The object item.</param>
         internal abstract void Evaluate(ValidationContext context, object item);
     }
 
@@ -19,8 +29,7 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// Class containing validation rule logic for <see cref="IOpenApiElement"/>.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class ValidationRule<T> : ValidationRule
-        where T: IOpenApiElement
+    public class ValidationRule<T> : ValidationRule where T: IOpenApiElement
     {
         private readonly Action<ValidationContext, T> _validate;
 
@@ -30,10 +39,10 @@ namespace Microsoft.OpenApi.Validations.Rules
         /// <param name="validate">Action to perform the validation.</param>
         public ValidationRule(Action<ValidationContext, T> validate)
         {
-            this._validate = validate;
+            _validate = validate ?? throw Error.ArgumentNull(nameof(validate));
         }
 
-        internal override Type ValidatedType
+        internal override Type ElementType
         {
             get { return typeof(T); }
         }

--- a/src/Microsoft.OpenApi/Validations/ValidationRule.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationRule.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. 
 
 using System;
-using System.Diagnostics;
 using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Properties;
 
 namespace Microsoft.OpenApi.Validations
 {
@@ -49,7 +49,21 @@ namespace Microsoft.OpenApi.Validations
 
         internal override void Evaluate(ValidationContext context, object item)
         {
-            Debug.Assert(item is T, "item should be " + typeof(T));
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (item == null)
+            {
+                return;
+            }
+
+            if (!(item is T))
+            {
+                throw Error.Argument(string.Format(SRResource.InputItemShouldBeType, typeof(T).FullName));
+            }
+
             T typedItem = (T)item;
             this._validate(context, typedItem);
         }

--- a/src/Microsoft.OpenApi/Validations/ValidationRuleSet.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationRuleSet.cs
@@ -8,8 +8,9 @@ using System.Collections;
 using System.Collections.Generic;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Properties;
+using Microsoft.OpenApi.Validations.Rules;
 
-namespace Microsoft.OpenApi.Validations.Rules
+namespace Microsoft.OpenApi.Validations
 {
     /// <summary>
     /// The rule set of the validation.

--- a/src/Microsoft.OpenApi/Validations/ValidationRuleSet.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationRuleSet.cs
@@ -40,6 +40,8 @@ namespace Microsoft.OpenApi.Validations.Rules
 
             OpenApiResponseRules.FieldIsRequired,
 
+            OpenApiOAuthFlowRules.FieldIsRequired,
+
             OpenApiExtensibleRules.ExtensionNameMustStartWithXDash,
             // add more default rules.
         };

--- a/src/Microsoft.OpenApi/Validations/ValidationRuleSet.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationRuleSet.cs
@@ -1,18 +1,17 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System;
 using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.OpenApi.Exceptions;
+using Microsoft.OpenApi.Properties;
 
 namespace Microsoft.OpenApi.Validations.Rules
 {
     /// <summary>
-    /// 
+    /// The rule set of the validation.
     /// </summary>
     public sealed class ValidationRuleSet : IEnumerable<ValidationRule>
     {
@@ -23,13 +22,25 @@ namespace Microsoft.OpenApi.Validations.Rules
         /// </summary>
         public static ValidationRuleSet DefaultRuleSet = new ValidationRuleSet
         {
-            OpenApiDocumentRules.InfoIsRequired,
-            OpenApiDocumentRules.PathsIsRequired,
+            OpenApiComponentsRules.KeyMustBeRegularExpression,
 
-            OpenApiInfoRules.TitleIsRequired,
+            OpenApiDocumentRules.FieldIsRequired,
+
+            OpenApiInfoRules.FieldIsRequired,
+
+            OpenApiLicenseRules.FieldIsRequired,
 
             OpenApiContactRules.EmailMustBeEmailFormat,
 
+            OpenApiExternalDocsRules.FieldIsRequired,
+
+            OpenApiServerRules.FieldIsRequired,
+
+            OpenApiTagRules.FieldIsRequired,
+
+            OpenApiResponseRules.FieldIsRequired,
+
+            OpenApiExtensibleRules.ExtensionNameMustStartWithXDash,
             // add more default rules.
         };
 
@@ -73,15 +84,15 @@ namespace Microsoft.OpenApi.Validations.Rules
         public void Add(ValidationRule rule)
         {
             IList<ValidationRule> typeRules;
-            if (!_rules.TryGetValue(rule.ValidatedType, out typeRules))
+            if (!_rules.TryGetValue(rule.ElementType, out typeRules))
             {
                 typeRules = new List<ValidationRule>();
-                _rules[rule.ValidatedType] = typeRules;
+                _rules[rule.ElementType] = typeRules;
             }
 
             if (typeRules.Contains(rule))
             {
-                throw new OpenApiException("The same rule cannot be in the same rule set twice.");
+                throw new OpenApiException(SRResource.Validation_RuleAddTwice);
             }
 
             typeRules.Add(rule);

--- a/src/Microsoft.OpenApi/Validations/Visitors/CallbackVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/CallbackVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/CallbackVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/CallbackVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="callback">The <see cref="OpenApiCallback"/>.</param>
         protected override void Next(ValidationContext context, OpenApiCallback callback)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(callback != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (callback == null)
+            {
+                throw Error.ArgumentNull(nameof(callback));
+            }
 
             foreach (var pathItem in callback.PathItems)
             {

--- a/src/Microsoft.OpenApi/Validations/Visitors/CallbackVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/CallbackVisitor.cs
@@ -9,25 +9,26 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiInfo"/>.
+    /// Visit <see cref="OpenApiCallback"/>.
     /// </summary>
-    internal class InfoVisitor : VisitorBase<OpenApiInfo>
+    internal class CallbackVisitor : VisitorBase<OpenApiCallback>
     {
         /// <summary>
-        /// Visit the children in <see cref="OpenApiInfo"/>.
+        /// Visit the children of the <see cref="OpenApiCallback"/>.
         /// </summary>
         /// <param name="context">The validation context.</param>
-        /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiInfo info)
+        /// <param name="callback">The <see cref="OpenApiCallback"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiCallback callback)
         {
             Debug.Assert(context != null);
-            Debug.Assert(info != null);
+            Debug.Assert(callback != null);
 
-            context.Validate(info.Contact);
+            foreach (var pathItem in callback.PathItems)
+            {
+                context.Validate(pathItem.Value);
+            }
 
-            context.Validate(info.License);
-
-            base.Next(context, info);
+            base.Next(context, callback);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/ComponentsVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ComponentsVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,18 +17,34 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="components">The <see cref="OpenApiComponents"/>.</param>
         protected override void Next(ValidationContext context, OpenApiComponents components)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(components != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (components == null)
+            {
+                throw Error.ArgumentNull(nameof(components));
+            }
 
             context.ValidateMap(components.Schemas);
+
             context.ValidateMap(components.Responses);
+
             context.ValidateMap(components.Parameters);
+
             context.ValidateMap(components.Examples);
+
             context.ValidateMap(components.RequestBodies);
+
             context.ValidateMap(components.Headers);
+
             context.ValidateMap(components.SecuritySchemes);
+
             context.ValidateMap(components.Links);
+
             context.ValidateMap(components.Callbacks);
+
             base.Next(context, components);
         }
     }

--- a/src/Microsoft.OpenApi/Validations/Visitors/ComponentsVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ComponentsVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/ComponentsVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ComponentsVisitor.cs
@@ -1,0 +1,38 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Diagnostics;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Visitors
+{
+    /// <summary>
+    /// Visit <see cref="OpenApiComponents"/>.
+    /// </summary>
+    internal class ComponentsVisitor : VisitorBase<OpenApiComponents>
+    {
+        /// <summary>
+        /// Visit the children of the <see cref="OpenApiComponents"/>.
+        /// </summary>
+        /// <param name="context">The validation context.</param>
+        /// <param name="components">The <see cref="OpenApiComponents"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiComponents components)
+        {
+            Debug.Assert(context != null);
+            Debug.Assert(components != null);
+
+            context.ValidateMap(components.Schemas);
+            context.ValidateMap(components.Responses);
+            context.ValidateMap(components.Parameters);
+            context.ValidateMap(components.Examples);
+            context.ValidateMap(components.RequestBodies);
+            context.ValidateMap(components.Headers);
+            context.ValidateMap(components.SecuritySchemes);
+            context.ValidateMap(components.Links);
+            context.ValidateMap(components.Callbacks);
+            base.Next(context, components);
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Visitors/ContactVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ContactVisitor.cs
@@ -1,0 +1,24 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Visitors
+{
+    /// <summary>
+    /// Visit <see cref="OpenApiContact"/>.
+    /// </summary>
+    internal class ContactVisitor : VisitorBase<OpenApiContact>
+    {
+        /// <summary>
+        /// Visit the children in <see cref="OpenApiContact"/>.
+        /// </summary>
+        /// <param name="context">The validation context.</param>
+        /// <param name="contact">The <see cref="OpenApiContact"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiContact contact)
+        {
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Visitors/ContactVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ContactVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using Microsoft.OpenApi.Models;
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/ContactVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ContactVisitor.cs
@@ -12,13 +12,5 @@ namespace Microsoft.OpenApi.Validations.Visitors
     /// </summary>
     internal class ContactVisitor : VisitorBase<OpenApiContact>
     {
-        /// <summary>
-        /// Visit the children in <see cref="OpenApiContact"/>.
-        /// </summary>
-        /// <param name="context">The validation context.</param>
-        /// <param name="contact">The <see cref="OpenApiContact"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiContact contact)
-        {
-        }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/DiscriminatorVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/DiscriminatorVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using Microsoft.OpenApi.Models;
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/DiscriminatorVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/DiscriminatorVisitor.cs
@@ -8,9 +8,9 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiLicense"/>.
+    /// Visit <see cref="OpenApiDiscriminator"/>.
     /// </summary>
-    internal class LicenseVisitor : VisitorBase<OpenApiLicense>
+    internal class DiscriminatorVisitor : VisitorBase<OpenApiDiscriminator>
     {
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/DocumentVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/DocumentVisitor.cs
@@ -1,0 +1,34 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Visitors
+{
+    /// <summary>
+    /// Vistor for <see cref="OpenApiDocument"/>
+    /// </summary>
+    internal class DocumentVisitor : VisitorBase<OpenApiDocument>
+    {
+        /// <summary>
+        /// Visit the children of the <see cref="OpenApiDocument"/>.
+        /// </summary>
+        /// <param name="context">The validation context.</param>
+        /// <param name="document">The <see cref="OpenApiDocument"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiDocument document)
+        {
+            if (document == null)
+            {
+                return;
+            }
+
+            context.Validate(document.Info);
+
+            context.ValidateCollection(document.Tags);
+
+            // add more.
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Visitors/DocumentVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/DocumentVisitor.cs
@@ -17,16 +17,31 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="document">The <see cref="OpenApiDocument"/>.</param>
         protected override void Next(ValidationContext context, OpenApiDocument document)
         {
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
             if (document == null)
             {
-                return;
+                throw Error.ArgumentNull(nameof(document));
             }
 
             context.Validate(document.Info);
 
+            context.ValidateCollection(document.Servers);
+
+            context.Validate(document.Paths);
+
+            context.Validate(document.Components);
+
+            context.ValidateCollection(document.SecurityRequirements);
+
             context.ValidateCollection(document.Tags);
 
-            // add more.
+            context.Validate(document.ExternalDocs);
+
+            base.Next(context, document);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/DocumentVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/DocumentVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using Microsoft.OpenApi.Models;
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/EncodingVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/EncodingVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/EncodingVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/EncodingVisitor.cs
@@ -9,25 +9,23 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiInfo"/>.
+    /// Visit <see cref="OpenApiEncoding"/>.
     /// </summary>
-    internal class InfoVisitor : VisitorBase<OpenApiInfo>
+    internal class EncodingVisitor : VisitorBase<OpenApiEncoding>
     {
         /// <summary>
-        /// Visit the children in <see cref="OpenApiInfo"/>.
+        /// Visit the children in <see cref="OpenApiEncoding"/>.
         /// </summary>
         /// <param name="context">The validation context.</param>
-        /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiInfo info)
+        /// <param name="encoding">The <see cref="OpenApiEncoding"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiEncoding encoding)
         {
             Debug.Assert(context != null);
-            Debug.Assert(info != null);
+            Debug.Assert(encoding != null);
 
-            context.Validate(info.Contact);
+            context.ValidateMap(encoding.Headers);
 
-            context.Validate(info.License);
-
-            base.Next(context, info);
+            base.Next(context, encoding);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/EncodingVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/EncodingVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="encoding">The <see cref="OpenApiEncoding"/>.</param>
         protected override void Next(ValidationContext context, OpenApiEncoding encoding)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(encoding != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (encoding == null)
+            {
+                throw Error.ArgumentNull(nameof(encoding));
+            }
 
             context.ValidateMap(encoding.Headers);
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/ExampleVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ExampleVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using Microsoft.OpenApi.Models;
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/ExampleVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ExampleVisitor.cs
@@ -8,9 +8,9 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiLicense"/>.
+    /// Visit <see cref="OpenApiExample"/>.
     /// </summary>
-    internal class LicenseVisitor : VisitorBase<OpenApiLicense>
+    internal class ExampleVisitor : VisitorBase<OpenApiExample>
     {
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/ExternalDocsVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ExternalDocsVisitor.cs
@@ -8,9 +8,9 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiLicense"/>.
+    /// Visit <see cref="OpenApiExternalDocs"/>.
     /// </summary>
-    internal class LicenseVisitor : VisitorBase<OpenApiLicense>
+    internal class ExternalDocsVisitor : VisitorBase<OpenApiExternalDocs>
     {
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/ExternalDocsVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ExternalDocsVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using Microsoft.OpenApi.Models;
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/HeaderVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/HeaderVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/HeaderVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/HeaderVisitor.cs
@@ -9,25 +9,27 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiInfo"/>.
+    /// Visit <see cref="OpenApiHeader"/>.
     /// </summary>
-    internal class InfoVisitor : VisitorBase<OpenApiInfo>
+    internal class HeaderVisitor : VisitorBase<OpenApiHeader>
     {
         /// <summary>
-        /// Visit the children in <see cref="OpenApiInfo"/>.
+        /// Visit the children in <see cref="OpenApiHeader"/>.
         /// </summary>
         /// <param name="context">The validation context.</param>
-        /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiInfo info)
+        /// <param name="header">The <see cref="OpenApiHeader"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiHeader header)
         {
             Debug.Assert(context != null);
-            Debug.Assert(info != null);
+            Debug.Assert(header != null);
 
-            context.Validate(info.Contact);
+            context.Validate(header.Schema);
 
-            context.Validate(info.License);
+            context.ValidateCollection(header.Examples);
 
-            base.Next(context, info);
+            context.ValidateMap(header.Content);
+
+            base.Next(context, header);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/HeaderVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/HeaderVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="header">The <see cref="OpenApiHeader"/>.</param>
         protected override void Next(ValidationContext context, OpenApiHeader header)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(header != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (header == null)
+            {
+                throw Error.ArgumentNull(nameof(header));
+            }
 
             context.Validate(header.Schema);
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/IVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/IVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 namespace Microsoft.OpenApi.Validations.Visitors
 {

--- a/src/Microsoft.OpenApi/Validations/Visitors/IVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/IVisitor.cs
@@ -1,0 +1,20 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.OpenApi.Validations.Visitors
+{
+    /// <summary>
+    /// The interface for visitor.
+    /// </summary>
+    internal interface IVisitor
+    {
+        /// <summary>
+        /// Visit the object.
+        /// </summary>
+        /// <param name="context">The validation context.</param>
+        /// <param name="item">The validation object.</param>
+        void Visit(ValidationContext context, object item);
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Visitors/InfoVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/InfoVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/InfoVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/InfoVisitor.cs
@@ -1,0 +1,32 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Visitors
+{
+    /// <summary>
+    /// Visit <see cref="OpenApiInfo"/>.
+    /// </summary>
+    internal class InfoVisitor : VisitorBase<OpenApiInfo>
+    {
+        /// <summary>
+        /// Visit the children in <see cref="OpenApiInfo"/>.
+        /// </summary>
+        /// <param name="context">The validation context.</param>
+        /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiInfo info)
+        {
+            if (info == null)
+            {
+                return;
+            }
+
+            context.Validate(info.Contact);
+
+            context.Validate(info.License);
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Visitors/InfoVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/InfoVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
         protected override void Next(ValidationContext context, OpenApiInfo info)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(info != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (info == null)
+            {
+                throw Error.ArgumentNull(nameof(info));
+            }
 
             context.Validate(info.Contact);
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/LicenseVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/LicenseVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using Microsoft.OpenApi.Models;
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/LicenseVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/LicenseVisitor.cs
@@ -1,0 +1,28 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Visitors
+{
+    /// <summary>
+    /// Visit <see cref="OpenApiContact"/>.
+    /// </summary>
+    internal class LicenseVisitor : VisitorBase<OpenApiLicense>
+    {
+        /// <summary>
+        /// Visit the children in <see cref="OpenApiLicense"/>.
+        /// </summary>
+        /// <param name="context">The validation context.</param>
+        /// <param name="license">The <see cref="OpenApiLicense"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiLicense license)
+        {
+            if (license == null)
+            {
+                return;
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Visitors/LinkVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/LinkVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="link">The <see cref="OpenApiLink"/>.</param>
         protected override void Next(ValidationContext context, OpenApiLink link)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(link != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (link == null)
+            {
+                throw Error.ArgumentNull(nameof(link));
+            }
 
             context.Validate(link.Server);
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/LinkVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/LinkVisitor.cs
@@ -9,25 +9,23 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiInfo"/>.
+    /// Visit <see cref="OpenApiLink"/>.
     /// </summary>
-    internal class InfoVisitor : VisitorBase<OpenApiInfo>
+    internal class LinkVisitor : VisitorBase<OpenApiLink>
     {
         /// <summary>
-        /// Visit the children in <see cref="OpenApiInfo"/>.
+        /// Visit the children of the <see cref="OpenApiLink"/>.
         /// </summary>
         /// <param name="context">The validation context.</param>
-        /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiInfo info)
+        /// <param name="link">The <see cref="OpenApiLink"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiLink link)
         {
             Debug.Assert(context != null);
-            Debug.Assert(info != null);
+            Debug.Assert(link != null);
 
-            context.Validate(info.Contact);
+            context.Validate(link.Server);
 
-            context.Validate(info.License);
-
-            base.Next(context, info);
+            base.Next(context, link);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/LinkVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/LinkVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/MediaTypeVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/MediaTypeVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/MediaTypeVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/MediaTypeVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="mediaType">The <see cref="OpenApiMediaType"/>.</param>
         protected override void Next(ValidationContext context, OpenApiMediaType mediaType)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(mediaType != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (mediaType == null)
+            {
+                throw Error.ArgumentNull(nameof(mediaType));
+            }
 
             context.Validate(mediaType.Schema);
             context.ValidateMap(mediaType.Examples);

--- a/src/Microsoft.OpenApi/Validations/Visitors/MediaTypeVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/MediaTypeVisitor.cs
@@ -9,25 +9,25 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiInfo"/>.
+    /// Visit <see cref="OpenApiMediaType"/>.
     /// </summary>
-    internal class InfoVisitor : VisitorBase<OpenApiInfo>
+    internal class MediaTypeVisitor : VisitorBase<OpenApiMediaType>
     {
         /// <summary>
-        /// Visit the children in <see cref="OpenApiInfo"/>.
+        /// Visit the children of the <see cref="OpenApiMediaType"/>.
         /// </summary>
         /// <param name="context">The validation context.</param>
-        /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiInfo info)
+        /// <param name="mediaType">The <see cref="OpenApiMediaType"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiMediaType mediaType)
         {
             Debug.Assert(context != null);
-            Debug.Assert(info != null);
+            Debug.Assert(mediaType != null);
 
-            context.Validate(info.Contact);
+            context.Validate(mediaType.Schema);
+            context.ValidateMap(mediaType.Examples);
+            context.ValidateMap(mediaType.Encoding);
 
-            context.Validate(info.License);
-
-            base.Next(context, info);
+            base.Next(context, mediaType);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/OAuthFlowVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/OAuthFlowVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using Microsoft.OpenApi.Models;
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/OAuthFlowVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/OAuthFlowVisitor.cs
@@ -8,9 +8,9 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiLicense"/>.
+    /// Visit <see cref="OpenApiOAuthFlow"/>.
     /// </summary>
-    internal class LicenseVisitor : VisitorBase<OpenApiLicense>
+    internal class OAuthFlowVisitor : VisitorBase<OpenApiOAuthFlow>
     {
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/OAuthFlowsVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/OAuthFlowsVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/OAuthFlowsVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/OAuthFlowsVisitor.cs
@@ -1,0 +1,34 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Diagnostics;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Visitors
+{
+    /// <summary>
+    /// Visit <see cref="OpenApiOAuthFlows"/>.
+    /// </summary>
+    internal class OAuthFlowsVisitor : VisitorBase<OpenApiOAuthFlows>
+    {
+        /// <summary>
+        /// Visit the children of the <see cref="OpenApiOAuthFlows"/>.
+        /// </summary>
+        /// <param name="context">The validation context.</param>
+        /// <param name="oAuthFlows">The <see cref="OpenApiOAuthFlows"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiOAuthFlows oAuthFlows)
+        {
+            Debug.Assert(context != null);
+            Debug.Assert(oAuthFlows != null);
+
+            context.Validate(oAuthFlows.Implicit);
+            context.Validate(oAuthFlows.Password);
+            context.Validate(oAuthFlows.ClientCredentials);
+            context.Validate(oAuthFlows.AuthorizationCode);
+
+            base.Next(context, oAuthFlows);
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Visitors/OAuthFlowsVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/OAuthFlowsVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="oAuthFlows">The <see cref="OpenApiOAuthFlows"/>.</param>
         protected override void Next(ValidationContext context, OpenApiOAuthFlows oAuthFlows)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(oAuthFlows != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (oAuthFlows == null)
+            {
+                throw Error.ArgumentNull(nameof(oAuthFlows));
+            }
 
             context.Validate(oAuthFlows.Implicit);
             context.Validate(oAuthFlows.Password);

--- a/src/Microsoft.OpenApi/Validations/Visitors/OpenApiVisitorSet.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/OpenApiVisitorSet.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System;
 using System.Collections.Generic;

--- a/src/Microsoft.OpenApi/Validations/Visitors/OpenApiVisitorSet.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/OpenApiVisitorSet.cs
@@ -3,27 +3,50 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
-using Microsoft.OpenApi.Models;
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using Microsoft.OpenApi.Exceptions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
 
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// 
+    /// Class to cache the <see cref="IVisitor"/>.
     /// </summary>
     internal static class OpenApiVisitorSet
     {
-        private static IDictionary<Type, IVisitor> _elementVisitor = new Dictionary<Type, IVisitor>
+        private static IDictionary<Type, IVisitor> _visitorCache = new Dictionary<Type, IVisitor>
         {
-            { typeof(OpenApiDocument), new DocumentVisitor() },
-            { typeof(OpenApiInfo), new InfoVisitor() },
-            { typeof(OpenApiTag), new TagVisitor() },
-            { typeof(OpenApiLicense), new LicenseVisitor() },
+            { typeof(OpenApiCallback), new CallbackVisitor() },
+            { typeof(OpenApiComponents), new ComponentsVisitor() },
             { typeof(OpenApiContact), new ContactVisitor() },
-
-            // add more
+            { typeof(OpenApiDiscriminator), new DiscriminatorVisitor() },
+            { typeof(OpenApiDocument), new DocumentVisitor() },
+            { typeof(OpenApiEncoding), new EncodingVisitor() },
+            { typeof(OpenApiExample), new ExampleVisitor() },
+            { typeof(OpenApiExternalDocs), new ExternalDocsVisitor() },
+            { typeof(OpenApiHeader), new HeaderVisitor() },
+            { typeof(OpenApiInfo), new InfoVisitor() },
+            { typeof(OpenApiLicense), new LicenseVisitor() },
+            { typeof(OpenApiLink), new LinkVisitor() },
+            { typeof(OpenApiMediaType), new MediaTypeVisitor() },
+            { typeof(OpenApiOAuthFlows), new OAuthFlowsVisitor() },
+            { typeof(OpenApiOAuthFlow), new OAuthFlowVisitor() },
+            { typeof(OpenApiOperation), new OperationVisitor() },
+            { typeof(OpenApiParameter), new ParameterVisitor() },
+            { typeof(OpenApiPathItem), new PathItemVisitor() },
+            { typeof(OpenApiPaths), new PathsVisitor() },
+            { typeof(OpenApiRequestBody), new RequestBodyVisitor() },
+            { typeof(OpenApiResponses), new ResponsesVisitor() },
+            { typeof(OpenApiResponse), new ResponseVisitor() },
+            { typeof(OpenApiSchema), new SchemaVisitor() },
+            { typeof(OpenApiSecurityRequirement), new SecurityRequirementVisitor() },
+            { typeof(OpenApiSecurityScheme), new SecuritySchemeVisitor() },
+            { typeof(OpenApiServerVariable), new ServerVariableVisitor() },
+            { typeof(OpenApiServer), new ServerVisitor() },
+            { typeof(OpenApiTag), new TagVisitor() },
+            { typeof(OpenApiXml), new XmlVisitor() }
         };
 
         /// <summary>
@@ -33,13 +56,13 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <returns>The element visitor or null.</returns>
         public static IVisitor GetVisitor(Type elementType)
         {
-            var visitor = _elementVisitor.FirstOrDefault(c => c.Key == elementType).Value;
-            if (visitor != null)
+            IVisitor visitor;
+            if (_visitorCache.TryGetValue(elementType, out visitor))
             {
                 return visitor;
             }
 
-            return null;
+            throw new OpenApiException(String.Format(SRResource.UnknownVisitorType, elementType.FullName));
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/OpenApiVisitorSet.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/OpenApiVisitorSet.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Exceptions;
-using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Properties;
 using Microsoft.OpenApi.Interfaces;
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/OpenApiVisitorSet.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/OpenApiVisitorSet.cs
@@ -1,0 +1,45 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.OpenApi.Validations.Visitors
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    internal static class OpenApiVisitorSet
+    {
+        private static IDictionary<Type, IVisitor> _elementVisitor = new Dictionary<Type, IVisitor>
+        {
+            { typeof(OpenApiDocument), new DocumentVisitor() },
+            { typeof(OpenApiInfo), new InfoVisitor() },
+            { typeof(OpenApiTag), new TagVisitor() },
+            { typeof(OpenApiLicense), new LicenseVisitor() },
+            { typeof(OpenApiContact), new ContactVisitor() },
+
+            // add more
+        };
+
+        /// <summary>
+        /// Get the element visitor.
+        /// </summary>
+        /// <param name="elementType">The element type.</param>
+        /// <returns>The element visitor or null.</returns>
+        public static IVisitor GetVisitor(Type elementType)
+        {
+            var visitor = _elementVisitor.FirstOrDefault(c => c.Key == elementType).Value;
+            if (visitor != null)
+            {
+                return visitor;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Visitors/OperationVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/OperationVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/OperationVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/OperationVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="operation">The <see cref="OpenApiOperation"/>.</param>
         protected override void Next(ValidationContext context, OpenApiOperation operation)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(operation != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (operation == null)
+            {
+                throw Error.ArgumentNull(nameof(operation));
+            }
 
             context.ValidateCollection(operation.Tags);
             context.Validate(operation.ExternalDocs);

--- a/src/Microsoft.OpenApi/Validations/Visitors/OperationVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/OperationVisitor.cs
@@ -1,0 +1,38 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Diagnostics;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Visitors
+{
+    /// <summary>
+    /// Visit <see cref="OpenApiOperation"/>.
+    /// </summary>
+    internal class OperationVisitor : VisitorBase<OpenApiOperation>
+    {
+        /// <summary>
+        /// Visit the children of the <see cref="OpenApiOperation"/>.
+        /// </summary>
+        /// <param name="context">The validation context.</param>
+        /// <param name="operation">The <see cref="OpenApiOperation"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiOperation operation)
+        {
+            Debug.Assert(context != null);
+            Debug.Assert(operation != null);
+
+            context.ValidateCollection(operation.Tags);
+            context.Validate(operation.ExternalDocs);
+            context.ValidateCollection(operation.Parameters);
+            context.Validate(operation.RequestBody);
+            context.Validate(operation.Responses);
+            context.ValidateMap(operation.Callbacks);
+            context.ValidateCollection(operation.Security);
+            context.ValidateCollection(operation.Servers);
+
+            base.Next(context, operation);
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Visitors/ParameterVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ParameterVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="parameter">The <see cref="OpenApiParameter"/>.</param>
         protected override void Next(ValidationContext context, OpenApiParameter parameter)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(parameter != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (parameter == null)
+            {
+                throw Error.ArgumentNull(nameof(parameter));
+            }
 
             context.Validate(parameter.Schema);
             context.ValidateCollection(parameter.Examples);

--- a/src/Microsoft.OpenApi/Validations/Visitors/ParameterVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ParameterVisitor.cs
@@ -9,25 +9,25 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiInfo"/>.
+    /// Visit <see cref="OpenApiParameter"/>.
     /// </summary>
-    internal class InfoVisitor : VisitorBase<OpenApiInfo>
+    internal class ParameterVisitor : VisitorBase<OpenApiParameter>
     {
         /// <summary>
-        /// Visit the children in <see cref="OpenApiInfo"/>.
+        /// Visit the children of the <see cref="OpenApiParameter"/>.
         /// </summary>
         /// <param name="context">The validation context.</param>
-        /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiInfo info)
+        /// <param name="parameter">The <see cref="OpenApiParameter"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiParameter parameter)
         {
             Debug.Assert(context != null);
-            Debug.Assert(info != null);
+            Debug.Assert(parameter != null);
 
-            context.Validate(info.Contact);
+            context.Validate(parameter.Schema);
+            context.ValidateCollection(parameter.Examples);
+            context.ValidateMap(parameter.Content);
 
-            context.Validate(info.License);
-
-            base.Next(context, info);
+            base.Next(context, parameter);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/ParameterVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ParameterVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/PathItemVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/PathItemVisitor.cs
@@ -1,0 +1,37 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Diagnostics;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Visitors
+{
+    /// <summary>
+    /// Visit <see cref="OpenApiPathItem"/>.
+    /// </summary>
+    internal class PathItemVisitor : VisitorBase<OpenApiPathItem>
+    {
+        /// <summary>
+        /// Visit the children of the <see cref="OpenApiPathItem"/>.
+        /// </summary>
+        /// <param name="context">The validation context.</param>
+        /// <param name="pathItem">The <see cref="OpenApiPathItem"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiPathItem pathItem)
+        {
+            Debug.Assert(context != null);
+            Debug.Assert(pathItem != null);
+
+            foreach (var operation in pathItem.Operations)
+            {
+                context.Validate(operation.Value);
+            }
+
+            context.ValidateCollection(pathItem.Servers);
+            context.ValidateCollection(pathItem.Parameters);
+
+            base.Next(context, pathItem);
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Visitors/PathItemVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/PathItemVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/PathItemVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/PathItemVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="pathItem">The <see cref="OpenApiPathItem"/>.</param>
         protected override void Next(ValidationContext context, OpenApiPathItem pathItem)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(pathItem != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (pathItem == null)
+            {
+                throw Error.ArgumentNull(nameof(pathItem));
+            }
 
             foreach (var operation in pathItem.Operations)
             {

--- a/src/Microsoft.OpenApi/Validations/Visitors/PathsVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/PathsVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/PathsVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/PathsVisitor.cs
@@ -9,25 +9,22 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiInfo"/>.
+    /// Visit <see cref="OpenApiPaths"/>.
     /// </summary>
-    internal class InfoVisitor : VisitorBase<OpenApiInfo>
+    internal class PathsVisitor : VisitorBase<OpenApiPaths>
     {
         /// <summary>
-        /// Visit the children in <see cref="OpenApiInfo"/>.
+        /// Visit the children of the <see cref="OpenApiPaths"/>.
         /// </summary>
         /// <param name="context">The validation context.</param>
-        /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiInfo info)
+        /// <param name="paths">The <see cref="OpenApiPaths"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiPaths paths)
         {
             Debug.Assert(context != null);
-            Debug.Assert(info != null);
+            Debug.Assert(paths != null);
 
-            context.Validate(info.Contact);
-
-            context.Validate(info.License);
-
-            base.Next(context, info);
+            context.ValidateMap(paths);
+            base.Next(context, paths);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/PathsVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/PathsVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="paths">The <see cref="OpenApiPaths"/>.</param>
         protected override void Next(ValidationContext context, OpenApiPaths paths)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(paths != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (paths == null)
+            {
+                throw Error.ArgumentNull(nameof(paths));
+            }
 
             context.ValidateMap(paths);
             base.Next(context, paths);

--- a/src/Microsoft.OpenApi/Validations/Visitors/RequestBodyVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/RequestBodyVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/RequestBodyVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/RequestBodyVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="requestBody">The <see cref="OpenApiRequestBody"/>.</param>
         protected override void Next(ValidationContext context, OpenApiRequestBody requestBody)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(requestBody != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (requestBody == null)
+            {
+                throw Error.ArgumentNull(nameof(requestBody));
+            }
 
             context.ValidateMap(requestBody.Content);
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/RequestBodyVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/RequestBodyVisitor.cs
@@ -9,25 +9,23 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiInfo"/>.
+    /// Visit <see cref="OpenApiRequestBody"/>.
     /// </summary>
-    internal class InfoVisitor : VisitorBase<OpenApiInfo>
+    internal class RequestBodyVisitor : VisitorBase<OpenApiRequestBody>
     {
         /// <summary>
-        /// Visit the children in <see cref="OpenApiInfo"/>.
+        /// Visit the children of the <see cref="OpenApiRequestBody"/>.
         /// </summary>
         /// <param name="context">The validation context.</param>
-        /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiInfo info)
+        /// <param name="requestBody">The <see cref="OpenApiRequestBody"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiRequestBody requestBody)
         {
             Debug.Assert(context != null);
-            Debug.Assert(info != null);
+            Debug.Assert(requestBody != null);
 
-            context.Validate(info.Contact);
+            context.ValidateMap(requestBody.Content);
 
-            context.Validate(info.License);
-
-            base.Next(context, info);
+            base.Next(context, requestBody);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/ResponseVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ResponseVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/ResponseVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ResponseVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="response">The <see cref="OpenApiResponse"/>.</param>
         protected override void Next(ValidationContext context, OpenApiResponse response)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(response != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (response == null)
+            {
+                throw Error.ArgumentNull(nameof(response));
+            }
 
             context.ValidateMap(response.Headers);
             context.ValidateMap(response.Content);

--- a/src/Microsoft.OpenApi/Validations/Visitors/ResponseVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ResponseVisitor.cs
@@ -9,25 +9,25 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiInfo"/>.
+    /// Visit <see cref="OpenApiResponse"/>.
     /// </summary>
-    internal class InfoVisitor : VisitorBase<OpenApiInfo>
+    internal class ResponseVisitor : VisitorBase<OpenApiResponse>
     {
         /// <summary>
-        /// Visit the children in <see cref="OpenApiInfo"/>.
+        /// Visit the children of the <see cref="OpenApiResponse"/>.
         /// </summary>
         /// <param name="context">The validation context.</param>
-        /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiInfo info)
+        /// <param name="response">The <see cref="OpenApiResponse"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiResponse response)
         {
             Debug.Assert(context != null);
-            Debug.Assert(info != null);
+            Debug.Assert(response != null);
 
-            context.Validate(info.Contact);
+            context.ValidateMap(response.Headers);
+            context.ValidateMap(response.Content);
+            context.ValidateMap(response.Links);
 
-            context.Validate(info.License);
-
-            base.Next(context, info);
+            base.Next(context, response);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/ResponsesVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ResponsesVisitor.cs
@@ -3,28 +3,29 @@
 //  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
 // ------------------------------------------------------------
 
+using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiTag"/>.
+    /// Visit <see cref="OpenApiResponses"/>.
     /// </summary>
-    internal class TagVisitor : VisitorBase<OpenApiTag>
+    internal class ResponsesVisitor : VisitorBase<OpenApiResponses>
     {
         /// <summary>
-        /// Visit the children in <see cref="OpenApiTag"/>.
+        /// Visit the children of the <see cref="OpenApiResponses"/>.
         /// </summary>
         /// <param name="context">The validation context.</param>
-        /// <param name="tag">The <see cref="OpenApiTag"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiTag tag)
+        /// <param name="responses">The <see cref="OpenApiResponses"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiResponses responses)
         {
-            if (tag == null)
-            {
-                return;
-            }
+            Debug.Assert(context != null);
+            Debug.Assert(responses != null);
 
-            context.Validate(tag.ExternalDocs);
+            context.ValidateMap(responses);
+
+            base.Next(context, responses);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/ResponsesVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ResponsesVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/ResponsesVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ResponsesVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="responses">The <see cref="OpenApiResponses"/>.</param>
         protected override void Next(ValidationContext context, OpenApiResponses responses)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(responses != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (responses == null)
+            {
+                throw Error.ArgumentNull(nameof(responses));
+            }
 
             context.ValidateMap(responses);
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/SchemaVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/SchemaVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/SchemaVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/SchemaVisitor.cs
@@ -1,0 +1,49 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Diagnostics;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Visitors
+{
+    /// <summary>
+    /// Visit <see cref="OpenApiSchema"/>.
+    /// </summary>
+    internal class SchemaVisitor : VisitorBase<OpenApiSchema>
+    {
+        /// <summary>
+        /// Visit the children of the <see cref="OpenApiSchema"/>.
+        /// </summary>
+        /// <param name="context">The validation context.</param>
+        /// <param name="schema">The <see cref="OpenApiSchema"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiSchema schema)
+        {
+            Debug.Assert(context != null);
+            Debug.Assert(schema != null);
+
+            context.ValidateCollection(schema.AllOf);
+
+            context.ValidateCollection(schema.OneOf);
+
+            context.ValidateCollection(schema.AnyOf);
+
+            context.Validate(schema.Not);
+
+            context.Validate(schema.Items);
+
+            context.ValidateMap(schema.Properties);
+
+            context.Validate(schema.AdditionalProperties);
+
+            context.Validate(schema.Discriminator);
+
+            context.Validate(schema.ExternalDocs);
+
+            context.Validate(schema.Xml);
+
+            base.Next(context, schema);
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Visitors/SchemaVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/SchemaVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="schema">The <see cref="OpenApiSchema"/>.</param>
         protected override void Next(ValidationContext context, OpenApiSchema schema)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(schema != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (schema == null)
+            {
+                throw Error.ArgumentNull(nameof(schema));
+            }
 
             context.ValidateCollection(schema.AllOf);
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/SecurityRequirementVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/SecurityRequirementVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using Microsoft.OpenApi.Models;
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/SecurityRequirementVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/SecurityRequirementVisitor.cs
@@ -8,9 +8,9 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiLicense"/>.
+    /// Visit <see cref="OpenApiSecurityRequirement"/>.
     /// </summary>
-    internal class LicenseVisitor : VisitorBase<OpenApiLicense>
+    internal class SecurityRequirementVisitor : VisitorBase<OpenApiSecurityRequirement>
     {
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/SecuritySchemeVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/SecuritySchemeVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/SecuritySchemeVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/SecuritySchemeVisitor.cs
@@ -9,25 +9,24 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiInfo"/>.
+    /// Visit <see cref="OpenApiSecurityScheme"/>.
     /// </summary>
-    internal class InfoVisitor : VisitorBase<OpenApiInfo>
+    internal class SecuritySchemeVisitor : VisitorBase<OpenApiSecurityScheme>
     {
         /// <summary>
-        /// Visit the children in <see cref="OpenApiInfo"/>.
+        /// Visit the children of the <see cref="OpenApiSecurityScheme"/>.
         /// </summary>
         /// <param name="context">The validation context.</param>
-        /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiInfo info)
+        /// <param name="securityScheme">The <see cref="OpenApiSecurityScheme"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiSecurityScheme securityScheme)
         {
             Debug.Assert(context != null);
-            Debug.Assert(info != null);
+            Debug.Assert(securityScheme != null);
 
-            context.Validate(info.Contact);
+            context.Validate(securityScheme.Flows);
 
-            context.Validate(info.License);
-
-            base.Next(context, info);
+            // add more.
+            base.Next(context, securityScheme);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/SecuritySchemeVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/SecuritySchemeVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,12 +17,18 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="securityScheme">The <see cref="OpenApiSecurityScheme"/>.</param>
         protected override void Next(ValidationContext context, OpenApiSecurityScheme securityScheme)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(securityScheme != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (securityScheme == null)
+            {
+                throw Error.ArgumentNull(nameof(securityScheme));
+            }
 
             context.Validate(securityScheme.Flows);
 
-            // add more.
             base.Next(context, securityScheme);
         }
     }

--- a/src/Microsoft.OpenApi/Validations/Visitors/ServerVariableVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ServerVariableVisitor.cs
@@ -8,9 +8,9 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiLicense"/>.
+    /// Visit <see cref="OpenApiServerVariable"/>.
     /// </summary>
-    internal class LicenseVisitor : VisitorBase<OpenApiLicense>
+    internal class ServerVariableVisitor : VisitorBase<OpenApiServerVariable>
     {
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/ServerVariableVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ServerVariableVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using Microsoft.OpenApi.Models;
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/ServerVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ServerVisitor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/ServerVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ServerVisitor.cs
@@ -9,25 +9,24 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiInfo"/>.
+    /// Visit <see cref="OpenApiServer"/>.
     /// </summary>
-    internal class InfoVisitor : VisitorBase<OpenApiInfo>
+    internal class ServerVisitor : VisitorBase<OpenApiServer>
     {
         /// <summary>
-        /// Visit the children in <see cref="OpenApiInfo"/>.
+        /// Visit the children of the <see cref="OpenApiServer"/>.
         /// </summary>
         /// <param name="context">The validation context.</param>
-        /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiInfo info)
+        /// <param name="server">The <see cref="OpenApiServer"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiServer server)
         {
             Debug.Assert(context != null);
-            Debug.Assert(info != null);
+            Debug.Assert(server != null);
 
-            context.Validate(info.Contact);
+            context.ValidateMap(server.Variables);
 
-            context.Validate(info.License);
-
-            base.Next(context, info);
+            // add more.
+            base.Next(context, server);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/ServerVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/ServerVisitor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,12 +17,18 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="server">The <see cref="OpenApiServer"/>.</param>
         protected override void Next(ValidationContext context, OpenApiServer server)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(server != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (server == null)
+            {
+                throw Error.ArgumentNull(nameof(server));
+            }
 
             context.ValidateMap(server.Variables);
 
-            // add more.
             base.Next(context, server);
         }
     }

--- a/src/Microsoft.OpenApi/Validations/Visitors/TagVisitor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/TagVisitor.cs
@@ -1,0 +1,30 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Visitors
+{
+    /// <summary>
+    /// Visit <see cref="OpenApiTag"/>.
+    /// </summary>
+    internal class TagVisitor : VisitorBase<OpenApiTag>
+    {
+        /// <summary>
+        /// Visit the children in <see cref="OpenApiTag"/>.
+        /// </summary>
+        /// <param name="context">The validation context.</param>
+        /// <param name="tag">The <see cref="OpenApiTag"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiTag tag)
+        {
+            if (tag == null)
+            {
+                return;
+            }
+
+            context.Validate(tag.ExternalDocs);
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Visitors/TagVistor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/TagVistor.cs
@@ -9,25 +9,23 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiInfo"/>.
+    /// Visit <see cref="OpenApiTag"/>.
     /// </summary>
-    internal class InfoVisitor : VisitorBase<OpenApiInfo>
+    internal class TagVisitor : VisitorBase<OpenApiTag>
     {
         /// <summary>
-        /// Visit the children in <see cref="OpenApiInfo"/>.
+        /// Visit the children in <see cref="OpenApiTag"/>.
         /// </summary>
         /// <param name="context">The validation context.</param>
-        /// <param name="info">The <see cref="OpenApiInfo"/>.</param>
-        protected override void Next(ValidationContext context, OpenApiInfo info)
+        /// <param name="tag">The <see cref="OpenApiTag"/>.</param>
+        protected override void Next(ValidationContext context, OpenApiTag tag)
         {
             Debug.Assert(context != null);
-            Debug.Assert(info != null);
+            Debug.Assert(tag != null);
 
-            context.Validate(info.Contact);
+            context.Validate(tag.ExternalDocs);
 
-            context.Validate(info.License);
-
-            base.Next(context, info);
+            base.Next(context, tag);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/TagVistor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/TagVistor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi/Validations/Visitors/TagVistor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/TagVistor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Diagnostics;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Visitors
@@ -18,8 +17,15 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="tag">The <see cref="OpenApiTag"/>.</param>
         protected override void Next(ValidationContext context, OpenApiTag tag)
         {
-            Debug.Assert(context != null);
-            Debug.Assert(tag != null);
+            if (context == null)
+            {
+                throw Error.ArgumentNull(nameof(context));
+            }
+
+            if (tag == null)
+            {
+                throw Error.ArgumentNull(nameof(tag));
+            }
 
             context.Validate(tag.ExternalDocs);
 

--- a/src/Microsoft.OpenApi/Validations/Visitors/VisitorBase.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/VisitorBase.cs
@@ -38,6 +38,17 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// </summary>
         /// <param name="context">The validation context.</param>
         /// <param name="element">The element.</param>
-        protected abstract void Next(ValidationContext context, T element);
+        protected virtual void Next(ValidationContext context, T element)
+        {
+            IOpenApiExtensible extensbile = element as IOpenApiExtensible;
+            if (extensbile != null)
+            {
+                var rules = context.RuleSet.Where(r => r.ValidatedType == typeof(IOpenApiExtensible));
+                foreach (var rule in rules)
+                {
+                    rule.Evaluate(context, extensbile);
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/VisitorBase.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/VisitorBase.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using System.Diagnostics;
 using System.Linq;
@@ -23,7 +21,7 @@ namespace Microsoft.OpenApi.Validations.Visitors
         {
             Debug.Assert(item is T, "item should be " + typeof(T));
 
-            var rules = context.RuleSet.Where(r => r.ValidatedType == typeof(T));
+            var rules = context.RuleSet.Where(r => r.ElementType == typeof(T));
             foreach (var rule in rules)
             {
                 rule.Evaluate(context, item);
@@ -43,7 +41,7 @@ namespace Microsoft.OpenApi.Validations.Visitors
             IOpenApiExtensible extensbile = element as IOpenApiExtensible;
             if (extensbile != null)
             {
-                var rules = context.RuleSet.Where(r => r.ValidatedType == typeof(IOpenApiExtensible));
+                var rules = context.RuleSet.Where(r => r.ElementType == typeof(IOpenApiExtensible));
                 foreach (var rule in rules)
                 {
                     rule.Evaluate(context, extensbile);

--- a/src/Microsoft.OpenApi/Validations/Visitors/VisitorBase.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/VisitorBase.cs
@@ -38,13 +38,13 @@ namespace Microsoft.OpenApi.Validations.Visitors
         /// <param name="element">The element.</param>
         protected virtual void Next(ValidationContext context, T element)
         {
-            IOpenApiExtensible extensbile = element as IOpenApiExtensible;
-            if (extensbile != null)
+            IOpenApiExtensible extensible = element as IOpenApiExtensible;
+            if (extensible != null)
             {
                 var rules = context.RuleSet.Where(r => r.ElementType == typeof(IOpenApiExtensible));
                 foreach (var rule in rules)
                 {
-                    rule.Evaluate(context, extensbile);
+                    rule.Evaluate(context, extensible);
                 }
             }
         }

--- a/src/Microsoft.OpenApi/Validations/Visitors/VisitorBase.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/VisitorBase.cs
@@ -1,0 +1,43 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.OpenApi.Interfaces;
+
+namespace Microsoft.OpenApi.Validations.Visitors
+{
+    /// <summary>
+    /// The base visitor class for Open Api elements.
+    /// </summary>
+    internal abstract class VisitorBase<T> : IVisitor where T : IOpenApiElement
+    {
+        /// <summary>
+        /// Visit the element itself.
+        /// </summary>
+        /// <param name="context">The validation context.</param>
+        /// <param name="item">The element.</param>
+        public void Visit(ValidationContext context, object item)
+        {
+            Debug.Assert(item is T, "item should be " + typeof(T));
+
+            var rules = context.RuleSet.Where(r => r.ValidatedType == typeof(T));
+            foreach (var rule in rules)
+            {
+                rule.Evaluate(context, item);
+            }
+
+            T typedItem = (T)item;
+            this.Next(context, typedItem);
+        }
+
+        /// <summary>
+        /// Visit the children.
+        /// </summary>
+        /// <param name="context">The validation context.</param>
+        /// <param name="element">The element.</param>
+        protected abstract void Next(ValidationContext context, T element);
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Visitors/XmlVistor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/XmlVistor.cs
@@ -8,9 +8,9 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Validations.Visitors
 {
     /// <summary>
-    /// Visit <see cref="OpenApiLicense"/>.
+    /// Visit <see cref="OpenApiXml"/>.
     /// </summary>
-    internal class LicenseVisitor : VisitorBase<OpenApiLicense>
+    internal class XmlVisitor : VisitorBase<OpenApiXml>
     {
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Visitors/XmlVistor.cs
+++ b/src/Microsoft.OpenApi/Validations/Visitors/XmlVistor.cs
@@ -1,7 +1,5 @@
-﻿// ------------------------------------------------------------
-//  Copyright (c) Microsoft Corporation.  All rights reserved.
-//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
-// ------------------------------------------------------------
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
 
 using Microsoft.OpenApi.Models;
 

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiComponentsValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiComponentsValidationTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System.Collections.Generic;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Validations;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Models
+{
+    public class OpenApiComponentsValidationTests
+    {
+        [Fact]
+        public void ValidateKeyMustMatchRegularExpressionInComponents()
+        {
+            // Arrange
+            IEnumerable<ValidationError> errors;
+            OpenApiComponents components = new OpenApiComponents()
+            {
+                Responses = new Dictionary<string, OpenApiResponse>
+                {
+                    { "%@abc", new OpenApiResponse { Description = "any" } }
+                }
+            };
+
+            // Act
+            bool result = components.Validate(out errors);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(errors);
+            ValidationError error = Assert.Single(errors);
+            Assert.Equal(@"The key '%@abc' in 'responses' of components MUST match the regular expression '^[a-zA-Z0-9\.\-_]+$'.",
+                error.ErrorMessage);
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiComponentsValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiComponentsValidationTests.cs
@@ -6,7 +6,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Validations;
 using Xunit;
 
-namespace Microsoft.OpenApi.Tests.Models
+namespace Microsoft.OpenApi.Validations.Tests
 {
     public class OpenApiComponentsValidationTests
     {

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiComponentsValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiComponentsValidationTests.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Validations;
+using Microsoft.OpenApi.Properties;
+using Microsoft.OpenApi.Validations.Rules;
 using Xunit;
 
 namespace Microsoft.OpenApi.Validations.Tests
@@ -14,12 +16,13 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateKeyMustMatchRegularExpressionInComponents()
         {
             // Arrange
+            const string key = "%@abc";
             IEnumerable<ValidationError> errors;
             OpenApiComponents components = new OpenApiComponents()
             {
                 Responses = new Dictionary<string, OpenApiResponse>
                 {
-                    { "%@abc", new OpenApiResponse { Description = "any" } }
+                    { key, new OpenApiResponse { Description = "any" } }
                 }
             };
 
@@ -30,7 +33,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.False(result);
             Assert.NotNull(errors);
             ValidationError error = Assert.Single(errors);
-            Assert.Equal(@"The key '%@abc' in 'responses' of components MUST match the regular expression '^[a-zA-Z0-9\.\-_]+$'.",
+            Assert.Equal(String.Format(SRResource.Validation_ComponentsKeyMustMatchRegularExpr, key, "responses", OpenApiComponentsRules.KeyRegex.ToString()),
                 error.ErrorMessage);
         }
     }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiContactValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiContactValidationTests.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT license. 
 
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Validations;
 using System.Collections.Generic;
 using Xunit;
 
-namespace Microsoft.OpenApi.Tests.Models
+namespace Microsoft.OpenApi.Validations.Tests
 {
     public class OpenApiContactValidationTests
     {

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiContactValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiContactValidationTests.cs
@@ -1,0 +1,36 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// ------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Validations;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Models
+{
+    public class OpenApiContactValidationTests
+    {
+        public static OpenApiContact Contact = new OpenApiContact()
+        {
+            Email = "support/example.com",
+        };
+
+        [Fact]
+        public void SerializeAdvanceContactAsJsonWorks()
+        {
+            // Arrange
+            IEnumerable<ValidationError> errors;
+
+            // Act
+            bool result = Contact.Validate(out errors);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(errors);
+            ValidationError error = Assert.Single(errors);
+            Assert.Equal("The string 'support/example.com' MUST be in the format of an email address.", error.ErrorMessage);
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiContactValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiContactValidationTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using Microsoft.OpenApi.Models;
+using System;
 using System.Collections.Generic;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
 using Xunit;
 
 namespace Microsoft.OpenApi.Validations.Tests
@@ -13,10 +15,11 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateEmailFieldIsEmailAddressInContact()
         {
             // Arrange
+            const string testEmail = "support/example.com";
             IEnumerable<ValidationError> errors;
             OpenApiContact Contact = new OpenApiContact()
             {
-                Email = "support/example.com",
+                Email = testEmail
             };
 
             // Act
@@ -26,7 +29,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.False(result);
             Assert.NotNull(errors);
             ValidationError error = Assert.Single(errors);
-            Assert.Equal("The string 'support/example.com' MUST be in the format of an email address.", error.ErrorMessage);
+            Assert.Equal(String.Format(SRResource.Validation_StringMustBeEmailAddress, testEmail), error.ErrorMessage);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiExternalDocsValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiExternalDocsValidationTests.cs
@@ -3,10 +3,9 @@
 
 using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Validations;
 using Xunit;
 
-namespace Microsoft.OpenApi.Tests.Models
+namespace Microsoft.OpenApi.Validations.Tests
 {
     public class OpenApiExternalDocsValidationTests
     {

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiExternalDocsValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiExternalDocsValidationTests.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System.Collections.Generic;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Validations;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Models
+{
+    public class OpenApiExternalDocsValidationTests
+    {
+        [Fact]
+        public void ValidateUrlIsRequiredInExternalDocs()
+        {
+            // Arrange
+            IEnumerable<ValidationError> errors;
+            OpenApiExternalDocs externalDocs = new OpenApiExternalDocs();
+
+            // Act
+            bool result = externalDocs.Validate(out errors);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(errors);
+            ValidationError error = Assert.Single(errors);
+            Assert.Equal("The field 'url' in 'External Documentation' object is REQUIRED.", error.ErrorMessage);
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiExternalDocsValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiExternalDocsValidationTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
 using Xunit;
 
 namespace Microsoft.OpenApi.Validations.Tests
@@ -23,7 +25,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.False(result);
             Assert.NotNull(errors);
             ValidationError error = Assert.Single(errors);
-            Assert.Equal("The field 'url' in 'External Documentation' object is REQUIRED.", error.ErrorMessage);
+            Assert.Equal(String.Format(SRResource.Validation_FieldIsRequired, "url", "External Documentation"), error.ErrorMessage);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiInfoValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiInfoValidationTests.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
 using Xunit;
 
 namespace Microsoft.OpenApi.Validations.Tests
@@ -14,6 +16,8 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateFieldIsRequiredInInfo()
         {
             // Arrange
+            string urlError = String.Format(SRResource.Validation_FieldIsRequired, "url", "info");
+            string versionError = String.Format(SRResource.Validation_FieldIsRequired, "version", "info");
             IEnumerable<ValidationError> errors;
             OpenApiInfo info = new OpenApiInfo();
 
@@ -24,8 +28,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.False(result);
             Assert.NotNull(errors);
 
-            Assert.Equal(new[] { "The field 'url' in 'info' object is REQUIRED.",
-                "The field 'version' in 'info' object is REQUIRED."}, errors.Select(e => e.ErrorMessage));
+            Assert.Equal(new[] { urlError, versionError }, errors.Select(e => e.ErrorMessage));
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiInfoValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiInfoValidationTests.cs
@@ -4,10 +4,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Validations;
 using Xunit;
 
-namespace Microsoft.OpenApi.Tests.Models
+namespace Microsoft.OpenApi.Validations.Tests
 {
     public class OpenApiInfoValidationTests
     {

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiInfoValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiInfoValidationTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Validations;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Models
+{
+    public class OpenApiInfoValidationTests
+    {
+        [Fact]
+        public void ValidateFieldIsRequiredInInfo()
+        {
+            // Arrange
+            IEnumerable<ValidationError> errors;
+            OpenApiInfo info = new OpenApiInfo();
+
+            // Act
+            bool result = info.Validate(out errors);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(errors);
+
+            Assert.Equal(new[] { "The field 'url' in 'info' object is REQUIRED.",
+                "The field 'version' in 'info' object is REQUIRED."}, errors.Select(e => e.ErrorMessage));
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiLicenseValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiLicenseValidationTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
 using Xunit;
 
 namespace Microsoft.OpenApi.Validations.Tests
@@ -23,7 +25,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.False(result);
             Assert.NotNull(errors);
             ValidationError error = Assert.Single(errors);
-            Assert.Equal("The field 'name' in 'license' object is REQUIRED.", error.ErrorMessage);
+            Assert.Equal(String.Format(SRResource.Validation_FieldIsRequired, "name", "license"), error.ErrorMessage);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiLicenseValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiLicenseValidationTests.cs
@@ -1,33 +1,30 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Validations;
-using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.OpenApi.Tests.Models
 {
-    public class OpenApiContactValidationTests
+    public class OpenApiLicenseValidationTests
     {
         [Fact]
-        public void ValidateEmailFieldIsEmailAddressInContact()
+        public void ValidateFieldIsRequiredInLicense()
         {
             // Arrange
             IEnumerable<ValidationError> errors;
-            OpenApiContact Contact = new OpenApiContact()
-            {
-                Email = "support/example.com",
-            };
+            OpenApiLicense license = new OpenApiLicense();
 
             // Act
-            bool result = Contact.Validate(out errors);
+            bool result = license.Validate(out errors);
 
             // Assert
             Assert.False(result);
             Assert.NotNull(errors);
             ValidationError error = Assert.Single(errors);
-            Assert.Equal("The string 'support/example.com' MUST be in the format of an email address.", error.ErrorMessage);
+            Assert.Equal("The field 'name' in 'license' object is REQUIRED.", error.ErrorMessage);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiLicenseValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiLicenseValidationTests.cs
@@ -3,10 +3,9 @@
 
 using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Validations;
 using Xunit;
 
-namespace Microsoft.OpenApi.Tests.Models
+namespace Microsoft.OpenApi.Validations.Tests
 {
     public class OpenApiLicenseValidationTests
     {

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiOAuthFlowValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiOAuthFlowValidationTests.cs
@@ -4,10 +4,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Validations;
 using Xunit;
 
-namespace Microsoft.OpenApi.Tests.Models
+namespace Microsoft.OpenApi.Validations.Tests
 {
     public class OpenApiOAuthFlowValidationTests
     {

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiOAuthFlowValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiOAuthFlowValidationTests.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
 using Xunit;
 
 namespace Microsoft.OpenApi.Validations.Tests
@@ -14,6 +16,8 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateFixedFieldsIsRequiredInResponse()
         {
             // Arrange
+            string authorizationUrlError = String.Format(SRResource.Validation_FieldIsRequired, "authorizationUrl", "OAuth Flow");
+            string tokenUrlError = String.Format(SRResource.Validation_FieldIsRequired, "tokenUrl", "OAuth Flow");
             IEnumerable<ValidationError> errors;
             OpenApiOAuthFlow oAuthFlow = new OpenApiOAuthFlow();
 
@@ -24,8 +28,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.False(result);
             Assert.NotNull(errors);
             Assert.Equal(2, errors.Count());
-            Assert.Equal(new[] { "The field 'authorizationUrl' in 'OAuth Flow' object is REQUIRED.",
-                "The field 'tokenUrl' in 'OAuth Flow' object is REQUIRED."}, errors.Select(e => e.ErrorMessage));
+            Assert.Equal(new[] { authorizationUrlError, tokenUrlError }, errors.Select(e => e.ErrorMessage));
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiOAuthFlowValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiOAuthFlowValidationTests.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Validations;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Models
+{
+    public class OpenApiOAuthFlowValidationTests
+    {
+        [Fact]
+        public void ValidateFixedFieldsIsRequiredInResponse()
+        {
+            // Arrange
+            IEnumerable<ValidationError> errors;
+            OpenApiOAuthFlow oAuthFlow = new OpenApiOAuthFlow();
+
+            // Act
+            bool result = oAuthFlow.Validate(out errors);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(errors);
+            Assert.Equal(2, errors.Count());
+            Assert.Equal(new[] { "The field 'authorizationUrl' in 'OAuth Flow' object is REQUIRED.",
+                "The field 'tokenUrl' in 'OAuth Flow' object is REQUIRED."}, errors.Select(e => e.ErrorMessage));
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiResponseValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiResponseValidationTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
 using Xunit;
 
 namespace Microsoft.OpenApi.Validations.Tests
@@ -23,7 +25,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.False(result);
             Assert.NotNull(errors);
             ValidationError error = Assert.Single(errors);
-            Assert.Equal("The field 'description' in 'response' object is REQUIRED.", error.ErrorMessage);
+            Assert.Equal(String.Format(SRResource.Validation_FieldIsRequired, "description", "response"), error.ErrorMessage);
             Assert.Equal(ErrorReason.Required, error.ErrorCode);
             Assert.Equal("#/description", error.ErrorPath);
         }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiResponseValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiResponseValidationTests.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System.Collections.Generic;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Validations;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Models
+{
+    public class OpenApiResponseValidationTests
+    {
+        [Fact]
+        public void ValidateDescriptionIsRequiredInResponse()
+        {
+            // Arrange
+            IEnumerable<ValidationError> errors;
+            OpenApiResponse response = new OpenApiResponse();
+
+            // Act
+            bool result = response.Validate(out errors);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(errors);
+            ValidationError error = Assert.Single(errors);
+            Assert.Equal("The field 'description' in 'response' object is REQUIRED.", error.ErrorMessage);
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiResponseValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiResponseValidationTests.cs
@@ -24,6 +24,8 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.NotNull(errors);
             ValidationError error = Assert.Single(errors);
             Assert.Equal("The field 'description' in 'response' object is REQUIRED.", error.ErrorMessage);
+            Assert.Equal(ErrorReason.Required, error.ErrorCode);
+            Assert.Equal("#/description", error.ErrorPath);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiResponseValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiResponseValidationTests.cs
@@ -3,10 +3,9 @@
 
 using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Validations;
 using Xunit;
 
-namespace Microsoft.OpenApi.Tests.Models
+namespace Microsoft.OpenApi.Validations.Tests
 {
     public class OpenApiResponseValidationTests
     {

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiServerValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiServerValidationTests.cs
@@ -3,10 +3,9 @@
 
 using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Validations;
 using Xunit;
 
-namespace Microsoft.OpenApi.Tests.Models
+namespace Microsoft.OpenApi.Validations.Tests
 {
     public class OpenApiServerValidationTests
     {

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiServerValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiServerValidationTests.cs
@@ -1,33 +1,30 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Validations;
-using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.OpenApi.Tests.Models
 {
-    public class OpenApiContactValidationTests
+    public class OpenApiServerValidationTests
     {
         [Fact]
-        public void ValidateEmailFieldIsEmailAddressInContact()
+        public void ValidateFieldIsRequiredInServer()
         {
             // Arrange
             IEnumerable<ValidationError> errors;
-            OpenApiContact Contact = new OpenApiContact()
-            {
-                Email = "support/example.com",
-            };
+            OpenApiServer server = new OpenApiServer();
 
             // Act
-            bool result = Contact.Validate(out errors);
+            bool result = server.Validate(out errors);
 
             // Assert
             Assert.False(result);
             Assert.NotNull(errors);
             ValidationError error = Assert.Single(errors);
-            Assert.Equal("The string 'support/example.com' MUST be in the format of an email address.", error.ErrorMessage);
+            Assert.Equal("The field 'url' in 'server' object is REQUIRED.", error.ErrorMessage);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiServerValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiServerValidationTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
 using Xunit;
 
 namespace Microsoft.OpenApi.Validations.Tests
@@ -23,7 +25,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.False(result);
             Assert.NotNull(errors);
             ValidationError error = Assert.Single(errors);
-            Assert.Equal("The field 'url' in 'server' object is REQUIRED.", error.ErrorMessage);
+            Assert.Equal(String.Format(SRResource.Validation_FieldIsRequired, "url", "server"), error.ErrorMessage);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiTagValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiTagValidationTests.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
 using Xunit;
 
 namespace Microsoft.OpenApi.Validations.Tests
@@ -24,7 +26,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.False(result);
             Assert.NotNull(errors);
             ValidationError error = Assert.Single(errors);
-            Assert.Equal("The field 'name' in 'Tag' object is REQUIRED.", error.ErrorMessage);
+            Assert.Equal(String.Format(SRResource.Validation_FieldIsRequired, "name", "tag"), error.ErrorMessage);
         }
 
         [Fact]
@@ -45,7 +47,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.False(result);
             Assert.NotNull(errors);
             ValidationError error = Assert.Single(errors);
-            Assert.Equal("The extension name 'tagExt' in '#/extensions' object MUST begin with 'x-'.", error.ErrorMessage);
+            Assert.Equal(String.Format(SRResource.Validation_ExtensionNameMustBeginWithXDash, "tagExt", "#/extensions"), error.ErrorMessage);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiTagValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiTagValidationTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System.Collections.Generic;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Validations;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Models
+{
+    public class OpenApiTagValidationTests
+    {
+        [Fact]
+        public void ValidateNameIsRequiredInTag()
+        {
+            // Arrange
+            IEnumerable<ValidationError> errors;
+            OpenApiTag tag = new OpenApiTag();
+
+            // Act
+            bool result = tag.Validate(out errors);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(errors);
+            ValidationError error = Assert.Single(errors);
+            Assert.Equal("The field 'name' in 'Tag' object is REQUIRED.", error.ErrorMessage);
+        }
+
+        [Fact]
+        public void ValidateExtensionNameStartsWithXDashInTag()
+        {
+            // Arrange
+            IEnumerable<ValidationError> errors;
+            OpenApiTag tag = new OpenApiTag
+            {
+                Name = "tag"
+            };
+            tag.Extensions.Add("tagExt", new OpenApiString("value"));
+
+            // Act
+            bool result = tag.Validate(out errors);
+
+            // Assert
+            Assert.False(result);
+            Assert.NotNull(errors);
+            ValidationError error = Assert.Single(errors);
+            Assert.Equal("The extension name 'tagExt' in '#/extensions' object MUST begin with 'x-'.", error.ErrorMessage);
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiTagValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiTagValidationTests.cs
@@ -4,10 +4,9 @@
 using System.Collections.Generic;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Validations;
 using Xunit;
 
-namespace Microsoft.OpenApi.Tests.Models
+namespace Microsoft.OpenApi.Validations.Tests
 {
     public class OpenApiTagValidationTests
     {

--- a/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Validations.Tests
+{
+    public class ValidationRuleSetTests
+    {
+        [Fact]
+        public void DefaultRuleSetReturnsTheCorrectRules()
+        {
+            // Arrange
+            var ruleSet = new ValidationRuleSet();
+
+            // Act
+            var rules = ruleSet.Rules;
+
+            // Assert
+            Assert.NotNull(rules);
+            Assert.Empty(rules);
+        }
+
+        [Fact]
+        public void DefaultRuleSetPropertyReturnsTheCorrectRules()
+        {
+            // Arrange & Act
+            var ruleSet = ValidationRuleSet.DefaultRuleSet;
+            Assert.NotNull(ruleSet); // guard
+
+            var rules = ruleSet.Rules;
+
+            // Assert
+            Assert.NotNull(rules);
+            Assert.NotEmpty(rules);
+            Assert.Equal(13, rules.ToList().Count); // please update the number if you add new rule.
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/Visitors/OpenApiVisitorSetTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/Visitors/OpenApiVisitorSetTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using Microsoft.OpenApi.Exceptions;
+using Microsoft.OpenApi.Models;
+using Xunit;
+
+namespace Microsoft.OpenApi.Validations.Visitors.Tests
+{
+    public class OpenApiVisitorSetTests
+    {
+        [Fact]
+        public void VisitorsPropertyReturnsTheCorrectVisitorList()
+        {
+            for (int i = 0; i < 5; i++) // 5 is just a magic number
+            {
+                // Arrange & Act
+                var visitors = OpenApiVisitorSet.Visitors;
+
+                // Assert
+                Assert.NotNull(visitors);
+                Assert.NotEmpty(visitors);
+                Assert.Equal(29, visitors.Count);
+            }
+        }
+
+        [Fact]
+        public void GetVisitorThrowsUnknowElementType()
+        {
+            // Arrange & Act
+            Action test = () => OpenApiVisitorSet.GetVisitor(typeof(OpenApiVisitorSetTests));
+
+            // Assert
+            var exception = Assert.Throws<OpenApiException>(test);
+            Assert.Equal("Can not find visitor type registered for type 'Microsoft.OpenApi.Validations.Visitors.Tests.OpenApiVisitorSetTests'.",
+                exception.Message);
+        }
+
+        [Theory]
+        [InlineData(typeof(OpenApiDocument), typeof(DocumentVisitor))]
+        [InlineData(typeof(OpenApiInfo), typeof(InfoVisitor))]
+        [InlineData(typeof(OpenApiXml), typeof(XmlVisitor))]
+        [InlineData(typeof(OpenApiComponents), typeof(ComponentsVisitor))]
+        public void GetVisitorReturnsTheCorrectVisitor(Type elementType, Type visitorType)
+        {
+            // Arrange & Act
+            var visitor = OpenApiVisitorSet.GetVisitor(elementType);
+
+            // Assert
+            Assert.NotNull(visitor);
+            Assert.Same(visitorType, visitor.GetType());
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/Visitors/OpenApiVisitorSetTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/Visitors/OpenApiVisitorSetTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenApi.Validations.Visitors.Tests
                 // Assert
                 Assert.NotNull(visitors);
                 Assert.NotEmpty(visitors);
-                Assert.Equal(29, visitors.Count);
+                Assert.Equal(29, visitors.Count); // Now, we have 29 DOM classes.
             }
         }
 
@@ -38,10 +38,35 @@ namespace Microsoft.OpenApi.Validations.Visitors.Tests
         }
 
         [Theory]
-        [InlineData(typeof(OpenApiDocument), typeof(DocumentVisitor))]
-        [InlineData(typeof(OpenApiInfo), typeof(InfoVisitor))]
-        [InlineData(typeof(OpenApiXml), typeof(XmlVisitor))]
+        [InlineData(typeof(OpenApiCallback), typeof(CallbackVisitor))]
         [InlineData(typeof(OpenApiComponents), typeof(ComponentsVisitor))]
+        [InlineData(typeof(OpenApiContact), typeof(ContactVisitor))]
+        [InlineData(typeof(OpenApiDiscriminator), typeof(DiscriminatorVisitor))]
+        [InlineData(typeof(OpenApiDocument), typeof(DocumentVisitor))]
+        [InlineData(typeof(OpenApiEncoding), typeof(EncodingVisitor))]
+        [InlineData(typeof(OpenApiExample), typeof(ExampleVisitor))]
+        [InlineData(typeof(OpenApiExternalDocs), typeof(ExternalDocsVisitor))]
+        [InlineData(typeof(OpenApiHeader), typeof(HeaderVisitor))]
+        [InlineData(typeof(OpenApiInfo), typeof(InfoVisitor))]
+        [InlineData(typeof(OpenApiLicense), typeof(LicenseVisitor))]
+        [InlineData(typeof(OpenApiLink), typeof(LinkVisitor))]
+        [InlineData(typeof(OpenApiMediaType), typeof(MediaTypeVisitor))]
+        [InlineData(typeof(OpenApiOAuthFlows), typeof(OAuthFlowsVisitor))]
+        [InlineData(typeof(OpenApiOAuthFlow), typeof(OAuthFlowVisitor))]
+        [InlineData(typeof(OpenApiOperation), typeof(OperationVisitor))]
+        [InlineData(typeof(OpenApiParameter), typeof(ParameterVisitor))]
+        [InlineData(typeof(OpenApiPathItem), typeof(PathItemVisitor))]
+        [InlineData(typeof(OpenApiPaths), typeof(PathsVisitor))]
+        [InlineData(typeof(OpenApiRequestBody), typeof(RequestBodyVisitor))]
+        [InlineData(typeof(OpenApiResponses), typeof(ResponsesVisitor))]
+        [InlineData(typeof(OpenApiResponse), typeof(ResponseVisitor))]
+        [InlineData(typeof(OpenApiSchema), typeof(SchemaVisitor))]
+        [InlineData(typeof(OpenApiSecurityRequirement), typeof(SecurityRequirementVisitor))]
+        [InlineData(typeof(OpenApiSecurityScheme), typeof(SecuritySchemeVisitor))]
+        [InlineData(typeof(OpenApiServerVariable), typeof(ServerVariableVisitor))]
+        [InlineData(typeof(OpenApiServer), typeof(ServerVisitor))]
+        [InlineData(typeof(OpenApiTag), typeof(TagVisitor))]
+        [InlineData(typeof(OpenApiXml), typeof(XmlVisitor))]
         public void GetVisitorReturnsTheCorrectVisitor(Type elementType, Type visitorType)
         {
             // Arrange & Act


### PR DESCRIPTION
See #125:

I want to implement the validation logic for the Open API element. Here's my design (it's not finished).
General design:
Can validation each part individually. for example, Developer create a object, he can call the validate api to validate the created object.
Validate rule can be customized. For example, developer can create their own validation rules.
Detail:
OpenApiElementValidator.cs has the public apis
.\Validations\Visitors has the visitor classes for each element.
.\Validations\Rules has the rule classes for each element.
Please have a look and give me some feedback.