### PR TITLE
Fix V2 parameter deserializer to recognize "

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ReferenceServices/OpenApiV2ReferenceService.cs
+++ b/src/Microsoft.OpenApi.Readers/ReferenceServices/OpenApiV2ReferenceService.cs
@@ -97,6 +97,7 @@ namespace Microsoft.OpenApi.Readers.ReferenceServices
                     break;
 
                 case ReferenceType.Parameter:
+                    // TODO: Handle referencing to a "body" parameter in V2
                     referencedObject = OpenApiV2Deserializer.LoadParameter(node);
                     break;
 

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
@@ -202,13 +202,14 @@ namespace Microsoft.OpenApi.Readers.V2
                 case "body":
                     n.Context.SetTempStorage("bodyParameter", o);
                     break;
-                case "form":
+                case "formData":
                     var formParameters = n.Context.GetFromTempStorage<List<OpenApiParameter>>("formParameters");
                     if (formParameters == null)
                     {
                         formParameters = new List<OpenApiParameter>();
                         n.Context.SetTempStorage("formParameters", formParameters);
                     }
+
                     formParameters.Add(o);
                     break;
                 default:
@@ -226,11 +227,12 @@ namespace Microsoft.OpenApi.Readers.V2
             var mapNode = node.CheckMapNode("parameter");
 
             var pointer = mapNode.GetReferencePointer();
+
             if (pointer != null)
             {
                 return mapNode.GetReferencedObject<OpenApiParameter>(ReferenceType.Parameter, pointer);
             }
-
+            
             var parameter = new OpenApiParameter();
 
             ParseMap(mapNode, parameter, _parameterFixedFields, _parameterPatternFields);

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -65,6 +65,21 @@
         <None Update="V2Tests\Samples\minimal.v3.yaml">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Update="V2Tests\Samples\OpenApiParameter\formDataParameter.yaml">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="V2Tests\Samples\OpenApiParameter\queryParameter.yaml">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="V2Tests\Samples\OpenApiParameter\pathParameter.yaml">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="V2Tests\Samples\OpenApiParameter\headerParameter.yaml">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="V2Tests\Samples\OpenApiParameter\bodyParameter.yaml">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
         <None Update="V2Tests\Samples\OpenApiSecurityScheme\apiKeySecurityScheme.yaml">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiParameterTests.cs
@@ -1,0 +1,180 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.ParseNodes;
+using Microsoft.OpenApi.Readers.V2;
+using SharpYaml.Serialization;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.V2Tests
+{
+    [Collection("DefaultSettings")]
+    public class OpenApiParameterTests
+    {
+        private const string SampleFolderPath = "V2Tests/Samples/OpenApiParameter";
+
+        [Fact]
+        public void ParseBodyParameterShouldSucceed()
+        {
+            using (var stream = File.OpenRead(Path.Combine(SampleFolderPath, "bodyParameter.yaml")))
+            {
+                var yamlStream = new YamlStream();
+                yamlStream.Load(new StreamReader(stream));
+                var yamlNode = yamlStream.Documents.First().RootNode;
+
+                var context = new ParsingContext();
+                var diagnostic = new OpenApiDiagnostic();
+
+                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+
+                // Act
+                var parameter = OpenApiV2Deserializer.LoadParameter(node);
+
+                // Assert
+                // Body parameter is currently not translated via LoadParameter.
+                // This design may be revisited and this unit test may likely change.
+                parameter.ShouldBeEquivalentTo(null);
+            }
+        }
+
+        [Fact]
+        public void ParsePathParameterShouldSucceed()
+        {
+            using (var stream = File.OpenRead(Path.Combine(SampleFolderPath, "pathParameter.yaml")))
+            {
+                var yamlStream = new YamlStream();
+                yamlStream.Load(new StreamReader(stream));
+                var yamlNode = yamlStream.Documents.First().RootNode;
+
+                var context = new ParsingContext();
+                var diagnostic = new OpenApiDiagnostic();
+
+                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+
+                // Act
+                var parameter = OpenApiV2Deserializer.LoadParameter(node);
+
+                // Assert
+                parameter.ShouldBeEquivalentTo(
+                    new OpenApiParameter
+                    {
+                        In = ParameterLocation.Path,
+                        Name = "username",
+                        Description = "username to fetch",
+                        Required = true,
+                        Schema = new OpenApiSchema()
+                        {
+                            Type = "string"
+                        }
+                    });
+            }
+        }
+
+        [Fact]
+        public void ParseQueryParameterShouldSucceed()
+        {
+            using (var stream = File.OpenRead(Path.Combine(SampleFolderPath, "queryParameter.yaml")))
+            {
+                var yamlStream = new YamlStream();
+                yamlStream.Load(new StreamReader(stream));
+                var yamlNode = yamlStream.Documents.First().RootNode;
+
+                var context = new ParsingContext();
+                var diagnostic = new OpenApiDiagnostic();
+
+                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+
+                // Act
+                var parameter = OpenApiV2Deserializer.LoadParameter(node);
+
+                // Assert
+                parameter.ShouldBeEquivalentTo(
+                    new OpenApiParameter
+                    {
+                        In = ParameterLocation.Query,
+                        Name = "id",
+                        Description = "ID of the object to fetch",
+                        Required = false,
+                        Schema = new OpenApiSchema()
+                        {
+                            Type = "array",
+                            Items = new OpenApiSchema()
+                            {
+                                Type = "string"
+                            }
+                        },
+                        Style = ParameterStyle.Form,
+                        Explode = true
+                    });
+            }
+        }
+
+        [Fact]
+        public void ParseFormDataParameterShouldSucceed()
+        {
+            using (var stream = File.OpenRead(Path.Combine(SampleFolderPath, "formDataParameter.yaml")))
+            {
+                var yamlStream = new YamlStream();
+                yamlStream.Load(new StreamReader(stream));
+                var yamlNode = yamlStream.Documents.First().RootNode;
+
+                var context = new ParsingContext();
+                var diagnostic = new OpenApiDiagnostic();
+
+                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+
+                // Act
+                var parameter = OpenApiV2Deserializer.LoadParameter(node);
+
+                // Assert
+                // Form data parameter is currently not translated via LoadParameter.
+                // This design may be revisited and this unit test may likely change.
+                parameter.ShouldBeEquivalentTo(null);
+            }
+        }
+
+        [Fact]
+        public void ParseHeaderParameterShouldSucceed()
+        {
+            using (var stream = File.OpenRead(Path.Combine(SampleFolderPath, "headerParameter.yaml")))
+            {
+                var yamlStream = new YamlStream();
+                yamlStream.Load(new StreamReader(stream));
+                var yamlNode = yamlStream.Documents.First().RootNode;
+
+                var context = new ParsingContext();
+                var diagnostic = new OpenApiDiagnostic();
+
+                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+
+                // Act
+                var parameter = OpenApiV2Deserializer.LoadParameter(node);
+
+                // Assert
+                parameter.ShouldBeEquivalentTo(
+                    new OpenApiParameter
+                    {
+                        In = ParameterLocation.Header,
+                        Name = "token",
+                        Description = "token to be passed as a header",
+                        Required = true,
+                        Style = ParameterStyle.Simple,
+                        Schema = new OpenApiSchema()
+                        {
+                            Type = "array",
+                            Items = new OpenApiSchema()
+                            {
+                                Type = "integer",
+                                Format = "int64"
+                            }
+                        }
+                    });
+            }
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/bodyParameter.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/bodyParameter.yaml
@@ -1,0 +1,9 @@
+﻿# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
+name: user
+in: body
+description: user to add to the system
+required: true
+schema:
+  type: array
+  items:
+    type: string

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/formDataParameter.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/formDataParameter.yaml
@@ -1,0 +1,6 @@
+﻿# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
+name: avatar
+in: formData
+description: The avatar of the user
+required: true
+type: file

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/headerParameter.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/headerParameter.yaml
@@ -1,0 +1,10 @@
+﻿# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
+name: token
+in: header
+description: token to be passed as a header
+required: true
+type: array
+items:
+  type: integer
+  format: int64
+collectionFormat: csv

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/pathParameter.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/pathParameter.yaml
@@ -1,0 +1,6 @@
+﻿# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
+name: username
+in: path
+description: username to fetch
+required: true
+type: string

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/queryParameter.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/queryParameter.yaml
@@ -1,0 +1,9 @@
+﻿# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
+name: id
+in: query
+description: ID of the object to fetch
+required: false
+type: array
+items:
+  type: string
+collectionFormat: multi


### PR DESCRIPTION
- Basic unit tests for 5 types of possible parameters in V2.
- V2 doc parameter in can be "formData", not just "form".