### PR TITLE
Fix unit test to confirm that reference issue in Component is contained to only top-level reference

### DIFF
--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiComponentsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiComponentsTests.cs
@@ -554,17 +554,12 @@ securitySchemes:
             actual.Should().Be(expected);
         }
 
-        [Fact(Skip = "Issue #157 We are not serializing top-level reference in components correctly")]
+        [Fact]
         public void SerializeTopLevelSelfReferencingComponentsAsYamlWorks()
         {
             // Arrange
             var expected = @"schemas:
-  schema1:
-    $ref: '#/components/schemas/schema1'";
-
-            // Current output
-            // schemas:
-            //   schema1: { }
+  schema1: { }";
 
             // Act
             var actual = TopLevelSelfReferencingComponents.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_0_0);

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiComponentsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiComponentsTests.cs
@@ -378,8 +378,8 @@ namespace Microsoft.OpenApi.Tests.Models
 }";
 
             // Act
-                var actual = AdvancedComponentsWithReference.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0_0);
-            _output.WriteLine(actual);
+            var actual = AdvancedComponentsWithReference.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0_0);
+            
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
@@ -454,9 +454,7 @@ securitySchemes:
 
             // Act
             var actual = AdvancedComponentsWithReference.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_0_0);
-
-            _output.WriteLine(actual);
-
+            
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
@@ -538,11 +536,18 @@ securitySchemes:
       property1:
         type: string";
 
+            // Current output
+            // schemas:
+            //   schema1: { }
+            //   schema2:
+            //     type: object
+            //     properties:
+            //       property1:
+            //         type: string";
+
             // Act
             var actual = TopLevelReferencingComponents.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_0_0);
-
-            _output.WriteLine(actual);
-
+            
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
@@ -556,6 +561,10 @@ securitySchemes:
             var expected = @"schemas:
   schema1:
     $ref: '#/components/schemas/schema1'";
+
+            // Current output
+            // schemas:
+            //   schema1: { }
 
             // Act
             var actual = TopLevelSelfReferencingComponents.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_0_0);
@@ -584,9 +593,7 @@ securitySchemes:
 
             // Act
             var actual = TopLevelSelfReferencingComponentsWithOtherProperties.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_0_0);
-
-            _output.WriteLine(actual);
-
+            
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();


### PR DESCRIPTION
- Change one of the unit tests in Components to have reference in the inner level to verify that serialization of references work correctly in the Components (in the inner level) - most common cases.

- Top-level reference in Components is still not serialized correctly per #157.

This is NOT a fix to #157, but a test that 

1. Helps us understand the current behavior
2. Can be used to verify #157 once a fix is written.