### PR TITLE
Serialize reference in top-level component properly

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
@@ -78,32 +78,170 @@ namespace Microsoft.OpenApi.Models
 
             writer.WriteStartObject();
 
+            // Serialize each referenceable object as full object without reference if the reference in the object points to itself.
+            // If the reference exists but points to other objects, the object is serialized to just that reference.
+
             // schemas
-            writer.WriteOptionalMap(OpenApiConstants.Schemas, Schemas, (w, s) => s.SerializeAsV3WithoutReference(w));
+            writer.WriteOptionalMap(
+                OpenApiConstants.Schemas,
+                Schemas,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Schema &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
 
             // responses
-            writer.WriteOptionalMap(OpenApiConstants.Responses, Responses, (w, r) => r.SerializeAsV3WithoutReference(w));
+            writer.WriteOptionalMap(
+                OpenApiConstants.Responses,
+                Responses,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Response &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
 
             // parameters
-            writer.WriteOptionalMap(OpenApiConstants.Parameters, Parameters, (w, p) => p.SerializeAsV3WithoutReference(w));
+            writer.WriteOptionalMap(
+                OpenApiConstants.Parameters,
+                Parameters,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Parameter &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
 
             // examples
-            writer.WriteOptionalMap(OpenApiConstants.Examples, Examples, (w, e) => e.SerializeAsV3WithoutReference(w));
+            writer.WriteOptionalMap(
+                OpenApiConstants.Examples,
+                Examples,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Example &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
 
             // requestBodies
-            writer.WriteOptionalMap(OpenApiConstants.RequestBodies, RequestBodies, (w, r) => r.SerializeAsV3WithoutReference(w));
+            writer.WriteOptionalMap(
+                OpenApiConstants.RequestBodies,
+                RequestBodies,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.RequestBody &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
 
             // headers
-            writer.WriteOptionalMap(OpenApiConstants.Headers, Headers, (w, h) => h.SerializeAsV3WithoutReference(w));
+            writer.WriteOptionalMap(
+                OpenApiConstants.Headers,
+                Headers,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Header &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
 
             // securitySchemes
-            writer.WriteOptionalMap(OpenApiConstants.SecuritySchemes, SecuritySchemes, (w, s) => s.SerializeAsV3WithoutReference(w));
+            writer.WriteOptionalMap(
+                OpenApiConstants.SecuritySchemes,
+                SecuritySchemes,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.SecurityScheme &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
 
             // links
-            writer.WriteOptionalMap(OpenApiConstants.Links, Links, (w, link) => link.SerializeAsV3WithoutReference(w));
+            writer.WriteOptionalMap(
+                OpenApiConstants.Links,
+                Links,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Link &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
 
             // callbacks
-            writer.WriteOptionalMap(OpenApiConstants.Callbacks, Callbacks, (w, c) => c.SerializeAsV3WithoutReference(w));
+            writer.WriteOptionalMap(
+                OpenApiConstants.Callbacks,
+                Callbacks,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Callback &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
 
             // extensions
             writer.WriteExtensions(Extensions);

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -125,17 +125,80 @@ namespace Microsoft.OpenApi.Models
             // paths
             writer.WriteRequiredObject(OpenApiConstants.Paths, Paths, (w, p) => p.SerializeAsV2(w));
 
+            // Serialize each referenceable object as full object without reference if the reference in the object points to itself. 
+            // If the reference exists but points to other objects, the object is serialized to just that reference.
+
             // definitions
-            writer.WriteOptionalMap(OpenApiConstants.Definitions, Components?.Schemas, (w, s) => s.SerializeAsV2WithoutReference(w));
+            writer.WriteOptionalMap(
+                OpenApiConstants.Definitions,
+                Components?.Schemas,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Schema &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV2WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV2(w);
+                    }
+                });
 
             // parameters
-            writer.WriteOptionalMap(OpenApiConstants.Parameters, Components?.Parameters, (w, p) => p.SerializeAsV2WithoutReference(w));
+            writer.WriteOptionalMap(
+                OpenApiConstants.Parameters,
+                Components?.Parameters,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Parameter &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV2WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV2(w);
+                    }
+                });
 
             // responses
-            writer.WriteOptionalMap(OpenApiConstants.Responses, Components?.Responses, (w, r) => r.SerializeAsV2WithoutReference(w));
+            writer.WriteOptionalMap(
+                OpenApiConstants.Responses,
+                Components?.Responses,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Response &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV2WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV2(w);
+                    }
+                });
 
             // securityDefinitions
-            writer.WriteOptionalMap(OpenApiConstants.SecurityDefinitions, Components?.SecuritySchemes, (w, s) => s.SerializeAsV2WithoutReference(w));
+            writer.WriteOptionalMap(
+                OpenApiConstants.SecurityDefinitions,
+                Components?.SecuritySchemes,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.SecurityScheme &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV2WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV2(w);
+                    }
+                });
 
             // security
             writer.WriteOptionalCollection(

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterExtensions.cs
@@ -261,12 +261,33 @@ namespace Microsoft.OpenApi.Writers
         /// <param name="writer">The Open API writer.</param>
         /// <param name="name">The property name.</param>
         /// <param name="elements">The map values.</param>
-        /// <param name="action">The map element writer action.</param>
+        /// <param name="action">The map element writer action with writer and value as input.</param>
         public static void WriteOptionalMap<T>(
             this IOpenApiWriter writer,
             string name,
             IDictionary<string, T> elements,
             Action<IOpenApiWriter, T> action)
+            where T : IOpenApiElement
+        {
+            if (elements != null && elements.Any())
+            {
+                writer.WriteMapInternal(name, elements, action);
+            }
+        }
+
+        /// <summary>
+        /// Write the optional Open API element map.
+        /// </summary>
+        /// <typeparam name="T">The Open API element type. <see cref="IOpenApiElement"/></typeparam>
+        /// <param name="writer">The Open API writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="elements">The map values.</param>
+        /// <param name="action">The map element writer action with writer, key, and value as input.</param>
+        public static void WriteOptionalMap<T>(
+            this IOpenApiWriter writer,
+            string name,
+            IDictionary<string, T> elements,
+            Action<IOpenApiWriter, string, T> action)
             where T : IOpenApiElement
         {
             if (elements != null && elements.Any())
@@ -327,6 +348,15 @@ namespace Microsoft.OpenApi.Writers
             IDictionary<string, T> elements,
             Action<IOpenApiWriter, T> action)
         {
+            WriteMapInternal(writer, name, elements, (w, k, s) => action(w, s));
+        }
+
+        private static void WriteMapInternal<T>(
+            this IOpenApiWriter writer,
+            string name,
+            IDictionary<string, T> elements,
+            Action<IOpenApiWriter, string, T> action)
+        {
             CheckArguments(writer, name, action);
 
             writer.WritePropertyName(name);
@@ -339,7 +369,7 @@ namespace Microsoft.OpenApi.Writers
                     writer.WritePropertyName(item.Key);
                     if (item.Value != null)
                     {
-                        action(writer, item.Value);
+                        action(writer, item.Key, item.Value);
                     }
                     else
                     {
@@ -352,6 +382,16 @@ namespace Microsoft.OpenApi.Writers
         }
 
         private static void CheckArguments<T>(IOpenApiWriter writer, string name, Action<IOpenApiWriter, T> action)
+        {
+            CheckArguments(writer, name);
+
+            if (action == null)
+            {
+                throw Error.ArgumentNull(nameof(action));
+            }
+        }
+
+        private static void CheckArguments<T>(IOpenApiWriter writer, string name, Action<IOpenApiWriter, string, T> action)
         {
             CheckArguments(writer, name);
 

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiComponentsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiComponentsTests.cs
@@ -462,7 +462,7 @@ securitySchemes:
         }
 
         [Fact]
-        public void SerializeBrokenComponentsAsJsonWorks()
+        public void SerializeBrokenComponentsAsJsonV3Works()
         {
             // Arrange
             var expected = @"{
@@ -497,7 +497,7 @@ securitySchemes:
         }
 
         [Fact]
-        public void SerializeBrokenComponentsAsYamlWorks()
+        public void SerializeBrokenComponentsAsYamlV3Works()
         {
             // Arrange
             var expected = @"schemas:
@@ -523,8 +523,8 @@ securitySchemes:
             actual.Should().Be(expected);
         }
 
-        [Fact(Skip = "Issue #157 We are not serializing top-level reference in components correctly")]
-        public void SerializeTopLevelReferencingComponentsAsYamlWorks()
+        [Fact]
+        public void SerializeTopLevelReferencingComponentsAsYamlV3Works()
         {
             // Arrange
             var expected = @"schemas:
@@ -536,15 +536,6 @@ securitySchemes:
       property1:
         type: string";
 
-            // Current output
-            // schemas:
-            //   schema1: { }
-            //   schema2:
-            //     type: object
-            //     properties:
-            //       property1:
-            //         type: string";
-
             // Act
             var actual = TopLevelReferencingComponents.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_0);
             
@@ -555,7 +546,7 @@ securitySchemes:
         }
 
         [Fact]
-        public void SerializeTopLevelSelfReferencingComponentsAsYamlWorks()
+        public void SerializeTopLevelSelfReferencingComponentsAsYamlV3Works()
         {
             // Arrange
             var expected = @"schemas:
@@ -571,7 +562,7 @@ securitySchemes:
         }
 
         [Fact]
-        public void SerializeTopLevelSelfReferencingWithOtherPropertiesComponentsAsYamlWorks()
+        public void SerializeTopLevelSelfReferencingWithOtherPropertiesComponentsAsYamlV3Works()
         {
             // Arrange
             var expected = @"schemas:

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
+using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Writers;
 using Xunit;
@@ -15,6 +16,108 @@ namespace Microsoft.OpenApi.Tests.Models
     [Collection("DefaultSettings")]
     public class OpenApiDocumentTests
     {
+        public static OpenApiComponents TopLevelReferencingComponents = new OpenApiComponents()
+        {
+            Schemas =
+            {
+                ["schema1"] = new OpenApiSchema
+                {
+                    Reference = new OpenApiReference()
+                    {
+                        Type = ReferenceType.Schema,
+                        Id = "schema2"
+                    }
+                },
+                ["schema2"] = new OpenApiSchema
+                {
+                    Type = "object",
+                    Properties =
+                    {
+                        ["property1"] = new OpenApiSchema()
+                        {
+                            Type = "string"
+                        }
+                    }
+                },
+            }
+        };
+
+        public static OpenApiComponents TopLevelSelfReferencingComponentsWithOtherProperties = new OpenApiComponents()
+        {
+            Schemas =
+            {
+                ["schema1"] = new OpenApiSchema
+                {
+                    Type = "object",
+                    Properties =
+                    {
+                        ["property1"] = new OpenApiSchema()
+                        {
+                            Type = "string"
+                        }
+                    },
+                    Reference = new OpenApiReference()
+                    {
+                        Type = ReferenceType.Schema,
+                        Id = "schema1"
+                    }
+                },
+                ["schema2"] = new OpenApiSchema
+                {
+                    Type = "object",
+                    Properties =
+                    {
+                        ["property1"] = new OpenApiSchema()
+                        {
+                            Type = "string"
+                        }
+                    }
+                },
+            }
+        };
+
+        public static OpenApiComponents TopLevelSelfReferencingComponents = new OpenApiComponents()
+        {
+            Schemas =
+            {
+                ["schema1"] = new OpenApiSchema
+                {
+                    Reference = new OpenApiReference()
+                    {
+                        Type = ReferenceType.Schema,
+                        Id = "schema1"
+                    }
+                }
+            }
+        };
+
+        public static OpenApiDocument SimpleDocumentWithTopLevelReferencingComponents = new OpenApiDocument()
+        {
+            Info = new OpenApiInfo()
+            {
+                Version = "1.0.0"
+            },
+            Components = TopLevelReferencingComponents
+        };
+
+        public static OpenApiDocument SimpleDocumentWithTopLevelSelfReferencingComponentsWithOtherProperties = new OpenApiDocument()
+        {
+            Info = new OpenApiInfo()
+            {
+                Version = "1.0.0"
+            },
+            Components = TopLevelSelfReferencingComponentsWithOtherProperties
+        };
+
+        public static OpenApiDocument SimpleDocumentWithTopLevelSelfReferencingComponents = new OpenApiDocument()
+        {
+            Info = new OpenApiInfo()
+            {
+                Version = "1.0.0"
+            },
+            Components = TopLevelSelfReferencingComponents
+        };
+
         public static OpenApiComponents AdvancedComponentsWithReference = new OpenApiComponents
         {
             Schemas = new Dictionary<string, OpenApiSchema>
@@ -2312,6 +2415,81 @@ namespace Microsoft.OpenApi.Tests.Models
             writer.Flush();
             var actual = outputStringWriter.GetStringBuilder().ToString();
 
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeSimpleDocumentWithTopLevelReferencingComponentsAsYamlV2Works()
+        {
+            // Arrange
+            var expected = @"swagger: '2.0'
+info:
+  version: 1.0.0
+paths: { }
+definitions:
+  schema1:
+    $ref: '#/definitions/schema2'
+  schema2:
+    type: object
+    properties:
+      property1:
+        type: string";
+
+            // Act
+            var actual = SimpleDocumentWithTopLevelReferencingComponents.SerializeAsYaml(OpenApiSpecVersion.OpenApi2_0);
+            
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeSimpleDocumentWithTopLevelSelfReferencingComponentsAsYamlV3Works()
+        {
+            // Arrange
+            var expected = @"swagger: '2.0'
+info:
+  version: 1.0.0
+paths: { }
+definitions:
+  schema1: { }";
+
+            // Act
+            var actual = SimpleDocumentWithTopLevelSelfReferencingComponents.SerializeAsYaml(OpenApiSpecVersion.OpenApi2_0);
+            
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeSimpleDocumentWithTopLevelSelfReferencingWithOtherPropertiesComponentsAsYamlV3Works()
+        {
+            // Arrange
+            var expected = @"swagger: '2.0'
+info:
+  version: 1.0.0
+paths: { }
+definitions:
+  schema1:
+    type: object
+    properties:
+      property1:
+        type: string
+  schema2:
+    type: object
+    properties:
+      property1:
+        type: string";
+
+            // Act
+            var actual = SimpleDocumentWithTopLevelSelfReferencingComponentsWithOtherProperties.SerializeAsYaml(OpenApiSpecVersion.OpenApi2_0);
+            
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();


### PR DESCRIPTION
Fixes #157 

For each component (in Components in V3 or in Definitions/Parameters/etc. in V2), use the following serialization paradigm:

- If we don't see any reference, write full object.
- If we see a Reference to itself, write the full object without $ref.
- If we see a Reference to another object, always write as $ref

This is done by making "a Reference to itself" a special case (i.e. using SerializeAsVXWithoutReference). The rest of the logic is handled in SerializeAsVX.