### PR TITLE
Added support for custom extensions

### DIFF
--- a/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Readers.ParseNodes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.OpenApi.Readers
+{
+    /// <summary>
+    /// Configuration settings to control how OpenAPI documents are parsed
+    /// </summary>
+    public class OpenApiReaderSettings
+    {
+        /// <summary>
+        /// Dictionary of parsers for converting extensions into strongly typed classes
+        /// </summary>
+        public Dictionary<string, Func<IOpenApiAny , IOpenApiExtension>> ExtensionParsers { get; set; } = new Dictionary<string, Func<IOpenApiAny, IOpenApiExtension>>();
+
+    }
+}

--- a/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
@@ -15,7 +15,17 @@ namespace Microsoft.OpenApi.Readers
     /// </summary>
     public class OpenApiStreamReader : IOpenApiReader<Stream, OpenApiDiagnostic>
     {
+        private OpenApiReaderSettings _settings;
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="settings"></param>
+        public OpenApiStreamReader(OpenApiReaderSettings settings = null)
+        {
+            _settings = settings ?? new OpenApiReaderSettings();
+
+        }
         /// <summary>
         /// Reads the stream input and parses it into an Open API document.
         /// </summary>
@@ -38,7 +48,10 @@ namespace Microsoft.OpenApi.Readers
                 return new OpenApiDocument();
             }
 
-            context = new ParsingContext();
+            context = new ParsingContext
+            {
+                ExtensionParsers = _settings.ExtensionParsers
+            };
             return context.Parse(yamlDocument, diagnostic);
         }
 

--- a/src/Microsoft.OpenApi.Readers/OpenApiStringReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiStringReader.cs
@@ -12,6 +12,17 @@ namespace Microsoft.OpenApi.Readers
     /// </summary>
     public class OpenApiStringReader : IOpenApiReader<string, OpenApiDiagnostic>
     {
+        private readonly OpenApiReaderSettings _settings;
+
+        /// <summary>
+        /// Constructor tha allows reader to use non-default settings
+        /// </summary>
+        /// <param name="settings"></param>
+        public OpenApiStringReader(OpenApiReaderSettings settings = null)
+        {
+            _settings = settings ?? new OpenApiReaderSettings(); 
+        }
+
         /// <summary>
         /// Reads the string input and parses it into an Open API document.
         /// </summary>
@@ -24,7 +35,7 @@ namespace Microsoft.OpenApi.Readers
                 writer.Flush();
                 memoryStream.Position = 0;
 
-                return new OpenApiStreamReader().Read(memoryStream, out diagnostic);
+                return new OpenApiStreamReader(_settings).Read(memoryStream, out diagnostic);
             }
         }
     }

--- a/src/Microsoft.OpenApi.Readers/ParsingContext.cs
+++ b/src/Microsoft.OpenApi.Readers/ParsingContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.Interface;
@@ -23,6 +24,9 @@ namespace Microsoft.OpenApi.Readers
         private readonly Dictionary<string, IOpenApiReferenceable> _referenceStore = new Dictionary<string, IOpenApiReferenceable>();
         private readonly Dictionary<string, object> _tempStorage = new Dictionary<string, object>();
         private IOpenApiVersionService _versionService;
+
+        internal Dictionary<string, Func<IOpenApiAny, IOpenApiExtension>> ExtensionParsers { get; set; }  = new Dictionary<string, Func<IOpenApiAny, IOpenApiExtension>>();
+
         internal RootNode RootNode { get; set; }
         internal List<OpenApiTag> Tags { get; private set; } = new List<OpenApiTag>();
 
@@ -60,6 +64,7 @@ namespace Microsoft.OpenApi.Readers
             }
             return doc;
         }
+
 
         /// <summary>
         /// Gets the version of the Open API document.

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiDocumentDeserializer.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
 
@@ -49,6 +51,18 @@ namespace Microsoft.OpenApi.Readers.V3
             ReportMissing(openApiNode, required);
 
             return openApidoc;
+        }
+
+
+        public static IOpenApiExtension LoadExtension(string name, ParseNode node)
+        {
+            if (node.Context.ExtensionParsers.TryGetValue(name, out var parser)) {
+                return parser(node.CreateAny());
+            }
+            else
+            {
+                return node.CreateAny();
+            }
         }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiInfoDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiInfoDeserializer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.OpenApi.Readers.V3
 
         public static PatternFieldMap<OpenApiInfo> InfoPatternFields = new PatternFieldMap<OpenApiInfo>
         {
-            {s => s.StartsWith("x-"), (o, k, n) => o.AddExtension(k, n.CreateAny())}
+            {s => s.StartsWith("x-"), (o, k, n) => o.Extensions.Add(k,LoadExtension(k, n))}
         };
 
         public static OpenApiInfo LoadInfo(ParseNode node)

--- a/src/Microsoft.OpenApi/Any/IOpenApiAny.cs
+++ b/src/Microsoft.OpenApi/Any/IOpenApiAny.cs
@@ -8,7 +8,7 @@ namespace Microsoft.OpenApi.Any
     /// <summary>
     /// Base interface for all the types that represent Open API Any.
     /// </summary>
-    public interface IOpenApiAny : IOpenApiElement
+    public interface IOpenApiAny : IOpenApiElement, IOpenApiExtension
     {
         /// <summary>
         /// Type of an <see cref="IOpenApiAny"/>.

--- a/src/Microsoft.OpenApi/Any/OpenApiArray.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiArray.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using Microsoft.OpenApi.Writers;
 using System.Collections.Generic;
 
 namespace Microsoft.OpenApi.Any
@@ -14,5 +15,22 @@ namespace Microsoft.OpenApi.Any
         /// The type of <see cref="IOpenApiAny"/>
         /// </summary>
         public AnyType AnyType { get; } = AnyType.Array;
+
+        /// <summary>
+        /// Write out contents of OpenApiArray to passed writer
+        /// </summary>
+        /// <param name="writer">Instance of JSON or YAML writer.</param>
+        public void Write(IOpenApiWriter writer)
+        {
+            writer.WriteStartArray();
+
+            foreach (var item in this)
+            {
+                writer.WriteAny(item);
+            }
+
+            writer.WriteEndArray();
+
+        }
     }
 }

--- a/src/Microsoft.OpenApi/Any/OpenApiNull.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiNull.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using Microsoft.OpenApi.Writers;
+
 namespace Microsoft.OpenApi.Any
 {
     /// <summary>
@@ -12,5 +14,14 @@ namespace Microsoft.OpenApi.Any
         /// The type of <see cref="IOpenApiAny"/>
         /// </summary>
         public AnyType AnyType { get; } = AnyType.Null;
+
+        /// <summary>
+        /// Write out null representation
+        /// </summary>
+        /// <param name="writer"></param>
+        public void Write(IOpenApiWriter writer)
+        {
+            writer.WriteAny(this);
+        }
     }
 }

--- a/src/Microsoft.OpenApi/Any/OpenApiObject.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiObject.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using Microsoft.OpenApi.Writers;
 
 namespace Microsoft.OpenApi.Any
 {
@@ -14,5 +15,23 @@ namespace Microsoft.OpenApi.Any
         /// Type of <see cref="IOpenApiAny"/>.
         /// </summary>
         public AnyType AnyType { get; } = AnyType.Object;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="writer"></param>
+        public void Write(IOpenApiWriter writer)
+        {
+            writer.WriteStartObject();
+
+            foreach (var item in this)
+            {
+                writer.WritePropertyName(item.Key);
+                writer.WriteAny(item.Value);
+            }
+
+            writer.WriteEndObject();
+
+        }
     }
 }

--- a/src/Microsoft.OpenApi/Any/OpenApiPrimitive.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiPrimitive.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using Microsoft.OpenApi.Exceptions;
+using Microsoft.OpenApi.Properties;
+using Microsoft.OpenApi.Writers;
+
 namespace Microsoft.OpenApi.Any
 {
     /// <summary>
@@ -32,5 +36,77 @@ namespace Microsoft.OpenApi.Any
         /// Value of this <see cref="IOpenApiPrimitive"/>
         /// </summary>
         public T Value { get; }
+
+        /// <summary>
+        /// Write out content of primitive element
+        /// </summary>
+        /// <param name="writer"></param>
+        public void Write(IOpenApiWriter writer)
+        {
+            switch (this.PrimitiveType)
+            {
+                case PrimitiveType.Integer:
+                    var intValue = (OpenApiInteger)(IOpenApiPrimitive)this;
+                    writer.WriteValue(intValue.Value);
+                    break;
+
+                case PrimitiveType.Long:
+                    var longValue = (OpenApiLong)(IOpenApiPrimitive)this;
+                    writer.WriteValue(longValue.Value);
+                    break;
+
+                case PrimitiveType.Float:
+                    var floatValue = (OpenApiFloat)(IOpenApiPrimitive)this;
+                    writer.WriteValue(floatValue.Value);
+                    break;
+
+                case PrimitiveType.Double:
+                    var doubleValue = (OpenApiDouble)(IOpenApiPrimitive)this;
+                    writer.WriteValue(doubleValue.Value);
+                    break;
+
+                case PrimitiveType.String:
+                    var stringValue = (OpenApiString)(IOpenApiPrimitive)this;
+                    writer.WriteValue(stringValue.Value);
+                    break;
+
+                case PrimitiveType.Byte:
+                    var byteValue = (OpenApiByte)(IOpenApiPrimitive)this;
+                    writer.WriteValue(byteValue.Value);
+                    break;
+
+                case PrimitiveType.Binary:
+                    var binaryValue = (OpenApiBinary)(IOpenApiPrimitive)this;
+                    writer.WriteValue(binaryValue.Value);
+                    break;
+
+                case PrimitiveType.Boolean:
+                    var boolValue = (OpenApiBoolean)(IOpenApiPrimitive)this;
+                    writer.WriteValue(boolValue.Value);
+                    break;
+
+                case PrimitiveType.Date:
+                    var dateValue = (OpenApiDate)(IOpenApiPrimitive)this;
+                    writer.WriteValue(dateValue.Value);
+                    break;
+
+                case PrimitiveType.DateTime:
+                    var dateTimeValue = (OpenApiDateTime)(IOpenApiPrimitive)this;
+                    writer.WriteValue(dateTimeValue.Value);
+                    break;
+
+                case PrimitiveType.Password:
+                    var passwordValue = (OpenApiPassword)(IOpenApiPrimitive)this;
+                    writer.WriteValue(passwordValue.Value);
+                    break;
+
+                default:
+                    throw new OpenApiWriterException(
+                        string.Format(
+                            SRResource.PrimitiveTypeNotSupported,
+                            this.PrimitiveType));
+            }
+
+        }
     }
 }

--- a/src/Microsoft.OpenApi/Extensions/OpenApiExtensibleExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiExtensibleExtensions.cs
@@ -41,5 +41,6 @@ namespace Microsoft.OpenApi.Extensions
 
             element.Extensions[name] = any ?? throw Error.ArgumentNull(nameof(any));
         }
+
     }
 }

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiExtensible.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiExtensible.cs
@@ -14,6 +14,6 @@ namespace Microsoft.OpenApi.Interfaces
         /// <summary>
         /// Specification extensions.
         /// </summary>
-        IDictionary<string, IOpenApiAny> Extensions { get; set; }
+        IDictionary<string, IOpenApiExtension> Extensions { get; set; }
     }
 }

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiExtension.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiExtension.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.OpenApi.Writers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.OpenApi.Interfaces
+{
+    /// <summary>
+    /// Interface requuired for implementing any custom extension
+    /// </summary>
+    public interface IOpenApiExtension
+    {
+        /// <summary>
+        /// Write out contents of custom extension
+        /// </summary>
+        /// <param name="writer"></param>
+        void Write(IOpenApiWriter writer);
+    }
+}

--- a/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
@@ -28,7 +28,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Add a <see cref="OpenApiPathItem"/> into the <see cref="PathItems"/>.

--- a/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
@@ -64,7 +64,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiComponents"/> to Open Api v3.0.

--- a/src/Microsoft.OpenApi/Models/OpenApiContact.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiContact.cs
@@ -33,7 +33,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiContact"/> to Open Api v3.0

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiDocument"/> to the latest patch of OpenAPI object V3.0.

--- a/src/Microsoft.OpenApi/Models/OpenApiEncoding.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiEncoding.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v3.0.

--- a/src/Microsoft.OpenApi/Models/OpenApiExample.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExample.cs
@@ -42,7 +42,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Reference object.

--- a/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize to Open Api v3.0

--- a/src/Microsoft.OpenApi/Models/OpenApiExternalDocs.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExternalDocs.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v3.0.

--- a/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
@@ -79,7 +79,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiHeader"/> to Open Api v3.0

--- a/src/Microsoft.OpenApi/Models/OpenApiInfo.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiInfo.cs
@@ -47,7 +47,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiInfo"/> to Open Api v3.0

--- a/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiLicense"/> to Open Api v3.0

--- a/src/Microsoft.OpenApi/Models/OpenApiLink.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiLink.cs
@@ -49,7 +49,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Reference pointer.

--- a/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
@@ -41,7 +41,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v3.0.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiMediaType"/> to Open Api v3.0.

--- a/src/Microsoft.OpenApi/Models/OpenApiOAuthFlow.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOAuthFlow.cs
@@ -39,7 +39,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiOAuthFlow"/> to Open Api v3.0

--- a/src/Microsoft.OpenApi/Models/OpenApiOAuthFlows.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOAuthFlows.cs
@@ -36,7 +36,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiOAuthFlows"/> to Open Api v3.0

--- a/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
@@ -104,7 +104,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiOperation"/> to Open Api v3.0.

--- a/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
@@ -122,7 +122,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiParameter"/> to Open Api v3.0

--- a/src/Microsoft.OpenApi/Models/OpenApiPathItem.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiPathItem.cs
@@ -44,7 +44,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Add one operation into this path item.

--- a/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
@@ -38,7 +38,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiRequestBody"/> to Open Api v3.0

--- a/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
@@ -40,7 +40,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Reference pointer.

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -223,7 +223,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Reference object.

--- a/src/Microsoft.OpenApi/Models/OpenApiSecurityScheme.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSecurityScheme.cs
@@ -61,7 +61,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Reference object.

--- a/src/Microsoft.OpenApi/Models/OpenApiServer.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiServer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiServer"/> to Open Api v3.0

--- a/src/Microsoft.OpenApi/Models/OpenApiServerVariable.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiServerVariable.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiServerVariable"/> to Open Api v3.0

--- a/src/Microsoft.OpenApi/Models/OpenApiTag.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiTag.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Reference.

--- a/src/Microsoft.OpenApi/Models/OpenApiXml.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiXml.cs
@@ -44,7 +44,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiAny> Extensions { get; set; } = new Dictionary<string, IOpenApiAny>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Serialize <see cref="OpenApiXml"/> to Open Api v3.0

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterAnyExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterAnyExtensions.cs
@@ -2,9 +2,10 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
-using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Properties;
+using Microsoft.OpenApi.Any;
 
 namespace Microsoft.OpenApi.Writers
 {
@@ -18,7 +19,7 @@ namespace Microsoft.OpenApi.Writers
         /// </summary>
         /// <param name="writer">The Open API writer.</param>
         /// <param name="extensions">The specification extensions.</param>
-        public static void WriteExtensions(this IOpenApiWriter writer, IDictionary<string, IOpenApiAny> extensions)
+        public static void WriteExtensions(this IOpenApiWriter writer, IDictionary<string, IOpenApiExtension> extensions)
         {
             if (writer == null)
             {
@@ -30,7 +31,7 @@ namespace Microsoft.OpenApi.Writers
                 foreach (var item in extensions)
                 {
                     writer.WritePropertyName(item.Key);
-                    writer.WriteAny(item.Value);
+                    item.Value.Write(writer);
                 }
             }
         }

--- a/test/Microsoft.OpenApi.Readers.Tests/TestCustomExtension.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/TestCustomExtension.cs
@@ -1,0 +1,69 @@
+﻿using FluentAssertions;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Writers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests
+{
+    public class TestCustomExtension
+    {
+        [Fact]
+        public void ParseCustomExtension()
+        {
+            var description = @"
+openapi: 3.0.0
+info: 
+    title: A doc with an extension
+    version: 1.0.0
+    x-foo: 
+        bar: hey
+        baz: hi!
+paths: {}
+";
+            var settings = new OpenApiReaderSettings()
+            {
+                ExtensionParsers = { { "x-foo", (a) => {
+                        var fooNode = (OpenApiObject)a;
+                        return new FooExtension() {
+                              Bar = (fooNode["bar"] as OpenApiString)?.Value,
+                              Baz = (fooNode["baz"] as OpenApiString)?.Value
+                        };
+                
+
+                } } }
+            };
+
+            var reader = new OpenApiStringReader(settings);
+        
+            var diag = new OpenApiDiagnostic();
+            var doc = reader.Read(description, out diag);
+
+            var fooExtension = doc.Info.Extensions["x-foo"] as FooExtension;
+
+            fooExtension.Should().NotBeNull();
+            fooExtension.Bar.Should().Be("hey");
+            fooExtension.Baz.Should().Be("hi!");
+        }
+    }
+
+    public class FooExtension : IOpenApiExtension
+    {
+        public string Baz { get; set; }
+
+        public string Bar { get; set; }
+
+        public void Write(IOpenApiWriter writer)
+        {
+            writer.WriteStartObject();
+            writer.WriteProperty("baz", Baz);
+            writer.WriteProperty("bar", Bar);
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiContactTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiContactTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Xunit;
 
@@ -21,7 +22,7 @@ namespace Microsoft.OpenApi.Tests.Models
             Name = "API Support",
             Url = new Uri("http://www.example.com/support"),
             Email = "support@example.com",
-            Extensions = new Dictionary<string, IOpenApiAny>
+            Extensions = new Dictionary<string, IOpenApiExtension>
             {
                 {"x-internal-id", new OpenApiInteger(42)}
             }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiInfoTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiInfoTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Xunit;
 
@@ -22,7 +23,7 @@ namespace Microsoft.OpenApi.Tests.Models
             Contact = OpenApiContactTests.AdvanceContact,
             License = OpenApiLicenseTests.AdvanceLicense,
             Version = "1.1.1",
-            Extensions = new Dictionary<string, IOpenApiAny>
+            Extensions = new Dictionary<string, IOpenApiExtension>
             {
                 {"x-updated", new OpenApiString("metadata")}
             }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiLicenseTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiLicenseTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Xunit;
 
@@ -23,7 +24,7 @@ namespace Microsoft.OpenApi.Tests.Models
         {
             Name = "Apache 2.0",
             Url = new Uri("http://www.apache.org/licenses/LICENSE-2.0.html"),
-            Extensions = new Dictionary<string, IOpenApiAny>
+            Extensions = new Dictionary<string, IOpenApiExtension>
             {
                 {"x-copyright", new OpenApiString("Abc")}
             }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiTagTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiTagTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Writers;
 using Xunit;
@@ -21,7 +22,7 @@ namespace Microsoft.OpenApi.Tests.Models
             Name = "pet",
             Description = "Pets operations",
             ExternalDocs = OpenApiExternalDocsTests.AdvanceExDocs,
-            Extensions = new Dictionary<string, IOpenApiAny>
+            Extensions = new Dictionary<string, IOpenApiExtension>
             {
                 {"x-tag-extension", new OpenApiNull()}
             }
@@ -32,7 +33,7 @@ namespace Microsoft.OpenApi.Tests.Models
             Name = "pet",
             Description = "Pets operations",
             ExternalDocs = OpenApiExternalDocsTests.AdvanceExDocs,
-            Extensions = new Dictionary<string, IOpenApiAny>
+            Extensions = new Dictionary<string, IOpenApiExtension>
             {
                 {"x-tag-extension", new OpenApiNull()}
             },

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiXmlTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiXmlTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Xunit;
 
@@ -21,7 +22,7 @@ namespace Microsoft.OpenApi.Tests.Models
             Prefix = "sample",
             Wrapped = true,
             Attribute = true,
-            Extensions = new Dictionary<string, IOpenApiAny>
+            Extensions = new Dictionary<string, IOpenApiExtension>
             {
                 {"x-xml-extension", new OpenApiInteger(7)}
             }


### PR DESCRIPTION
This PR is a proposal for potentially implementing strongly typed custom extensions.  I have introduced a new interface IOpenApiExtension which IOpenApiAny now implements so it does still work as it did before.  However, you can now also create custom classes for those extensions.  

Currently the custom classes need to deserialize from an IOpenApiAny instance, but this might not be the best approach.  I was going to make them deserialize from ParseNode but that would require making that set of classes public, which I'm not too sure we want to do.

I also want to make sure we can use the validation rules to validate these custom extensions.  That's the next thing I want to try.  But in the meanwhile, if I can get some feedback on the approach so far and your feeling about parsing from ParseNode vs OpenApiAny that would be great.