### PR TITLE
[Fix 177]: Throw exception when spec version is not recognized by reader

### DIFF
--- a/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiReaderException.cs
+++ b/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiReaderException.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. 
 
 using System;
-using System.Runtime.Serialization;
 
 namespace Microsoft.OpenApi.Readers.Exceptions
 {
@@ -29,12 +28,5 @@ namespace Microsoft.OpenApi.Readers.Exceptions
         /// <param name="message">Plain text error message for this exception.</param>
         /// <param name="innerException">Inner exception that caused this exception to be thrown.</param>
         public OpenApiReaderException(string message, Exception innerException) : base(message, innerException) { }
-
-        /// <summary>
-        /// Initializes the <see cref="OpenApiReaderException" /> class based on serialization info and context.
-        /// </summary>
-        /// <param name="info">Info needed to serialize or deserialize this exception.</param>
-        /// <param name="context">Context needed to serialize or deserialize this exception.</param>
-        protected OpenApiReaderException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiReaderException.cs
+++ b/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiReaderException.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.OpenApi.Readers.Exceptions
+{
+    /// <summary>
+    /// Defines an exception indicating OpenAPI Reader encountered an issue while reading.
+    /// </summary>
+    [Serializable]
+    public class OpenApiReaderException : Exception
+    {
+        /// <summary>
+        /// Initializes the <see cref="OpenApiReaderException"/> class.
+        /// </summary>
+        public OpenApiReaderException() { }
+
+        /// <summary>
+        /// Initializes the <see cref="OpenApiReaderException"/> class with a custom message.
+        /// </summary>
+        /// <param name="message">Plain text error message for this exception.</param>
+        public OpenApiReaderException(string message) : base(message) { }
+
+        /// <summary>
+        /// Initializes the <see cref="OpenApiReaderException"/> class with a custom message and inner exception.
+        /// </summary>
+        /// <param name="message">Plain text error message for this exception.</param>
+        /// <param name="innerException">Inner exception that caused this exception to be thrown.</param>
+        public OpenApiReaderException(string message, Exception innerException) : base(message, innerException) { }
+
+        /// <summary>
+        /// Initializes the <see cref="OpenApiReaderException" /> class based on serialization info and context.
+        /// </summary>
+        /// <param name="info">Info needed to serialize or deserialize this exception.</param>
+        /// <param name="context">Context needed to serialize or deserialize this exception.</param>
+        protected OpenApiReaderException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiUnsupportedSpecVersionException.cs
+++ b/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiUnsupportedSpecVersionException.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using System.Globalization;
+using System.Runtime.Serialization;
+
+namespace Microsoft.OpenApi.Readers.Exceptions
+{
+    /// <summary>
+    /// Defines an exception indicating OpenAPI Reader encountered an unsupported specification version while reading.
+    /// </summary>
+    [Serializable]
+    public class OpenApiUnsupportedSpecVersionException : OpenApiReaderException
+    {
+        const string messagePattern = "OpenAPI specification version {0} is not supported.";
+
+        /// <summary>
+        /// Initializes the <see cref="OpenApiUnsupportedSpecVersionException"/> class.
+        /// </summary>
+        public OpenApiUnsupportedSpecVersionException() { }
+
+        /// <summary>
+        /// Initializes the <see cref="OpenApiUnsupportedSpecVersionException"/> class with a specification version.
+        /// </summary>
+        /// <param name="specificationVersion">Version that caused this exception to be thrown.</param>
+        public OpenApiUnsupportedSpecVersionException(string specificationVersion)
+            : base(string.Format(CultureInfo.InvariantCulture, messagePattern, specificationVersion)) { }
+
+        /// <summary>
+        /// Initializes the <see cref="OpenApiUnsupportedSpecVersionException"/> class with a specification version and
+        /// inner exception.
+        /// </summary>
+        /// <param name="specificationVersion">Version that caused this exception to be thrown.</param>
+        /// <param name="innerException">Inner exception that caused this exception to be thrown.</param>
+        public OpenApiUnsupportedSpecVersionException(string specificationVersion, Exception innerException)
+            : base(string.Format(CultureInfo.InvariantCulture, messagePattern, specificationVersion), innerException) { }
+
+        /// <summary>
+        /// Initializes the <see cref="OpenApiUnsupportedSpecVersionException" /> class based on serialization info and
+        /// context.
+        /// </summary>
+        /// <param name="info">Info needed to serialize or deserialize this exception.</param>
+        /// <param name="context">Context needed to serialize or deserialize this exception.</param>
+        protected OpenApiUnsupportedSpecVersionException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+    }
+}

--- a/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiUnsupportedSpecVersionException.cs
+++ b/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiUnsupportedSpecVersionException.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using System.Runtime.Serialization;
 
 namespace Microsoft.OpenApi.Readers.Exceptions
 {
@@ -16,16 +15,19 @@ namespace Microsoft.OpenApi.Readers.Exceptions
         const string messagePattern = "OpenAPI specification version {0} is not supported.";
 
         /// <summary>
-        /// Initializes the <see cref="OpenApiUnsupportedSpecVersionException"/> class.
-        /// </summary>
-        public OpenApiUnsupportedSpecVersionException() { }
-
-        /// <summary>
         /// Initializes the <see cref="OpenApiUnsupportedSpecVersionException"/> class with a specification version.
         /// </summary>
         /// <param name="specificationVersion">Version that caused this exception to be thrown.</param>
         public OpenApiUnsupportedSpecVersionException(string specificationVersion)
-            : base(string.Format(CultureInfo.InvariantCulture, messagePattern, specificationVersion)) { }
+            : base(string.Format(CultureInfo.InvariantCulture, messagePattern, specificationVersion))
+        {
+            if (string.IsNullOrWhiteSpace(specificationVersion))
+            {
+                throw new ArgumentException("Value cannot be null or white space.", nameof(specificationVersion));
+            }
+
+            this.SpecificationVersion = specificationVersion;
+        }
 
         /// <summary>
         /// Initializes the <see cref="OpenApiUnsupportedSpecVersionException"/> class with a specification version and
@@ -34,15 +36,19 @@ namespace Microsoft.OpenApi.Readers.Exceptions
         /// <param name="specificationVersion">Version that caused this exception to be thrown.</param>
         /// <param name="innerException">Inner exception that caused this exception to be thrown.</param>
         public OpenApiUnsupportedSpecVersionException(string specificationVersion, Exception innerException)
-            : base(string.Format(CultureInfo.InvariantCulture, messagePattern, specificationVersion), innerException) { }
+            : base(string.Format(CultureInfo.InvariantCulture, messagePattern, specificationVersion), innerException)
+        {
+            if (string.IsNullOrWhiteSpace(specificationVersion))
+            {
+                throw new ArgumentException("Value cannot be null or white space.", nameof(specificationVersion));
+            }
+
+            this.SpecificationVersion = specificationVersion;
+        }
 
         /// <summary>
-        /// Initializes the <see cref="OpenApiUnsupportedSpecVersionException" /> class based on serialization info and
-        /// context.
+        /// The unsupported specification version.
         /// </summary>
-        /// <param name="info">Info needed to serialize or deserialize this exception.</param>
-        /// <param name="context">Context needed to serialize or deserialize this exception.</param>
-        protected OpenApiUnsupportedSpecVersionException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
+        public string SpecificationVersion { get; }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+++ b/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi.Readers</Title>
         <PackageId>Microsoft.OpenApi.Readers</PackageId>
-        <Version>1.0.0-beta010</Version>
+        <Version>1.0.0-beta011</Version>
         <Description>OpenAPI.NET Readers for JSON and YAML documents</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/src/Microsoft.OpenApi.Readers/ParsingContext.cs
+++ b/src/Microsoft.OpenApi.Readers/ParsingContext.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.Exceptions;
 using Microsoft.OpenApi.Readers.Interface;
 using Microsoft.OpenApi.Readers.ParseNodes;
 using Microsoft.OpenApi.Readers.V2;
@@ -41,26 +42,24 @@ namespace Microsoft.OpenApi.Readers
 
             OpenApiDocument doc;
 
-            if (inputVersion == "2.0")
+            switch (inputVersion)
             {
-                VersionService = new OpenApiV2VersionService();
-                doc = this.VersionService.LoadDocument(this.RootNode);
-                diagnostic.SpecificationVersion = OpenApiSpecVersion.OpenApi2_0;
+                case string version when version == "2.0":
+                    VersionService = new OpenApiV2VersionService();
+                    doc = this.VersionService.LoadDocument(this.RootNode);
+                    diagnostic.SpecificationVersion = OpenApiSpecVersion.OpenApi2_0;
+                    break;
+
+                case string version when version.StartsWith("3.0"):
+                    this.VersionService = new OpenApiV3VersionService();
+                    doc = this.VersionService.LoadDocument(this.RootNode);
+                    diagnostic.SpecificationVersion = OpenApiSpecVersion.OpenApi3_0;
+                    break;
+
+                default:
+                    throw new OpenApiUnsupportedSpecVersionException(inputVersion);
             }
-            else if (inputVersion.StartsWith("3.0."))
-            {
-                this.VersionService = new OpenApiV3VersionService();
-                doc = this.VersionService.LoadDocument(this.RootNode);
-                diagnostic.SpecificationVersion = OpenApiSpecVersion.OpenApi3_0;
-            }
-            else
-            {
-                // If version number is not recognizable,
-                // our best effort will try to deserialize the document to V3.
-                this.VersionService = new OpenApiV3VersionService();
-                doc = this.VersionService.LoadDocument(this.RootNode);
-                diagnostic.SpecificationVersion = OpenApiSpecVersion.OpenApi3_0;
-            }
+
             return doc;
         }
 
@@ -81,7 +80,7 @@ namespace Microsoft.OpenApi.Readers
             return versionNode?.GetScalarValue();
         }
 
-        private void ComputeTags(List<OpenApiTag> tags, Func<MapNode,OpenApiTag> loadTag )
+        private void ComputeTags(List<OpenApiTag> tags, Func<MapNode, OpenApiTag> loadTag)
         {
             // Precompute the tags array so that each tag reference does not require a new deserialization.
             var tagListPointer = new JsonPointer("#/tags");

--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi</Title>
         <PackageId>Microsoft.OpenApi</PackageId>
-        <Version>1.0.0-beta010</Version>
+        <Version>1.0.0-beta011</Version>
         <Description>.NET models with JSON and YAML writers for OpenAPI specification</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -13,6 +13,9 @@
         <AssemblyOriginatorKeyFile>..\..\src\Microsoft.OpenApi.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
     <ItemGroup>
+      <EmbeddedResource Include="OpenApiReaderTests\Samples\unsupported.v1.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
       <EmbeddedResource Include="ReferenceService\Samples\multipleReferences.v2.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/Samples/unsupported.v1.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/Samples/unsupported.v1.yaml
@@ -1,0 +1,8 @@
+﻿swagger: 1.0
+info: 
+  title: This is a simple example
+  version: 1.0.0
+host: example.org
+basePath: /api
+schemes: ["http", "https"]
+paths: {}

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/Samples/unsupported.v1.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/Samples/unsupported.v1.yaml
@@ -1,4 +1,4 @@
-﻿swagger: 1.0
+﻿swagger: 1.0.0
 info: 
   title: This is a simple example
   version: 1.0.0

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/UnsupportedSpecVersionTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/UnsupportedSpecVersionTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System;
 using FluentAssertions;
 using Microsoft.OpenApi.Readers.Exceptions;
 using Xunit;
@@ -16,8 +15,14 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
         {
             using (var stream = Resources.GetStream("OpenApiReaderTests/Samples/unsupported.v1.yaml"))
             {
-                Action act = () => new OpenApiStreamReader().Read(stream, out var diagnostic);
-                act.ShouldThrow<OpenApiUnsupportedSpecVersionException>();
+                try
+                {
+                    new OpenApiStreamReader().Read(stream, out var diagnostic);
+                }
+                catch (OpenApiUnsupportedSpecVersionException exception)
+                {
+                    exception.SpecificationVersion.Should().Be("1.0.0");
+                }                
             }
         }
     }

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/UnsupportedSpecVersionTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/UnsupportedSpecVersionTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using FluentAssertions;
+using Microsoft.OpenApi.Readers.Exceptions;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
+{
+    [Collection("DefaultSettings")]
+    public class UnsupportedSpecVersionTests
+    {
+        [Fact]
+        public void ThrowOpenApiUnsupportedSpecVersionException()
+        {
+            using (var stream = Resources.GetStream("OpenApiReaderTests/Samples/unsupported.v1.yaml"))
+            {
+                Action act = () => new OpenApiStreamReader().Read(stream, out var diagnostic);
+                act.ShouldThrow<OpenApiUnsupportedSpecVersionException>();
+            }
+        }
+    }
+}


### PR DESCRIPTION
See https://github.com/Microsoft/OpenAPI.NET/issues/177 for context. 

I've introduced a fundamental exception type of `OpenApiReaderException` and throw an `OpenApiUnsupportedSpecVersionException` when we encounter an unrecognized version. The former exception type is meant to be the base type for any more specific exception types to come in future.

Test added with version 1.0.0, which I assume we'll never support, so the test should be robust in future versions of OpenAPI spec.