### PR TITLE
Fix formData/body parameter and consumes handling

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
@@ -221,23 +221,22 @@ namespace Microsoft.OpenApi.Models
         {
             writer.WriteStartObject();
 
-            // name
             // in
-            if (IsFormDataParameter())
+            if (this is OpenApiFormDataParameter)
             {
-                writer.WriteProperty(OpenApiConstants.Name, "formData");
                 writer.WriteProperty(OpenApiConstants.In, "formData");
             }
-            else if (IsBodyParameter())
+            else if (this is OpenApiBodyParameter)
             {
-                writer.WriteProperty(OpenApiConstants.Name, "body");
                 writer.WriteProperty(OpenApiConstants.In, "body");
             }
             else
             {
-                writer.WriteProperty(OpenApiConstants.Name, Name);
                 writer.WriteProperty(OpenApiConstants.In, In.GetDisplayName());
             }
+
+            // name
+            writer.WriteProperty(OpenApiConstants.Name, Name);
 
             // description
             writer.WriteProperty(OpenApiConstants.Description, Description);
@@ -249,7 +248,7 @@ namespace Microsoft.OpenApi.Models
             writer.WriteProperty(OpenApiConstants.Deprecated, Deprecated, false);
 
             // schema
-            if (IsBodyParameter())
+            if (this is OpenApiBodyParameter)
             {
                 writer.WriteOptionalObject(OpenApiConstants.Schema, Schema, (w, s) => s.SerializeAsV2(w));
             }
@@ -283,44 +282,19 @@ namespace Microsoft.OpenApi.Models
 
             writer.WriteEndObject();
         }
-
-        private bool IsBodyParameter()
-        {
-            if (this is BodyParameter)
-            {
-                var parameter = (BodyParameter)this;
-
-                return !(
-                    parameter.Format.Contains("application/x-www-form-urlencoded") ||
-                    parameter.Format.Contains("multipart/form-data"));
-            }
-
-            return false;
-        }
-
-        private bool IsFormDataParameter()
-        {
-            if (this is BodyParameter)
-            {
-                var parameter = (BodyParameter)this;
-
-                return
-                    parameter.Format.Contains("application/x-www-form-urlencoded") ||
-                    parameter.Format.Contains("multipart/form-data");
-            }
-
-            return false;
-        }
     }
 
     /// <summary>
     /// Body parameter class to propagate information needed for <see cref="OpenApiParameter.SerializeAsV2"/>
     /// </summary>
-    internal class BodyParameter : OpenApiParameter
+    internal class OpenApiBodyParameter : OpenApiParameter
     {
-        /// <summary>
-        /// Format of the parameter. This should be the same as the "consumes" property in Operation.
-        /// </summary>
-        public IList<string> Format { get; set; }
+    }
+
+    /// <summary>
+    /// Form parameter class to propagate information needed for <see cref="OpenApiParameter.SerializeAsV2"/>
+    /// </summary>
+    internal class OpenApiFormDataParameter : OpenApiParameter
+    {
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -31,6 +31,15 @@
       <EmbeddedResource Include="V2Tests\Samples\minimal.v3.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiOperation\basicOperation.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+        <EmbeddedResource Include="V2Tests\Samples\OpenApiOperation\operationWithBody.yaml">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+        </EmbeddedResource>
+        <EmbeddedResource Include="V2Tests\Samples\OpenApiOperation\operationWithFormData.yaml">
+            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+        </EmbeddedResource>
       <EmbeddedResource Include="V2Tests\Samples\OpenApiParameter\bodyParameter.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiOperationTests.cs
@@ -1,0 +1,286 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.ParseNodes;
+using Microsoft.OpenApi.Readers.V2;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.V2Tests
+{
+    [Collection("DefaultSettings")]
+    public class OpenApiOperationTests
+    {
+        private const string SampleFolderPath = "V2Tests/Samples/OpenApiOperation/";
+
+        private static readonly OpenApiOperation _basicOperation = new OpenApiOperation
+        {
+            Summary = "Updates a pet in the store",
+            Description = "",
+            OperationId = "updatePet",
+            Parameters = new List<OpenApiParameter>
+            {
+                new OpenApiParameter
+                {
+                    Name = "petId",
+                    In = ParameterLocation.Path,
+                    Description = "ID of pet that needs to be updated",
+                    Required = true,
+                    Schema = new OpenApiSchema
+                    {
+                        Type = "string"
+                    }
+                }
+            },
+            Responses = new OpenApiResponses
+            {
+                ["200"] = new OpenApiResponse
+                {
+                    Description = "Pet updated."
+                }
+            }
+        };
+
+        private static readonly OpenApiOperation _operationWithFormData =
+            new OpenApiOperation
+            {
+                Summary = "Updates a pet in the store with form data",
+                Description = "",
+                OperationId = "updatePetWithForm",
+                Parameters = new List<OpenApiParameter>
+                {
+                    new OpenApiParameter
+                    {
+                        Name = "petId",
+                        In = ParameterLocation.Path,
+                        Description = "ID of pet that needs to be updated",
+                        Required = true,
+                        Schema = new OpenApiSchema
+                        {
+                            Type = "string"
+                        }
+                    }
+                },
+                RequestBody = new OpenApiRequestBody
+                {
+                    Content =
+                    {
+                        ["application/x-www-form-urlencoded"] = new OpenApiMediaType
+                        {
+                            Schema = new OpenApiSchema
+                            {
+                                Properties =
+                                {
+                                    ["name"] = new OpenApiSchema
+                                    {
+                                        Description = "Updated name of the pet",
+                                        Type = "string"
+                                    },
+                                    ["status"] = new OpenApiSchema
+                                    {
+                                        Description = "Updated status of the pet",
+                                        Type = "string"
+                                    }
+                                },
+                                Required = new List<string>
+                                {
+                                    "name"
+                                }
+                            }
+                        },
+                        ["multipart/form-data"] = new OpenApiMediaType
+                        {
+                            Schema = new OpenApiSchema
+                            {
+                                Properties =
+                                {
+                                    ["name"] = new OpenApiSchema
+                                    {
+                                        Description = "Updated name of the pet",
+                                        Type = "string"
+                                    },
+                                    ["status"] = new OpenApiSchema
+                                    {
+                                        Description = "Updated status of the pet",
+                                        Type = "string"
+                                    }
+                                },
+                                Required = new List<string>
+                                {
+                                    "name"
+                                }
+                            }
+                        }
+                    }
+                },
+                Responses = new OpenApiResponses
+                {
+                    ["200"] = new OpenApiResponse
+                    {
+                        Description = "Pet updated."
+                    },
+                    ["405"] = new OpenApiResponse
+                    {
+                        Description = "Invalid input"
+                    }
+                }
+            };
+
+        private static readonly OpenApiOperation _operationWithBody = new OpenApiOperation
+        {
+            Summary = "Updates a pet in the store with request body",
+            Description = "",
+            OperationId = "updatePetWithBody",
+            Parameters = new List<OpenApiParameter>
+            {
+                new OpenApiParameter
+                {
+                    Name = "petId",
+                    In = ParameterLocation.Path,
+                    Description = "ID of pet that needs to be updated",
+                    Required = true,
+                    Schema = new OpenApiSchema
+                    {
+                        Type = "string"
+                    }
+                },
+            },
+            RequestBody = new OpenApiRequestBody
+            {
+                Description = "Pet to update with",
+                Required = true,
+                Content =
+                {
+                    ["application/json"] = new OpenApiMediaType
+                    {
+                        Schema = new OpenApiSchema
+                        {
+                            Type = "object"
+                        }
+                    }
+                }
+            },
+            Responses = new OpenApiResponses
+            {
+                ["200"] = new OpenApiResponse
+                {
+                    Description = "Pet updated."
+                },
+                ["405"] = new OpenApiResponse
+                {
+                    Description = "Invalid input"
+                }
+            },
+        };
+
+        [Fact]
+        public void ParseBasicOperationShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "basicOperation.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var operation = OpenApiV2Deserializer.LoadOperation(node);
+
+            // Assert
+            operation.ShouldBeEquivalentTo(_basicOperation);
+        }
+
+        [Fact]
+        public void ParseBasicOperationTwiceShouldYieldSameObject()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = new MemoryStream(
+                Encoding.Default.GetBytes(_basicOperation.SerializeAsYaml(OpenApiSpecVersion.OpenApi2_0))))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var operation = OpenApiV2Deserializer.LoadOperation(node);
+
+            // Assert
+            operation.ShouldBeEquivalentTo(_basicOperation);
+        }
+
+        [Fact]
+        public void ParseOperationWithFormDataShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "operationWithFormData.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var operation = OpenApiV2Deserializer.LoadOperation(node);
+
+            // Assert
+            operation.ShouldBeEquivalentTo(_operationWithFormData);
+        }
+
+        [Fact]
+        public void ParseOperationWithFormDataTwiceShouldYieldSameObject()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = new MemoryStream(
+                Encoding.Default.GetBytes(_operationWithFormData.SerializeAsYaml(OpenApiSpecVersion.OpenApi2_0))))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var operation = OpenApiV2Deserializer.LoadOperation(node);
+
+            // Assert
+            operation.ShouldBeEquivalentTo(_operationWithFormData);
+        }
+
+        [Fact]
+        public void ParseOperationWithBodyShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "operationWithBody.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var operation = OpenApiV2Deserializer.LoadOperation(node);
+
+            // Assert
+            operation.ShouldBeEquivalentTo(_operationWithBody);
+        }
+
+        [Fact]
+        public void ParseOperationWithBodyTwiceShouldYieldSameObject()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = new MemoryStream(
+                Encoding.Default.GetBytes(_operationWithBody.SerializeAsYaml(OpenApiSpecVersion.OpenApi2_0))))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var operation = OpenApiV2Deserializer.LoadOperation(node);
+
+            // Assert
+            operation.ShouldBeEquivalentTo(_operationWithBody);
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/basicOperation.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/basicOperation.yaml
@@ -1,0 +1,16 @@
+﻿# Modified from https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#operation-object-example
+summary: Updates a pet in the store
+description: ""
+operationId: updatePet
+produces:
+- application/json
+- application/xml
+parameters:
+- name: petId
+  in: path
+  description: ID of pet that needs to be updated
+  required: true
+  type: string
+responses:
+  '200':
+    description: Pet updated.

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/operationWithBody.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/operationWithBody.yaml
@@ -1,0 +1,26 @@
+﻿# Modified from https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#operation-object-example
+summary: Updates a pet in the store with request body
+description: ""
+operationId: updatePetWithBody
+consumes:
+- application/json
+produces:
+- application/json
+- application/xml
+parameters:
+- name: petId
+  in: path
+  description: ID of pet that needs to be updated
+  required: true
+  type: string
+- name: petObject
+  in: body
+  description: Pet to update with
+  required: true
+  schema: 
+    type: object
+responses:
+  '200':
+    description: Pet updated.
+  '405':
+    description: Invalid input

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/operationWithFormData.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/operationWithFormData.yaml
@@ -1,0 +1,31 @@
+﻿# Modified from https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#operation-object-example
+summary: Updates a pet in the store with form data
+description: ""
+operationId: updatePetWithForm
+consumes:
+- application/x-www-form-urlencoded
+- multipart/form-data
+produces:
+- application/json
+- application/xml
+parameters:
+- name: petId
+  in: path
+  description: ID of pet that needs to be updated
+  required: true
+  type: string
+- name: name
+  in: formData
+  description: Updated name of the pet
+  required: true
+  type: string
+- name: status
+  in: formData
+  description: Updated status of the pet
+  required: false
+  type: string
+responses:
+  '200':
+    description: Pet updated.
+  '405':
+    description: Invalid input

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
@@ -1726,8 +1726,7 @@ namespace Microsoft.OpenApi.Tests.Models
             // Arrange
             var outputStringWriter = new StringWriter();
             var writer = new OpenApiJsonWriter(outputStringWriter);
-            var expected =
-                @"{
+            var expected = @"{
   ""swagger"": ""2.0"",
   ""info"": {
     ""title"": ""Swagger Petstore (Simple)"",
@@ -1761,8 +1760,8 @@ namespace Microsoft.OpenApi.Tests.Models
         ],
         ""parameters"": [
           {
-            ""name"": ""tags"",
             ""in"": ""query"",
+            ""name"": ""tags"",
             ""description"": ""tags to filter by"",
             ""type"": ""array"",
             ""items"": {
@@ -1770,8 +1769,8 @@ namespace Microsoft.OpenApi.Tests.Models
             }
           },
           {
-            ""name"": ""limit"",
             ""in"": ""query"",
+            ""name"": ""limit"",
             ""description"": ""maximum number of results to return"",
             ""type"": ""integer"",
             ""format"": ""int32""
@@ -1855,9 +1854,10 @@ namespace Microsoft.OpenApi.Tests.Models
         ],
         ""parameters"": [
           {
-            ""name"": ""body"",
             ""in"": ""body"",
+            ""name"": ""body"",
             ""description"": ""Pet to add to the store"",
+            ""required"": true,
             ""schema"": {
               ""required"": [
                 ""name""
@@ -1953,8 +1953,8 @@ namespace Microsoft.OpenApi.Tests.Models
         ],
         ""parameters"": [
           {
-            ""name"": ""id"",
             ""in"": ""path"",
+            ""name"": ""id"",
             ""description"": ""ID of pet to fetch"",
             ""required"": true,
             ""type"": ""integer"",
@@ -2032,8 +2032,8 @@ namespace Microsoft.OpenApi.Tests.Models
         ],
         ""parameters"": [
           {
-            ""name"": ""id"",
             ""in"": ""path"",
+            ""name"": ""id"",
             ""description"": ""ID of pet to delete"",
             ""required"": true,
             ""type"": ""integer"",
@@ -2147,7 +2147,7 @@ namespace Microsoft.OpenApi.Tests.Models
             AdvancedDocument.SerializeAsV2(writer);
             writer.Flush();
             var actual = outputStringWriter.GetStringBuilder().ToString();
-
+            
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
@@ -2195,8 +2195,8 @@ namespace Microsoft.OpenApi.Tests.Models
         ],
         ""parameters"": [
           {
-            ""name"": ""tags"",
             ""in"": ""query"",
+            ""name"": ""tags"",
             ""description"": ""tags to filter by"",
             ""type"": ""array"",
             ""items"": {
@@ -2204,8 +2204,8 @@ namespace Microsoft.OpenApi.Tests.Models
             }
           },
           {
-            ""name"": ""limit"",
             ""in"": ""query"",
+            ""name"": ""limit"",
             ""description"": ""maximum number of results to return"",
             ""type"": ""integer"",
             ""format"": ""int32""
@@ -2247,9 +2247,10 @@ namespace Microsoft.OpenApi.Tests.Models
         ],
         ""parameters"": [
           {
-            ""name"": ""body"",
             ""in"": ""body"",
+            ""name"": ""body"",
             ""description"": ""Pet to add to the store"",
+            ""required"": true,
             ""schema"": {
               ""$ref"": ""#/definitions/newPet""
             }
@@ -2288,8 +2289,8 @@ namespace Microsoft.OpenApi.Tests.Models
         ],
         ""parameters"": [
           {
-            ""name"": ""id"",
             ""in"": ""path"",
+            ""name"": ""id"",
             ""description"": ""ID of pet to fetch"",
             ""required"": true,
             ""type"": ""integer"",
@@ -2325,8 +2326,8 @@ namespace Microsoft.OpenApi.Tests.Models
         ],
         ""parameters"": [
           {
-            ""name"": ""id"",
             ""in"": ""path"",
+            ""name"": ""id"",
             ""description"": ""ID of pet to delete"",
             ""required"": true,
             ""type"": ""integer"",
@@ -2414,7 +2415,7 @@ namespace Microsoft.OpenApi.Tests.Models
             AdvancedDocumentWithReference.SerializeAsV2(writer);
             writer.Flush();
             var actual = outputStringWriter.GetStringBuilder().ToString();
-
+            
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiOperationTests.cs
@@ -14,9 +14,9 @@ namespace Microsoft.OpenApi.Tests.Models
     [Collection("DefaultSettings")]
     public class OpenApiOperationTests
     {
-        public static OpenApiOperation BasicOperation = new OpenApiOperation();
+        private static readonly OpenApiOperation _basicOperation = new OpenApiOperation();
 
-        public static OpenApiOperation AdvancedOperation = new OpenApiOperation
+        private static readonly OpenApiOperation _operationWithBody = new OpenApiOperation
         {
             Summary = "summary1",
             Description = "operationDescription",
@@ -92,7 +92,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static OpenApiOperation AdvancedOperationWithTagsAndSecurity = new OpenApiOperation
+        private static readonly OpenApiOperation _advancedOperationWithTagsAndSecurity = new OpenApiOperation
         {
             Tags = new List<OpenApiTag>
             {
@@ -210,6 +210,91 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
+        private static readonly OpenApiOperation _operationWithFormData =
+            new OpenApiOperation()
+            {
+                Summary = "Updates a pet in the store with form data",
+                Description = "",
+                OperationId = "updatePetWithForm",
+                Parameters = new List<OpenApiParameter>()
+                {
+                    new OpenApiParameter()
+                    {
+                        Name = "petId",
+                        In = ParameterLocation.Path,
+                        Description = "ID of pet that needs to be updated",
+                        Required = true,
+                        Schema = new OpenApiSchema()
+                        {
+                            Type = "string"
+                        }
+                    }
+                },
+                RequestBody = new OpenApiRequestBody()
+                {
+                    Content =
+                    {
+                        ["application/x-www-form-urlencoded"] = new OpenApiMediaType()
+                        {
+                            Schema = new OpenApiSchema()
+                            {
+                                Properties =
+                                {
+                                    ["name"] = new OpenApiSchema()
+                                    {
+                                        Description = "Updated name of the pet",
+                                        Type = "string"
+                                    },
+                                    ["status"] = new OpenApiSchema()
+                                    {
+                                        Description = "Updated status of the pet",
+                                        Type = "string"
+                                    }
+                                },
+                                Required = new List<string>()
+                                {
+                                    "name"
+                                }
+                            }
+                        },
+                        ["multipart/form-data"] = new OpenApiMediaType()
+                        {
+                            Schema = new OpenApiSchema()
+                            {
+                                Properties =
+                                {
+                                    ["name"] = new OpenApiSchema()
+                                    {
+                                        Description = "Updated name of the pet",
+                                        Type = "string"
+                                    },
+                                    ["status"] = new OpenApiSchema()
+                                    {
+                                        Description = "Updated status of the pet",
+                                        Type = "string"
+                                    }
+                                },
+                                Required = new List<string>()
+                                {
+                                    "name"
+                                }
+                            }
+                        }
+                    }
+                },
+                Responses = new OpenApiResponses()
+                {
+                    ["200"] = new OpenApiResponse()
+                    {
+                        Description = "Pet updated."
+                    },
+                    ["405"] = new OpenApiResponse()
+                    {
+                        Description = "Invalid input"
+                    }
+                }
+            };
+
         private readonly ITestOutputHelper _output;
 
         public OpenApiOperationTests(ITestOutputHelper output)
@@ -226,7 +311,7 @@ namespace Microsoft.OpenApi.Tests.Models
 }";
 
             // Act
-            var actual = BasicOperation.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+            var actual = _basicOperation.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
@@ -235,7 +320,7 @@ namespace Microsoft.OpenApi.Tests.Models
         }
 
         [Fact]
-        public void SerializeAdvancedOperationAsV3JsonWorks()
+        public void SerializeOperationWithBodyAsV3JsonWorks()
         {
             // Arrange
             var expected = @"{
@@ -294,7 +379,7 @@ namespace Microsoft.OpenApi.Tests.Models
 }";
 
             // Act
-            var actual = AdvancedOperation.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+            var actual = _operationWithBody.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
@@ -375,7 +460,7 @@ namespace Microsoft.OpenApi.Tests.Models
 }";
 
             // Act
-            var actual = AdvancedOperationWithTagsAndSecurity.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+            var actual = _advancedOperationWithTagsAndSecurity.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
@@ -392,7 +477,7 @@ namespace Microsoft.OpenApi.Tests.Models
 }";
 
             // Act
-            var actual = BasicOperation.SerializeAsJson(OpenApiSpecVersion.OpenApi2_0);
+            var actual = _basicOperation.SerializeAsJson(OpenApiSpecVersion.OpenApi2_0);
 
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
@@ -401,7 +486,136 @@ namespace Microsoft.OpenApi.Tests.Models
         }
 
         [Fact]
-        public void SerializeAdvancedOperationAsV2JsonWorks()
+        public void SerializeOperationWithFormDataAsV3JsonWorks()
+        {
+            // Arrange
+            var expected = @"{
+  ""summary"": ""Updates a pet in the store with form data"",
+  ""description"": """",
+  ""operationId"": ""updatePetWithForm"",
+  ""parameters"": [
+    {
+      ""name"": ""petId"",
+      ""in"": ""path"",
+      ""description"": ""ID of pet that needs to be updated"",
+      ""required"": true,
+      ""schema"": {
+        ""type"": ""string""
+      }
+    }
+  ],
+  ""requestBody"": {
+    ""content"": {
+      ""application/x-www-form-urlencoded"": {
+        ""schema"": {
+          ""required"": [
+            ""name""
+          ],
+          ""properties"": {
+            ""name"": {
+              ""type"": ""string"",
+              ""description"": ""Updated name of the pet""
+            },
+            ""status"": {
+              ""type"": ""string"",
+              ""description"": ""Updated status of the pet""
+            }
+          }
+        }
+      },
+      ""multipart/form-data"": {
+        ""schema"": {
+          ""required"": [
+            ""name""
+          ],
+          ""properties"": {
+            ""name"": {
+              ""type"": ""string"",
+              ""description"": ""Updated name of the pet""
+            },
+            ""status"": {
+              ""type"": ""string"",
+              ""description"": ""Updated status of the pet""
+            }
+          }
+        }
+      }
+    }
+  },
+  ""responses"": {
+    ""200"": {
+      ""description"": ""Pet updated.""
+    },
+    ""405"": {
+      ""description"": ""Invalid input""
+    }
+  }
+}";
+
+            // Act
+            var actual = _operationWithFormData.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+            
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeOperationWithFormDataAsV2JsonWorks()
+        {
+            // Arrange
+            var expected = @"{
+  ""summary"": ""Updates a pet in the store with form data"",
+  ""description"": """",
+  ""operationId"": ""updatePetWithForm"",
+  ""consumes"": [
+    ""application/x-www-form-urlencoded"",
+    ""multipart/form-data""
+  ],
+  ""parameters"": [
+    {
+      ""in"": ""path"",
+      ""name"": ""petId"",
+      ""description"": ""ID of pet that needs to be updated"",
+      ""required"": true,
+      ""type"": ""string""
+    },
+    {
+      ""in"": ""formData"",
+      ""name"": ""name"",
+      ""description"": ""Updated name of the pet"",
+      ""required"": true,
+      ""type"": ""string""
+    },
+    {
+      ""in"": ""formData"",
+      ""name"": ""status"",
+      ""description"": ""Updated status of the pet"",
+      ""type"": ""string""
+    }
+  ],
+  ""responses"": {
+    ""200"": {
+      ""description"": ""Pet updated.""
+    },
+    ""405"": {
+      ""description"": ""Invalid input""
+    }
+  }
+}";
+
+            // Act
+            var actual = _operationWithFormData.SerializeAsJson(OpenApiSpecVersion.OpenApi2_0);
+            
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeOperationWithBodyAsV2JsonWorks()
         {
             // Arrange
             var expected = @"{
@@ -420,17 +634,18 @@ namespace Microsoft.OpenApi.Tests.Models
   ],
   ""parameters"": [
     {
-      ""name"": ""parameter1"",
-      ""in"": ""path""
+      ""in"": ""path"",
+      ""name"": ""parameter1""
     },
     {
-      ""name"": ""parameter2"",
-      ""in"": ""header""
+      ""in"": ""header"",
+      ""name"": ""parameter2""
     },
     {
-      ""name"": ""body"",
       ""in"": ""body"",
+      ""name"": ""body"",
       ""description"": ""description2"",
+      ""required"": true,
       ""schema"": {
         ""maximum"": 10,
         ""minimum"": 5,
@@ -456,8 +671,8 @@ namespace Microsoft.OpenApi.Tests.Models
 }";
 
             // Act
-            var actual = AdvancedOperation.SerializeAsJson(OpenApiSpecVersion.OpenApi2_0);
-
+            var actual = _operationWithBody.SerializeAsJson(OpenApiSpecVersion.OpenApi2_0);
+            
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
@@ -488,17 +703,18 @@ namespace Microsoft.OpenApi.Tests.Models
   ],
   ""parameters"": [
     {
-      ""name"": ""parameter1"",
-      ""in"": ""path""
+      ""in"": ""path"",
+      ""name"": ""parameter1""
     },
     {
-      ""name"": ""parameter2"",
-      ""in"": ""header""
+      ""in"": ""header"",
+      ""name"": ""parameter2""
     },
     {
-      ""name"": ""body"",
       ""in"": ""body"",
+      ""name"": ""body"",
       ""description"": ""description2"",
+      ""required"": true,
       ""schema"": {
         ""maximum"": 10,
         ""minimum"": 5,
@@ -533,7 +749,7 @@ namespace Microsoft.OpenApi.Tests.Models
 }";
 
             // Act
-            var actual = AdvancedOperationWithTagsAndSecurity.SerializeAsJson(OpenApiSpecVersion.OpenApi2_0);
+            var actual = _advancedOperationWithTagsAndSecurity.SerializeAsJson(OpenApiSpecVersion.OpenApi2_0);
 
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
@@ -189,8 +189,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var writer = new OpenApiJsonWriter(outputStringWriter);
             var expected =
                 @"{
-  ""name"": ""name1"",
-  ""in"": ""path""
+  ""in"": ""path"",
+  ""name"": ""name1""
 }";
 
             // Act


### PR DESCRIPTION
- Fix the serialization and deserialization logic for V2 formData and body parameter.

- V2 operation deserialization now respects the `consumes` property.

- Unit tests verify that serializing, deserializing, and re-deserializing all work as expected.

Fix #178 
Fix #179