### PR TITLE
Support all numeric IOpenApiAny types in OpenApiWriterBase

### DIFF
--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
@@ -111,6 +111,26 @@ namespace Microsoft.OpenApi.Writers
         /// </summary>
         /// <param name="value">The string value.</param>
         public abstract void WriteValue(string value);
+        
+        /// <summary>
+        /// Write float value.
+        /// </summary>
+        /// <param name="value">The float value.</param>
+        public virtual void WriteValue(float value)
+        {
+            WriteValueSeparator();
+            Writer.Write(value);
+        }
+
+        /// <summary>
+        /// Write double value.
+        /// </summary>
+        /// <param name="value">The double value.</param>
+        public virtual void WriteValue(double value)
+        {
+            WriteValueSeparator();
+            Writer.Write(value);
+        }
 
         /// <summary>
         /// Write decimal value.
@@ -127,6 +147,16 @@ namespace Microsoft.OpenApi.Writers
         /// </summary>
         /// <param name="value">The integer value.</param>
         public virtual void WriteValue(int value)
+        {
+            WriteValueSeparator();
+            Writer.Write(value);
+        }
+
+        /// <summary>
+        /// Write long value.
+        /// </summary>
+        /// <param name="value">The long value.</param>
+        public virtual void WriteValue(long value)
         {
             WriteValueSeparator();
             Writer.Write(value);

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
@@ -194,9 +194,21 @@ namespace Microsoft.OpenApi.Writers
             {
                 WriteValue((int)value);
             }
+            else if (type == typeof(long) || type == typeof(long?))
+            {
+                WriteValue((long)value);
+            }
             else if (type == typeof(bool) || type == typeof(bool?))
             {
                 WriteValue((bool)value);
+            }
+            else if (type == typeof(float) || type == typeof(float?))
+            {
+                WriteValue((float)value);
+            }
+            else if (type == typeof(double) || type == typeof(double?))
+            {
+                WriteValue((double)value);
             }
             else if (type == typeof(decimal) || type == typeof(decimal?))
             {

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterAnyExtensionsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterAnyExtensionsTests.cs
@@ -25,10 +25,10 @@ namespace Microsoft.OpenApi.Tests.Writers
         }
 
         [Theory]
-        [InlineData(-100)]
-        [InlineData(0)]
+        [InlineData(int.MinValue)]
         [InlineData(42)]
-        public void WriteOpenApiIntergerAsJsonWorks(int input)
+        [InlineData(int.MaxValue)]
+        public void WriteOpenApiIntegerAsJsonWorks(int input)
         {
             // Arrange
             var intValue = new OpenApiInteger(input);
@@ -40,8 +40,8 @@ namespace Microsoft.OpenApi.Tests.Writers
         }
 
         [Theory]
-        [InlineData(-100)]
-        [InlineData(0)]
+        [InlineData(long.MinValue)]
+        [InlineData(42)]
         [InlineData(long.MaxValue)]
         public void WriteOpenApiLongAsJsonWorks(long input)
         {
@@ -55,9 +55,9 @@ namespace Microsoft.OpenApi.Tests.Writers
         }
 
         [Theory]
-        [InlineData(-100.1)]
-        [InlineData(0.0)]
-        [InlineData(42.42)]
+        [InlineData(float.MinValue)]
+        [InlineData(42)]
+        [InlineData(float.MaxValue)]
         public void WriteOpenApiFloatAsJsonWorks(float input)
         {
             // Arrange
@@ -70,9 +70,9 @@ namespace Microsoft.OpenApi.Tests.Writers
         }
 
         [Theory]
-        [InlineData(-100.1)]
-        [InlineData(0.0)]
-        [InlineData(42.42)]
+        [InlineData(double.MinValue)]
+        [InlineData(42)]
+        [InlineData(double.MaxValue)]
         public void WriteOpenApiDoubleAsJsonWorks(double input)
         {
             // Arrange

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterAnyExtensionsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterAnyExtensionsTests.cs
@@ -40,6 +40,51 @@ namespace Microsoft.OpenApi.Tests.Writers
         }
 
         [Theory]
+        [InlineData(-100)]
+        [InlineData(0)]
+        [InlineData(long.MaxValue)]
+        public void WriteOpenApiLongAsJsonWorks(long input)
+        {
+            // Arrange
+            var longValue = new OpenApiLong(input);
+
+            var json = WriteAsJson(longValue);
+
+            // Assert
+            json.Should().Be(input.ToString());
+        }
+
+        [Theory]
+        [InlineData(-100.1)]
+        [InlineData(0.0)]
+        [InlineData(42.42)]
+        public void WriteOpenApiFloatAsJsonWorks(float input)
+        {
+            // Arrange
+            var floatValue = new OpenApiFloat(input);
+
+            var json = WriteAsJson(floatValue);
+
+            // Assert
+            json.Should().Be(input.ToString());
+        }
+
+        [Theory]
+        [InlineData(-100.1)]
+        [InlineData(0.0)]
+        [InlineData(42.42)]
+        public void WriteOpenApiDoubleAsJsonWorks(double input)
+        {
+            // Arrange
+            var doubleValue = new OpenApiDouble(input);
+
+            var json = WriteAsJson(doubleValue);
+
+            // Assert
+            json.Should().Be(input.ToString());
+        }
+
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public void WriteOpenApiBooleanAsJsonWorks(bool input)

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterAnyExtensionsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterAnyExtensionsTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.OpenApi.Tests.Writers
 
         [Theory]
         [InlineData(float.MinValue)]
-        [InlineData(42)]
+        [InlineData(42.42)]
         [InlineData(float.MaxValue)]
         public void WriteOpenApiFloatAsJsonWorks(float input)
         {
@@ -71,7 +71,7 @@ namespace Microsoft.OpenApi.Tests.Writers
 
         [Theory]
         [InlineData(double.MinValue)]
-        [InlineData(42)]
+        [InlineData(42.42)]
         [InlineData(double.MaxValue)]
         public void WriteOpenApiDoubleAsJsonWorks(double input)
         {


### PR DESCRIPTION
The purpose of this PR is make sure that OpenApiFloat, OpenApiDouble, and OpenApiLong are supported in the default serializers (which inherits from OpenApiWriterBase).

Fixes issue https://github.com/Microsoft/OpenAPI.NET/issues/199

Some questsions:

1. I first added tests for long, float and double. Float and double tests failed expectedly, but the long tests somehow passed, even though no overloads or cases for long had yet been added. I dug around but could not find the reason why this is happening. Is the runtime implicitly casting the longs as ints? The tests still pass using long.MaxValue, which should rule out that possibility. I still added an overload and a case for long, for consistency. Please comment.

2. Is the tests I wrote for double and float satisfactory? Do we need to take culture or formatting in account?