### PR TITLE
Do not mark require property as read only

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -375,7 +375,7 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         public void SerializeAsV2(IOpenApiWriter writer)
         {
-            SerializeAsV2(writer, new List<string>(), null);
+            SerializeAsV2(writer: writer, parentRequiredProperties: new List<string>(), propertyName: null);
         }
 
         /// <summary>
@@ -383,7 +383,10 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         public void SerializeAsV2WithoutReference(IOpenApiWriter writer)
         {
-            SerializeAsV2WithoutReference(writer, new List<string>(), null);
+            SerializeAsV2WithoutReference(
+                writer: writer,
+                parentRequiredProperties: new List<string>(),
+                propertyName: null);
         }
 
         /// <summary>
@@ -393,7 +396,9 @@ namespace Microsoft.OpenApi.Models
         /// <param name="writer">The open api writer.</param>
         /// <param name="parentRequiredProperties">The list of required properties in parent schema.</param>
         /// <param name="propertyName">The property name that will be serialized.</param>
-        internal void SerializeAsV2(IOpenApiWriter writer, IList<string> parentRequiredProperties,
+        internal void SerializeAsV2(
+            IOpenApiWriter writer,
+            IList<string> parentRequiredProperties,
             string propertyName)
         {
             if (writer == null)
@@ -422,7 +427,9 @@ namespace Microsoft.OpenApi.Models
         /// <param name="writer">The open api writer.</param>
         /// <param name="parentRequiredProperties">The list of required properties in parent schema.</param>
         /// <param name="propertyName">The property name that will be serialized.</param>
-        internal void SerializeAsV2WithoutReference(IOpenApiWriter writer, IList<string> parentRequiredProperties,
+        internal void SerializeAsV2WithoutReference(
+            IOpenApiWriter writer,
+            IList<string> parentRequiredProperties,
             string propertyName)
         {
             writer.WriteStartObject();
@@ -494,7 +501,9 @@ namespace Microsoft.OpenApi.Models
             writer.WriteExtensions(Extensions);
         }
 
-        internal void WriteAsSchemaProperties(IOpenApiWriter writer, IList<string> parentRequiredProperties,
+        internal void WriteAsSchemaProperties(
+            IOpenApiWriter writer,
+            IList<string> parentRequiredProperties,
             string propertyName)
         {
             if (writer == null)
@@ -582,14 +591,11 @@ namespace Microsoft.OpenApi.Models
             writer.WriteProperty(OpenApiConstants.Discriminator, Discriminator?.PropertyName);
 
             // readOnly
-            // In V2 schema if a property is part of required properties of schema, it cannot be marked as readonly.
-            if (parentRequiredProperties.Contains(propertyName))
+            // In V2 schema if a property is part of required properties of parent schema,
+            // it cannot be marked as readonly.
+            if (!parentRequiredProperties.Contains(propertyName))
             {
-                writer.WriteProperty(OpenApiConstants.ReadOnly, false, false);
-            }
-            else
-            {
-                writer.WriteProperty(OpenApiConstants.ReadOnly, ReadOnly, false);
+                writer.WriteProperty(name: OpenApiConstants.ReadOnly, value: ReadOnly, defaultValue: false);
             }
 
             // xml

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -387,14 +387,14 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
-        /// Serialize <see cref="OpenApiSchema"/> to Open Api v2.0 and pass on parent required properties and 
-        /// property name that should not be marked as read only if part of parent required property.
+        /// Serialize <see cref="OpenApiSchema"/> to Open Api v2.0 and handles not marking the provided property 
+        /// as readonly if its included in the provided list of required properties of parent schema.
         /// </summary>
         /// <param name="writer">The open api writer.</param>
         /// <param name="parentRequiredProperties">The list of required properties in parent schema.</param>
-        /// <param name="currentPropertyName">The property name that will be serialized.</param>
+        /// <param name="propertyName">The property name that will be serialized.</param>
         internal void SerializeAsV2(IOpenApiWriter writer, IList<string> parentRequiredProperties,
-            string currentPropertyName)
+            string propertyName)
         {
             if (writer == null)
             {
@@ -412,20 +412,21 @@ namespace Microsoft.OpenApi.Models
                 parentRequiredProperties = new List<string>();
             }
 
-            SerializeAsV2WithoutReference(writer, parentRequiredProperties, currentPropertyName);
+            SerializeAsV2WithoutReference(writer, parentRequiredProperties, propertyName);
         }
 
         /// <summary>
-        /// Serialize to OpenAPI V2 document without using reference.
+        /// Serialize to OpenAPI V2 document without using reference and handles not marking the provided property 
+        /// as readonly if its included in the provided list of required properties of parent schema.
         /// </summary>
         /// <param name="writer">The open api writer.</param>
         /// <param name="parentRequiredProperties">The list of required properties in parent schema.</param>
-        /// <param name="currentPropertyName">The property name that will be serialized.</param>
+        /// <param name="propertyName">The property name that will be serialized.</param>
         internal void SerializeAsV2WithoutReference(IOpenApiWriter writer, IList<string> parentRequiredProperties,
-            string currentPropertyName)
+            string propertyName)
         {
             writer.WriteStartObject();
-            WriteAsSchemaProperties(writer, parentRequiredProperties, currentPropertyName);
+            WriteAsSchemaProperties(writer, parentRequiredProperties, propertyName);
             writer.WriteEndObject();
         }
 

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -160,6 +160,60 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
+        public static OpenApiSchema AdvancedSchemaWithRequiredPropertiesObject = new OpenApiSchema
+        {
+            Title = "title1",
+            Required = new List<string>(){ "property1" },
+            Properties = new Dictionary<string, OpenApiSchema>
+            {
+                ["property1"] = new OpenApiSchema
+                {
+                    Required = new List<string>() { "property3" },
+                    Properties = new Dictionary<string, OpenApiSchema>
+                    {
+                        ["property2"] = new OpenApiSchema
+                        {
+                            Type = "integer"
+                        },
+                        ["property3"] = new OpenApiSchema
+                        {
+                            Type = "string",
+                            MaxLength = 15,
+                            ReadOnly = true
+                        }
+                    },
+                    ReadOnly = true,
+                },
+                ["property4"] = new OpenApiSchema
+                {
+                    Properties = new Dictionary<string, OpenApiSchema>
+                    {
+                        ["property5"] = new OpenApiSchema
+                        {
+                            Properties = new Dictionary<string, OpenApiSchema>
+                            {
+                                ["property6"] = new OpenApiSchema
+                                {
+                                    Type = "boolean"
+                                }
+                            }
+                        },
+                        ["property7"] = new OpenApiSchema
+                        {
+                            Type = "string",
+                            MinLength = 2
+                        }
+                    },
+                    ReadOnly = true,
+                },
+            },
+            Nullable = true,
+            ExternalDocs = new OpenApiExternalDocs
+            {
+                Url = new Uri("http://example.com/externalDocs")
+            }
+        };
+
         private readonly ITestOutputHelper _output;
 
         public OpenApiSchemaTests(ITestOutputHelper output)
@@ -355,6 +409,66 @@ namespace Microsoft.OpenApi.Tests.Models
 
             // Act
             ReferencedSchema.SerializeAsV3(writer);
+            writer.Flush();
+            var actual = outputStringWriter.GetStringBuilder().ToString();
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeSchemaWRequiredPropertiesAsV2JsonWorks()
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(outputStringWriter);
+            // Arrange
+            var expected = @"{
+  ""title"": ""title1"",
+  ""required"": [
+    ""property1""
+  ],
+  ""properties"": {
+    ""property1"": {
+      ""required"": [
+        ""property3""
+      ],
+      ""properties"": {
+        ""property2"": {
+          ""type"": ""integer""
+        },
+        ""property3"": {
+          ""maxLength"": 15,
+          ""type"": ""string""
+        }
+      }
+    },
+    ""property4"": {
+      ""properties"": {
+        ""property5"": {
+          ""properties"": {
+            ""property6"": {
+              ""type"": ""boolean""
+            }
+          }
+        },
+        ""property7"": {
+          ""minLength"": 2,
+          ""type"": ""string""
+        }
+      },
+      ""readOnly"": true
+    }
+  },
+  ""externalDocs"": {
+    ""url"": ""http://example.com/externalDocs""
+  }
+}";
+
+            // Act
+            AdvancedSchemaWithRequiredPropertiesObject.SerializeAsV2(writer);
             writer.Flush();
             var actual = outputStringWriter.GetStringBuilder().ToString();
 

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -424,7 +424,6 @@ namespace Microsoft.OpenApi.Tests.Models
             // Arrange
             var outputStringWriter = new StringWriter();
             var writer = new OpenApiJsonWriter(outputStringWriter);
-            // Arrange
             var expected = @"{
   ""title"": ""title1"",
   ""required"": [


### PR DESCRIPTION
V2 serialization code changes to not allow a child property of a schema to be readonly if its inlcuded in the list of required properties of parent schema, to comply with V2 spec.