### PR TITLE
fix a bug in OpenApiOperation

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
@@ -124,7 +124,7 @@ namespace Microsoft.OpenApi.Models
                 Tags,
                 (w, t) =>
                 {
-                    t.SerializeAsV2(w);
+                    t.SerializeAsV3(w);
                 });
 
             // summary
@@ -184,7 +184,7 @@ namespace Microsoft.OpenApi.Models
                 Tags,
                 (w, t) =>
                 {
-                    t.SerializeAsV3(w);
+                    t.SerializeAsV2(w);
                 });
 
             // summary


### PR DESCRIPTION
Fix a bug in OpenApiOperation. 

The sub function call should target the correct version. See detail in the changed files. 

Thanks.