### PR TITLE
Performance enhancements to validation and reference resolution

### DIFF
--- a/Microsoft.OpenApi.sln
+++ b/Microsoft.OpenApi.sln
@@ -23,7 +23,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E546B92F-20A
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{6357D7FD-2DE4-4900-ADB9-ABC37052040A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.OpenApi.SmokeTests", "test\Microsoft.OpenApi.SmokeTests\Microsoft.OpenApi.SmokeTests.csproj", "{AD79B61D-88CF-497C-9ED5-41AE3867C5AC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.OpenApi.SmokeTests", "test\Microsoft.OpenApi.SmokeTests\Microsoft.OpenApi.SmokeTests.csproj", "{AD79B61D-88CF-497C-9ED5-41AE3867C5AC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
@@ -47,7 +47,7 @@ namespace Microsoft.OpenApi.Readers
         /// <summary>
         /// Rules to use for validating OpenAPI specification.  If none are provided a default set of rules are applied.
         /// </summary>
-        public ValidationRuleSet RuleSet { get; set; }
+        public ValidationRuleSet RuleSet { get; set; } = ValidationRuleSet.GetDefaultRuleSet();
 
     }
 }

--- a/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
@@ -90,11 +90,14 @@ namespace Microsoft.OpenApi.Readers
             }
 
             // Validate the document
-            var errors = document.Validate(_settings.RuleSet);
-            foreach (var item in errors)
+            if (_settings.RuleSet != null && _settings.RuleSet.Rules.Count > 0)
             {
-                diagnostic.Errors.Add(item);
-            } 
+                var errors = document.Validate(_settings.RuleSet);
+                foreach (var item in errors)
+                {
+                    diagnostic.Errors.Add(item);
+                }
+            }
 
             return document;
         }

--- a/src/Microsoft.OpenApi.Readers/Services/OpenApiReferenceResolver.cs
+++ b/src/Microsoft.OpenApi.Readers/Services/OpenApiReferenceResolver.cs
@@ -177,8 +177,7 @@ namespace Microsoft.OpenApi.Readers.Services
 
             if (IsUnresolvedReference(entity))
             {
-                var x = ResolveReference<T>(entity.Reference);
-                assign(x);
+                assign(ResolveReference<T>(entity.Reference));
             }
         }
 

--- a/src/Microsoft.OpenApi.Readers/Services/OpenApiReferenceResolver.cs
+++ b/src/Microsoft.OpenApi.Readers/Services/OpenApiReferenceResolver.cs
@@ -106,7 +106,8 @@ namespace Microsoft.OpenApi.Readers.Services
         {
             foreach (var scheme in securityRequirement.Keys.ToList())
             {
-                ResolveObject(scheme, (resolvedScheme) => {
+                ResolveObject(scheme, (resolvedScheme) =>
+                {
                     // If scheme was unresolved
                     // copy Scopes and remove old unresolved scheme
                     var scopes = securityRequirement[scheme];
@@ -176,7 +177,8 @@ namespace Microsoft.OpenApi.Readers.Services
 
             if (IsUnresolvedReference(entity))
             {
-                assign(ResolveReference<T>(entity.Reference));
+                var x = ResolveReference<T>(entity.Reference);
+                assign(x);
             }
         }
 

--- a/src/Microsoft.OpenApi.Workbench/MainModel.cs
+++ b/src/Microsoft.OpenApi.Workbench/MainModel.cs
@@ -9,6 +9,7 @@ using System.Text;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers;
+using Microsoft.OpenApi.Services;
 using Microsoft.OpenApi.Validations;
 
 namespace Microsoft.OpenApi.Workbench
@@ -211,6 +212,12 @@ namespace Microsoft.OpenApi.Workbench
                 stopwatch.Stop();
 
                 RenderTime = $"{stopwatch.ElapsedMilliseconds} ms";
+
+                var statsVisitor = new StatsVisitor();
+                var walker = new OpenApiWalker(statsVisitor);
+                walker.Walk(document);
+
+                Errors += Environment.NewLine + "Statistics:" + Environment.NewLine + statsVisitor.GetStatisticsReport();    
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.OpenApi.Workbench/MainModel.cs
+++ b/src/Microsoft.OpenApi.Workbench/MainModel.cs
@@ -163,7 +163,7 @@ namespace Microsoft.OpenApi.Workbench
         /// The core method of the class.
         /// Runs the parsing and serializing.
         /// </summary>
-        internal void Validate()
+        internal void ParseDocument()
         {
             try
             {

--- a/src/Microsoft.OpenApi.Workbench/MainModel.cs
+++ b/src/Microsoft.OpenApi.Workbench/MainModel.cs
@@ -9,6 +9,7 @@ using System.Text;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers;
+using Microsoft.OpenApi.Validations;
 
 namespace Microsoft.OpenApi.Workbench
 {
@@ -18,6 +19,8 @@ namespace Microsoft.OpenApi.Workbench
     public class MainModel : INotifyPropertyChanged
     {
         private string _input;
+
+        private string _inputFile;
 
         private string _output;
 
@@ -44,6 +47,16 @@ namespace Microsoft.OpenApi.Workbench
             {
                 _input = value;
                 OnPropertyChanged(nameof(Input));
+            }
+        }
+
+        public string InputFile
+        {
+            get => _inputFile;
+            set
+            {
+                _inputFile = value;
+                OnPropertyChanged(nameof(InputFile));
             }
         }
 
@@ -153,12 +166,26 @@ namespace Microsoft.OpenApi.Workbench
         {
             try
             {
-                var stream = CreateStream(_input);
+                Stream stream;
+                if (!String.IsNullOrWhiteSpace(_inputFile))
+                {
+                    stream = new FileStream(_inputFile, FileMode.Open);
+                }
+                else
+                {
+                    stream = CreateStream(_input);
+                }
+                
 
                 var stopwatch = new Stopwatch();
                 stopwatch.Start();
 
-                var document = new OpenApiStreamReader().Read(stream, out var context);
+                var document = new OpenApiStreamReader(new OpenApiReaderSettings
+                    {
+                        ReferenceResolution = ReferenceResolutionSetting.ResolveLocalReferences,
+                        RuleSet = ValidationRuleSet.GetDefaultRuleSet()
+                    }
+                ).Read(stream, out var context);
                 stopwatch.Stop();
                 ParseTime = $"{stopwatch.ElapsedMilliseconds} ms";
 

--- a/src/Microsoft.OpenApi.Workbench/MainWindow.xaml
+++ b/src/Microsoft.OpenApi.Workbench/MainWindow.xaml
@@ -11,8 +11,24 @@
             <ColumnDefinition/>
             <ColumnDefinition />
         </Grid.ColumnDefinitions>
-        <TextBox x:Name="txtInput" Text="{Binding Input}" VerticalScrollBarVisibility="Auto" Margin="10" TextWrapping="Wrap" AcceptsReturn="True" FontFamily="Consolas" />
-        <DockPanel Grid.Column="1" Margin="0,10" >
+    <DockPanel Grid.Column="0"  >
+      <StackPanel DockPanel.Dock="Top">
+        <Label>Input File:</Label>
+        <TextBox x:Name="txtInputFile"
+               Text="{Binding InputFile}" 
+               Margin="10" 
+               TextWrapping="Wrap" AcceptsReturn="false" FontFamily="Consolas" />
+        <Label>Input Content:</Label>
+      </StackPanel>
+      <TextBox x:Name="txtInput" Text="{Binding Input}" 
+               VerticalScrollBarVisibility="Auto" 
+               Margin="10" 
+               TextWrapping="Wrap" 
+               AcceptsReturn="True" 
+               FontFamily="Consolas"
+               VerticalContentAlignment="Stretch" />
+    </DockPanel>
+    <DockPanel Grid.Column="1" Margin="0,10" >
             <StackPanel Orientation="Horizontal"  DockPanel.Dock="Top">
                 <Button Content="Convert" VerticalAlignment="Center" HorizontalAlignment="Left" Height="20" Margin="10" Width="131" Click="Button_Click" Grid.Column="1"/>
                 <StackPanel Orientation="Vertical"  DockPanel.Dock="Top">

--- a/src/Microsoft.OpenApi.Workbench/MainWindow.xaml.cs
+++ b/src/Microsoft.OpenApi.Workbench/MainWindow.xaml.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OpenApi.Workbench
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
-            _mainModel.Validate();
+            _mainModel.ParseDocument();
         }
     }
 }

--- a/src/Microsoft.OpenApi.Workbench/Microsoft.OpenApi.Workbench.csproj
+++ b/src/Microsoft.OpenApi.Workbench/Microsoft.OpenApi.Workbench.csproj
@@ -1,135 +1,136 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{6A5E91E5-0441-46EE-AEB9-8334981B7F08}</ProjectGuid>
-        <OutputType>WinExe</OutputType>
-        <RootNamespace>Microsoft.OpenApi.Workbench</RootNamespace>
-        <AssemblyName>Microsoft.OpenApi.Workbench</AssemblyName>
-        <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-        <FileAlignment>512</FileAlignment>
-        <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-        <WarningLevel>4</WarningLevel>
-        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-        <TargetFrameworkProfile />
-        <NuGetPackageImportStamp>
-        </NuGetPackageImportStamp>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="System" />
-        <Reference Include="System.Data" />
-        <Reference Include="System.Xml" />
-        <Reference Include="Microsoft.CSharp" />
-        <Reference Include="System.Core" />
-        <Reference Include="System.Xml.Linq" />
-        <Reference Include="System.Data.DataSetExtensions" />
-        <Reference Include="System.Net.Http" />
-        <Reference Include="System.Xaml">
-            <RequiredTargetFramework>4.0</RequiredTargetFramework>
-        </Reference>
-        <Reference Include="WindowsBase" />
-        <Reference Include="PresentationCore" />
-        <Reference Include="PresentationFramework" />
-        <PackageReference Include="Infragistics.Themes.MetroLight.Wpf" Version="1.0.0" />
-    </ItemGroup>
-    <ItemGroup>
-        <ApplicationDefinition Include="App.xaml">
-            <Generator>MSBuild:Compile</Generator>
-            <SubType>Designer</SubType>
-        </ApplicationDefinition>
-        <Page Include="MainWindow.xaml">
-            <Generator>MSBuild:Compile</Generator>
-            <SubType>Designer</SubType>
-        </Page>
-        <Compile Include="App.xaml.cs">
-            <DependentUpon>App.xaml</DependentUpon>
-            <SubType>Code</SubType>
-        </Compile>
-        <Compile Include="MainModel.cs" />
-        <Compile Include="MainWindow.xaml.cs">
-            <DependentUpon>MainWindow.xaml</DependentUpon>
-            <SubType>Code</SubType>
-        </Compile>
-        <Resource Include="Themes\Metro\Metro.MSControls.Core.Implicit.xaml">
-            <Generator>MSBuild:Compile</Generator>
-            <SubType>Designer</SubType>
-        </Resource>
-        <Resource Include="Themes\Metro\Metro.MSControls.Toolkit.Implicit.xaml">
-            <Generator>MSBuild:Compile</Generator>
-            <SubType>Designer</SubType>
-        </Resource>
-        <Resource Include="Themes\Metro\Styles.Shared.xaml">
-            <Generator>MSBuild:Compile</Generator>
-            <SubType>Designer</SubType>
-        </Resource>
-        <Resource Include="Themes\Metro\Styles.WPF.xaml">
-            <Generator>MSBuild:Compile</Generator>
-            <SubType>Designer</SubType>
-        </Resource>
-        <Resource Include="Themes\Metro\Theme.Colors.xaml">
-            <Generator>MSBuild:Compile</Generator>
-            <SubType>Designer</SubType>
-        </Resource>
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="Properties\AssemblyInfo.cs">
-            <SubType>Code</SubType>
-        </Compile>
-        <Compile Include="Properties\Resources.Designer.cs">
-            <AutoGen>True</AutoGen>
-            <DesignTime>True</DesignTime>
-            <DependentUpon>Resources.resx</DependentUpon>
-        </Compile>
-        <Compile Include="Properties\Settings.Designer.cs">
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Settings.settings</DependentUpon>
-            <DesignTimeSharedInput>True</DesignTimeSharedInput>
-        </Compile>
-        <EmbeddedResource Include="Properties\Resources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <None Include="Properties\Settings.settings">
-            <Generator>SettingsSingleFileGenerator</Generator>
-            <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-        </None>
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="App.config" />
-    </ItemGroup>
-    <ItemGroup>
-        <Resource Include="Themes\Metro\HowToApplyTheme.txt" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\Microsoft.OpenApi.Readers\Microsoft.OpenApi.Readers.csproj">
-            <Project>{79933258-0126-4382-8755-d50820ecc483}</Project>
-            <Name>Microsoft.OpenApi.Readers</Name>
-        </ProjectReference>
-        <ProjectReference Include="..\Microsoft.OpenApi\Microsoft.OpenApi.csproj">
-            <Project>{a8e50143-69b2-472a-9d45-3f9a05d13202}</Project>
-            <Name>Microsoft.OpenApi.Core</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6A5E91E5-0441-46EE-AEB9-8334981B7F08}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>Microsoft.OpenApi.Workbench</RootNamespace>
+    <AssemblyName>Microsoft.OpenApi.Workbench</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <WarningLevel>4</WarningLevel>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <PackageReference Include="Infragistics.Themes.MetroLight.Wpf" Version="1.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Compile Include="StatsVisitor.cs" />
+    <Page Include="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Compile Include="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="MainModel.cs" />
+    <Compile Include="MainWindow.xaml.cs">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Resource Include="Themes\Metro\Metro.MSControls.Core.Implicit.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Resource>
+    <Resource Include="Themes\Metro\Metro.MSControls.Toolkit.Implicit.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Resource>
+    <Resource Include="Themes\Metro\Styles.Shared.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Resource>
+    <Resource Include="Themes\Metro\Styles.WPF.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Resource>
+    <Resource Include="Themes\Metro\Theme.Colors.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Resource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Properties\Resources.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\Settings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+    </Compile>
+    <EmbeddedResource Include="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <None Include="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Resource Include="Themes\Metro\HowToApplyTheme.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.OpenApi.Readers\Microsoft.OpenApi.Readers.csproj">
+      <Project>{79933258-0126-4382-8755-d50820ecc483}</Project>
+      <Name>Microsoft.OpenApi.Readers</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Microsoft.OpenApi\Microsoft.OpenApi.csproj">
+      <Project>{a8e50143-69b2-472a-9d45-3f9a05d13202}</Project>
+      <Name>Microsoft.OpenApi.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Microsoft.OpenApi.Workbench/StatsVisitor.cs
+++ b/src/Microsoft.OpenApi.Workbench/StatsVisitor.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Services;
+
+namespace Microsoft.OpenApi.Workbench
+{
+    public class StatsVisitor : OpenApiVisitorBase
+    {
+        public int ParameterCount { get; set; } = 0;
+
+        public override void Visit(OpenApiParameter parameter)
+        {
+            ParameterCount++;
+        }
+
+        public int SchemaCount { get; set; } = 0;
+
+        public override void Visit(OpenApiSchema schema)
+        {
+            SchemaCount++;
+        }
+
+        public int HeaderCount { get; set; } = 0;
+
+        public override void Visit(IDictionary<string, OpenApiHeader> headers)
+        {
+            HeaderCount++;
+        }
+
+        public int PathItemCount { get; set; } = 0;
+
+        public override void Visit(OpenApiPathItem pathItem)
+        {
+            PathItemCount++;
+        }
+
+        public int RequestBodyCount { get; set; } = 0;
+
+        public override void Visit(OpenApiRequestBody requestBody)
+        {
+            RequestBodyCount++;
+        }
+
+        public int ResponseCount { get; set; } = 0;
+
+        public override void Visit(OpenApiResponses response)
+        {
+            ResponseCount++;
+        }
+
+        public int OperationCount { get; set; } = 0;
+
+        public override void Visit(OpenApiOperation operation)
+        {
+            OperationCount++;
+        }
+
+        public int LinkCount { get; set; } = 0;
+
+        public override void Visit(OpenApiLink operation)
+        {
+            LinkCount++;
+        }
+
+        public int CallbackCount { get; set; } = 0;
+
+        public override void Visit(OpenApiCallback callback)
+        {
+            CallbackCount++;
+        }
+
+        public string GetStatisticsReport()
+        {
+            return $"Path Items: {PathItemCount}" + Environment.NewLine
+                 + $"Operations: {OperationCount}" + Environment.NewLine
+                 + $"Parameters: {ParameterCount}" + Environment.NewLine
+                 + $"Request Bodies: {RequestBodyCount}" + Environment.NewLine
+                 + $"Responses: {ResponseCount}" + Environment.NewLine
+                 + $"Links: {LinkCount}" + Environment.NewLine
+                 + $"Callbacks: {CallbackCount}" + Environment.NewLine
+                 + $"Schemas: {SchemaCount}" + Environment.NewLine;
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.Workbench/StatsVisitor.cs
+++ b/src/Microsoft.OpenApi.Workbench/StatsVisitor.cs
@@ -8,7 +8,7 @@ using Microsoft.OpenApi.Services;
 
 namespace Microsoft.OpenApi.Workbench
 {
-    public class StatsVisitor : OpenApiVisitorBase
+    internal class StatsVisitor : OpenApiVisitorBase
     {
         public int ParameterCount { get; set; } = 0;
 

--- a/src/Microsoft.OpenApi.Workbench/StatsVisitor.cs
+++ b/src/Microsoft.OpenApi.Workbench/StatsVisitor.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Microsoft.OpenApi/Extensions/OpenApiElementExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiElementExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OpenApi.Extensions
         /// <param name="element">Element to validate</param>
         /// <param name="ruleSet">Optional set of rules to use for validation</param>
         /// <returns>An IEnumerable of errors.  This function will never return null.</returns>
-        public static IEnumerable<OpenApiError> Validate(this IOpenApiElement element, ValidationRuleSet ruleSet = null)
+        public static IEnumerable<OpenApiError> Validate(this IOpenApiElement element, ValidationRuleSet ruleSet)
         {
             var validator = new OpenApiValidator(ruleSet);
             var walker = new OpenApiWalker(validator);

--- a/src/Microsoft.OpenApi/Services/OpenApiVisitorBase.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiVisitorBase.cs
@@ -15,6 +15,7 @@ namespace Microsoft.OpenApi.Services
     public abstract class OpenApiVisitorBase
     {
         private readonly Stack<string> _path = new Stack<string>();
+        private bool _inComponents = false;
        
         /// <summary>
         /// Allow Rule to indicate validation error occured at a deeper context level.  
@@ -33,6 +34,16 @@ namespace Microsoft.OpenApi.Services
             this._path.Pop();
         }
 
+        public void EnterComponents()
+        {
+            _inComponents = true;
+        }
+
+        public void ExitComponents()
+        {
+            _inComponents = false;
+        }
+
         /// <summary>
         /// Pointer to source of validation error in document
         /// </summary>
@@ -44,7 +55,14 @@ namespace Microsoft.OpenApi.Services
             }
         }
 
-        
+        public bool InComponents
+        {
+            get
+            {
+                return _inComponents;
+            }
+        }
+
         /// <summary>
         /// Visits <see cref="OpenApiDocument"/>
         /// </summary>

--- a/src/Microsoft.OpenApi/Services/OpenApiVisitorBase.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiVisitorBase.cs
@@ -15,7 +15,6 @@ namespace Microsoft.OpenApi.Services
     public abstract class OpenApiVisitorBase
     {
         private readonly Stack<string> _path = new Stack<string>();
-        private bool _inComponents = false;
        
         /// <summary>
         /// Allow Rule to indicate validation error occured at a deeper context level.  
@@ -34,16 +33,6 @@ namespace Microsoft.OpenApi.Services
             this._path.Pop();
         }
 
-        public void EnterComponents()
-        {
-            _inComponents = true;
-        }
-
-        public void ExitComponents()
-        {
-            _inComponents = false;
-        }
-
         /// <summary>
         /// Pointer to source of validation error in document
         /// </summary>
@@ -55,13 +44,7 @@ namespace Microsoft.OpenApi.Services
             }
         }
 
-        public bool InComponents
-        {
-            get
-            {
-                return _inComponents;
-            }
-        }
+    
 
         /// <summary>
         /// Visits <see cref="OpenApiDocument"/>

--- a/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
@@ -18,6 +18,7 @@ namespace Microsoft.OpenApi.Services
         private readonly OpenApiVisitorBase _visitor;
         private readonly Stack<OpenApiSchema> _schemaLoop = new Stack<OpenApiSchema>();
         private readonly Stack<OpenApiPathItem> _pathItemLoop = new Stack<OpenApiPathItem>();
+        private bool _inComponents = false;
 
         /// <summary>
         /// Initializes the <see cref="OpenApiWalker"/> class.
@@ -37,6 +38,9 @@ namespace Microsoft.OpenApi.Services
             {
                 return;
             }
+            _schemaLoop.Clear();
+            _pathItemLoop.Clear();
+            _inComponents = false;
 
             _visitor.Visit(doc);
 
@@ -96,7 +100,7 @@ namespace Microsoft.OpenApi.Services
                 return;
             }
 
-            _visitor.EnterComponents();
+            EnterComponents();
 
             _visitor.Visit(components);
 
@@ -194,7 +198,7 @@ namespace Microsoft.OpenApi.Services
             });
 
             Walk(components as IOpenApiExtensible);
-            _visitor.ExitComponents();
+            ExitComponents();
         }
 
         /// <summary>
@@ -1027,7 +1031,17 @@ namespace Microsoft.OpenApi.Services
         /// </summary>
         private bool IsReference(IOpenApiReferenceable referenceable)
         {
-            return referenceable.Reference != null && !_visitor.InComponents;
+            return referenceable.Reference != null && !_inComponents;
+        }
+
+        private void EnterComponents()
+        {
+            _inComponents = true;
+        }
+
+        private void ExitComponents()
+        {
+            _inComponents = false;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
@@ -96,6 +96,8 @@ namespace Microsoft.OpenApi.Services
                 return;
             }
 
+            _visitor.EnterComponents();
+
             _visitor.Visit(components);
 
             if (components == null)
@@ -192,6 +194,7 @@ namespace Microsoft.OpenApi.Services
             });
 
             Walk(components as IOpenApiExtensible);
+            _visitor.ExitComponents();
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
@@ -346,7 +346,7 @@ namespace Microsoft.OpenApi.Services
         /// </summary>
         internal void Walk(OpenApiTag tag)
         {
-            if (tag == null)
+            if (tag == null || IsReference(tag))
             {
                 return;
             }
@@ -527,7 +527,7 @@ namespace Microsoft.OpenApi.Services
         /// </summary>
         internal void Walk(OpenApiParameter parameter)
         {
-            if (parameter == null)
+            if (parameter == null || IsReference(parameter))
             {
                 return;
             }
@@ -567,7 +567,7 @@ namespace Microsoft.OpenApi.Services
         /// </summary>
         internal void Walk(OpenApiResponse response)
         {
-            if (response == null)
+            if (response == null || IsReference(response))
             {
                 return;
             }
@@ -580,13 +580,12 @@ namespace Microsoft.OpenApi.Services
             Walk(response as IOpenApiExtensible);
         }
 
-
         /// <summary>
         /// Visits <see cref="OpenApiRequestBody"/> and child objects
         /// </summary>
         internal void Walk(OpenApiRequestBody requestBody)
         {
-            if (requestBody == null)
+            if (requestBody == null || IsReference(requestBody))
             {
                 return;
             }
@@ -668,7 +667,7 @@ namespace Microsoft.OpenApi.Services
         /// </summary>
         internal void Walk(OpenApiMediaType mediaType)
         {
-            if (mediaType == null)
+            if (mediaType == null) 
             {
                 return;
             }
@@ -721,7 +720,7 @@ namespace Microsoft.OpenApi.Services
         /// </summary>
         internal void Walk(OpenApiSchema schema)
         {
-            if (schema == null)
+            if (schema == null || IsReference(schema))
             {
                 return;
             }
@@ -806,7 +805,7 @@ namespace Microsoft.OpenApi.Services
         /// </summary>
         internal void Walk(OpenApiExample example)
         {
-            if (example == null)
+            if (example == null || IsReference(example))
             {
                 return;
             }
@@ -910,7 +909,7 @@ namespace Microsoft.OpenApi.Services
         /// </summary>
         internal void Walk(OpenApiLink link)
         {
-            if (link == null)
+            if (link == null || IsReference(link))
             {
                 return;
             }
@@ -925,7 +924,7 @@ namespace Microsoft.OpenApi.Services
         /// </summary>
         internal void Walk(OpenApiHeader header)
         {
-            if (header == null)
+            if (header == null || IsReference(header))
             {
                 return;
             }
@@ -957,7 +956,7 @@ namespace Microsoft.OpenApi.Services
         /// </summary>
         internal void Walk(OpenApiSecurityScheme securityScheme)
         {
-            if (securityScheme == null)
+            if (securityScheme == null || IsReference(securityScheme))
             {
                 return;
             }
@@ -1023,7 +1022,12 @@ namespace Microsoft.OpenApi.Services
             _visitor.Exit();
         }
 
-
-
+        /// <summary>
+        /// Identify if an element is just a reference to a component, or an actual component
+        /// </summary>
+        private bool IsReference(IOpenApiReferenceable referenceable)
+        {
+            return referenceable.Reference != null && !_visitor.InComponents;
+        }
     }
 }

--- a/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
@@ -38,6 +38,7 @@ namespace Microsoft.OpenApi.Services
             {
                 return;
             }
+
             _schemaLoop.Clear();
             _pathItemLoop.Clear();
             _inComponents = false;

--- a/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
+++ b/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
@@ -119,7 +119,6 @@ namespace Microsoft.OpenApi.Validations
         /// <param name="item">The object to be validated</param>
         public override void Visit(OpenApiSchema item) => Validate(item);
 
-
         /// <summary>
         /// Execute validation rules against an <see cref="OpenApiServer"/>
         /// </summary>
@@ -170,23 +169,14 @@ namespace Microsoft.OpenApi.Validations
         private void Validate(object item, Type type)
         {
             if (item == null) return;  // Required fields should be checked by higher level objects
-            var potentialReference = item as IOpenApiReferenceable;
 
-            if (potentialReference != null && potentialReference.Reference != null)
+            // Validate unresolved references as references
+            var potentialReference = item as IOpenApiReferenceable;
+            if (potentialReference != null && potentialReference.UnresolvedReference)
             {
-                if (potentialReference.UnresolvedReference)
-                {
-                    return; // Don't attempt to validate unresolved references
-                }
-                else
-                {
-                    if (potentialReference.Reference != null && !InComponents)
-                    {
-                        // Don't validate references if they are in not in Components to avoid validating on every reference
-                        return;
-                    }
-                }
+                type = typeof(IOpenApiReferenceable);  
             }
+
             var rules = _ruleSet.FindRules(type);
             foreach (var rule in rules)
             {

--- a/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
+++ b/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
@@ -168,7 +168,10 @@ namespace Microsoft.OpenApi.Validations
         /// </summary>
         private void Validate(object item, Type type)
         {
-            if (item == null) return;  // Required fields should be checked by higher level objects
+            if (item == null)
+            {
+                return;  // Required fields should be checked by higher level objects
+            }
 
             // Validate unresolved references as references
             var potentialReference = item as IOpenApiReferenceable;

--- a/src/Microsoft.OpenApi/Validations/ValidationRuleSet.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationRuleSet.cs
@@ -56,12 +56,16 @@ namespace Microsoft.OpenApi.Validations
             return new ValidationRuleSet(_defaultRuleSet);
         }
 
+        /// <summary>
+        /// Return Ruleset with no rules
+        /// </summary>
         public static ValidationRuleSet GetEmptyRuleSet()
         {
             // We create a new instance of ValidationRuleSet per call as a safeguard
             // against unintentional modification of the private _defaultRuleSet.
             return new ValidationRuleSet();
         }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidationRuleSet"/> class.
         /// </summary>

--- a/src/Microsoft.OpenApi/Validations/ValidationRuleSet.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationRuleSet.cs
@@ -21,6 +21,20 @@ namespace Microsoft.OpenApi.Validations
 
         private static ValidationRuleSet _defaultRuleSet;
 
+        private IList<ValidationRule> _emptyRules = new List<ValidationRule>();
+
+        /// <summary>
+        /// Retrieve the rules that are related to a specific type
+        /// </summary>
+        /// <param name="type">The type that is to be validated</param>
+        /// <returns>Either the rules related to the type, or an empty list.</returns>
+        public IList<ValidationRule> FindRules(Type type)
+        {
+            IList<ValidationRule> results = null;
+            _rules.TryGetValue(type, out results);
+            return results ?? _emptyRules;
+        }
+
         /// <summary>
         /// Gets the default validation rule sets.
         /// </summary>
@@ -42,6 +56,12 @@ namespace Microsoft.OpenApi.Validations
             return new ValidationRuleSet(_defaultRuleSet);
         }
 
+        public static ValidationRuleSet GetEmptyRuleSet()
+        {
+            // We create a new instance of ValidationRuleSet per call as a safeguard
+            // against unintentional modification of the private _defaultRuleSet.
+            return new ValidationRuleSet();
+        }
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidationRuleSet"/> class.
         /// </summary>

--- a/test/Microsoft.OpenApi.Tests/Services/OpenApiValidatorTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Services/OpenApiValidatorTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OpenApi.Tests.Services
                     }
                 });
 
-            var validator = new OpenApiValidator();
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
             var walker = new OpenApiWalker(validator);
             walker.Walk(openApiDocument);
 
@@ -83,7 +83,7 @@ namespace Microsoft.OpenApi.Tests.Services
                 }
             };
             
-            var validator = new OpenApiValidator();
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
             var walker = new OpenApiWalker(validator);
             walker.Walk(openApiDocument);
 

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiComponentsValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiComponentsValidationTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.OpenApi.Validations.Tests
                 }
             };
 
-            var errors = components.Validate();
+            var errors = components.Validate(ValidationRuleSet.GetDefaultRuleSet());
 
             // Act
             bool result = !errors.Any();

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiContactValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiContactValidationTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             };
 
             // Act
-            var errors = contact.Validate();
+            var errors = contact.Validate(ValidationRuleSet.GetDefaultRuleSet());
             bool result = !errors.Any();
 
             // Assert

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiExternalDocsValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiExternalDocsValidationTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             OpenApiExternalDocs externalDocs = new OpenApiExternalDocs();
 
             // Act
-            var errors = externalDocs.Validate();
+            var errors = externalDocs.Validate(ValidationRuleSet.GetDefaultRuleSet());
 
             // Assert
           

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiInfoValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiInfoValidationTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             OpenApiInfo info = new OpenApiInfo();
 
             // Act
-            var errors = info.Validate();
+            var errors = info.Validate(ValidationRuleSet.GetDefaultRuleSet());
 
             // Assert
             bool result = !errors.Any();

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiLicenseValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiLicenseValidationTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             OpenApiLicense license = new OpenApiLicense();
 
             // Act
-            var validator = new OpenApiValidator();
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
             var walker = new OpenApiWalker(validator);
             walker.Walk(license);
 

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiOAuthFlowValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiOAuthFlowValidationTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             OpenApiOAuthFlow oAuthFlow = new OpenApiOAuthFlow();
 
             // Act
-            var validator = new OpenApiValidator();
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
             var walker = new OpenApiWalker(validator);
             walker.Walk(oAuthFlow);
 

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiReferenceValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiReferenceValidationTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.OpenApi.Tests.Validations
         }
 
         [Fact]
-        public void UnResolvedReferencedSchemaShouldNotBeValidated()
+        public void UnresolvedReferenceSchemaShouldNotBeValidated()
         {
             // Arrange
             var sharedSchema = new OpenApiSchema
@@ -105,7 +105,7 @@ namespace Microsoft.OpenApi.Tests.Validations
         }
 
         [Fact]
-        public void UnResolvedSchemaReferencedShouldNotBeValidated()
+        public void UnresolvedSchemaReferencedShouldNotBeValidated()
         {
             // Arrange
 

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiReferenceValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiReferenceValidationTests.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Validations;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Validations
+{
+    public class OpenApiReferenceValidationTests
+    {
+        [Fact]
+        public void ReferencedSchemaShouldOnlyBeValidatedOnce()
+        {
+            // Arrange
+
+            var sharedSchema = new OpenApiSchema
+            {
+                Type = "string",
+                Reference = new OpenApiReference()
+                {
+                    Id = "test"
+                },
+                UnresolvedReference = false
+            };
+
+            OpenApiDocument document = new OpenApiDocument();
+            document.Components = new OpenApiComponents()
+            {
+                Schemas = new Dictionary<string, OpenApiSchema>()
+                {
+                    [sharedSchema.Reference.Id] = sharedSchema
+                }
+            };
+
+            document.Paths = new OpenApiPaths()
+            {
+                ["/"] = new OpenApiPathItem()
+                {
+                    Operations = new Dictionary<OperationType,OpenApiOperation>
+                    {
+                        [OperationType.Get] = new OpenApiOperation()
+                        {
+                            Responses = new OpenApiResponses()
+                            {
+                                ["200"] = new OpenApiResponse()
+                                {
+                                    Content = new Dictionary<string,OpenApiMediaType>()
+                                    {
+                                        ["application/json"] = new OpenApiMediaType()
+                                        {
+                                            Schema = sharedSchema
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Act
+            var errors = document.Validate(new ValidationRuleSet() { new AllwaysFailRule<OpenApiSchema>()});
+
+
+            // Assert
+            Assert.True(errors.Count() == 1);            
+        }
+        [Fact]
+        public void UnResolvedReferencedSchemaShouldNotBeValidated()
+        {
+            // Arrange
+            var sharedSchema = new OpenApiSchema
+            {
+                Type = "string",
+                Reference = new OpenApiReference()
+                {
+                    Id = "test"
+                },
+                UnresolvedReference = true
+            };
+
+            OpenApiDocument document = new OpenApiDocument();
+            document.Components = new OpenApiComponents()
+            {
+                Schemas = new Dictionary<string, OpenApiSchema>()
+                {
+                    [sharedSchema.Reference.Id] = sharedSchema
+                }
+            };
+
+            // Act
+            var errors = document.Validate(new ValidationRuleSet() { new AllwaysFailRule<OpenApiSchema>() });
+
+            // Assert
+            Assert.True(errors.Count() == 0);
+        }
+
+    }
+
+    public class AllwaysFailRule<P> : ValidationRule<P> where P: IOpenApiElement
+    {
+        public AllwaysFailRule() : base( (c,t) =>  c.CreateError("x","y"))
+        {
+            
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiResponseValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiResponseValidationTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             OpenApiResponse response = new OpenApiResponse();
 
             // Act
-            var validator = new OpenApiValidator();
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
             var walker = new OpenApiWalker(validator);
             walker.Walk(response);
 

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiServerValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiServerValidationTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             OpenApiServer server = new OpenApiServer();
 
             // Act
-            var validator = new OpenApiValidator();
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
             validator.Visit(server);
             errors = validator.Errors;
             bool result = !errors.Any();

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiTagValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiTagValidationTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             OpenApiTag tag = new OpenApiTag();
 
             // Act
-            var validator = new OpenApiValidator();
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
             validator.Visit(tag);
             errors = validator.Errors;
             bool result = !errors.Any();
@@ -47,7 +47,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             tag.Extensions.Add("tagExt", new OpenApiString("value"));
 
             // Act
-            var validator = new OpenApiValidator();
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
             validator.Visit(tag as IOpenApiExtensible);
             errors = validator.Errors;
             bool result = !errors.Any(); 


### PR DESCRIPTION
The primary problem resolved in this PR is the walker, which is used for both reference resolution and validation, was walking objects multiple times when they were $ref'd.  This has been resolved in the OpenApiWalker by adding a guard that does not walk the object if it has a non-null Reference and we are currently not walking through the Components section.

For the large 30MB, million line MS Graph OpenAPI, the time has gone from > 20mins, to ~ 10 secs on my Surface Pro 4.

I also added some statistics to the workbench to get an overview of the parsed file.  e.g. for the Graph API file it produces:

Path Items: 6783
Operations: 10609
Parameters: 23392
Request Bodies: 3815
Responses: 10609
Links: 132
Callbacks: 0
Schemas: 336995
  
Also updated Workbench to allow taking input from a file.

![image](https://user-images.githubusercontent.com/447694/39225601-59fecb02-481b-11e8-9bcb-30e9c5180d31.png)
