### PR TITLE
Fix header deserialization in V2 documents

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
@@ -166,10 +166,6 @@ namespace Microsoft.OpenApi.Readers.V2
                     return;
                 case "tsv":
                     throw new NotSupportedException();
-                case "multi":
-                    h.Style = ParameterStyle.Form;
-                    h.Explode = true;
-                    return;
             }
         }
     }

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
@@ -22,30 +24,6 @@ namespace Microsoft.OpenApi.Readers.V2
                 }
             },
             {
-                "required", (o, n) =>
-                {
-                    o.Required = bool.Parse(n.GetScalarValue());
-                }
-            },
-            {
-                "deprecated", (o, n) =>
-                {
-                    o.Deprecated = bool.Parse(n.GetScalarValue());
-                }
-            },
-            {
-                "allowReserved", (o, n) =>
-                {
-                    o.AllowReserved = bool.Parse(n.GetScalarValue());
-                }
-            },
-            {
-                "style", (o, n) =>
-                {
-                    o.Style = n.GetScalarValue().GetEnumFromDisplayName<ParameterStyle>();
-                }
-            },
-            {
                 "type", (o, n) =>
                 {
                     GetOrCreateSchema(o).Type = n.GetScalarValue();
@@ -57,6 +35,97 @@ namespace Microsoft.OpenApi.Readers.V2
                     GetOrCreateSchema(o).Format = n.GetScalarValue();
                 }
             },
+            {
+                "items", (o, n) =>
+                {
+                    GetOrCreateSchema(o).Items = LoadSchema(n);
+                }
+            },
+            {
+                "collectionFormat", (o, n) =>
+                {
+                    LoadStyle(o, n.GetScalarValue());
+                }
+            },
+            {
+                "default", (o, n) =>
+                {
+                    GetOrCreateSchema(o).Default = n.CreateAny();
+                }
+            },
+                        {
+                "maximum", (o, n) =>
+                {
+                    GetOrCreateSchema(o).Maximum = decimal.Parse(n.GetScalarValue());
+                }
+            },
+            {
+                "exclusiveMaximum", (o, n) =>
+                {
+                    GetOrCreateSchema(o).ExclusiveMaximum = bool.Parse(n.GetScalarValue());
+                }
+            },
+            {
+                "minimum", (o, n) =>
+                {
+                    GetOrCreateSchema(o).Minimum = decimal.Parse(n.GetScalarValue());
+                }
+            },
+            {
+                "exclusiveMinimum", (o, n) =>
+                {
+                    GetOrCreateSchema(o).ExclusiveMinimum = bool.Parse(n.GetScalarValue());
+                }
+            },
+            {
+                "maxLength", (o, n) =>
+                {
+                    GetOrCreateSchema(o).MaxLength = int.Parse(n.GetScalarValue());
+                }
+            },
+            {
+                "minLength", (o, n) =>
+                {
+                    GetOrCreateSchema(o).MinLength = int.Parse(n.GetScalarValue());
+                }
+            },
+            {
+                "pattern", (o, n) =>
+                {
+                    GetOrCreateSchema(o).Pattern = n.GetScalarValue();
+                }
+            },
+            {
+                "maxItems", (o, n) =>
+                {
+                    GetOrCreateSchema(o).MaxItems = int.Parse(n.GetScalarValue());
+                }
+            },
+            {
+                "minItems", (o, n) =>
+                {
+                    GetOrCreateSchema(o).MinItems = int.Parse(n.GetScalarValue());
+                }
+            },
+            {
+                "uniqueItems", (o, n) =>
+                {
+                    GetOrCreateSchema(o).UniqueItems = bool.Parse(n.GetScalarValue());
+                }
+            },
+            {
+                "multipleOf", (o, n) =>
+                {
+                    GetOrCreateSchema(o).MultipleOf = decimal.Parse(n.GetScalarValue());
+                }
+            },
+            {
+                "enum", (o, n) =>
+                {
+                    GetOrCreateSchema(o).Enum =
+                        n.CreateSimpleList<IOpenApiAny>(l => new OpenApiString(l.GetScalarValue()));
+                }
+            }
         };
 
         private static readonly PatternFieldMap<OpenApiHeader> _headerPatternFields = new PatternFieldMap<OpenApiHeader>
@@ -81,6 +150,29 @@ namespace Microsoft.OpenApi.Readers.V2
             }
 
             return header;
+        }
+
+
+        private static void LoadStyle(OpenApiHeader h, string v)
+        {
+            switch (v)
+            {
+                case "csv":
+                    h.Style = ParameterStyle.Simple;
+                    return;
+                case "ssv":
+                    h.Style = ParameterStyle.SpaceDelimited;
+                    return;
+                case "pipes":
+                    h.Style = ParameterStyle.PipeDelimited;
+                    return;
+                case "tsv":
+                    throw new NotSupportedException();
+                case "multi":
+                    h.Style = ParameterStyle.Form;
+                    h.Explode = true;
+                    return;
+            }
         }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.Exceptions;
 using Microsoft.OpenApi.Readers.ParseNodes;
 
 namespace Microsoft.OpenApi.Readers.V2
@@ -151,21 +152,23 @@ namespace Microsoft.OpenApi.Readers.V2
             return header;
         }
 
-        private static void LoadStyle(OpenApiHeader h, string v)
+        private static void LoadStyle(OpenApiHeader header, string style)
         {
-            switch (v)
+            switch (style)
             {
                 case "csv":
-                    h.Style = ParameterStyle.Simple;
+                    header.Style = ParameterStyle.Simple;
                     return;
                 case "ssv":
-                    h.Style = ParameterStyle.SpaceDelimited;
+                    header.Style = ParameterStyle.SpaceDelimited;
                     return;
                 case "pipes":
-                    h.Style = ParameterStyle.PipeDelimited;
+                    header.Style = ParameterStyle.PipeDelimited;
                     return;
                 case "tsv":
                     throw new NotSupportedException();
+                default:
+                    throw new OpenApiReaderException("Unrecognized header style: " + style);
             }
         }
     }

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
@@ -122,8 +122,7 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "enum", (o, n) =>
                 {
-                    GetOrCreateSchema(o).Enum =
-                        n.CreateSimpleList<IOpenApiAny>(l => new OpenApiString(l.GetScalarValue()));
+                    GetOrCreateSchema(o).Enum = n.CreateListOfAny();
                 }
             }
         };
@@ -151,7 +150,6 @@ namespace Microsoft.OpenApi.Readers.V2
 
             return header;
         }
-
 
         private static void LoadStyle(OpenApiHeader h, string v)
         {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
@@ -132,8 +132,7 @@ namespace Microsoft.OpenApi.Readers.V2
                 {
                     "enum", (o, n) =>
                     {
-                        GetOrCreateSchema(o).Enum =
-                            n.CreateSimpleList<IOpenApiAny>(l => new OpenApiString(l.GetScalarValue()));
+                        GetOrCreateSchema(o).Enum = n.CreateListOfAny();
                     }
                 },
                 {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
@@ -120,7 +120,7 @@ namespace Microsoft.OpenApi.Readers.V2
                 {
                     "default", (o, n) =>
                     {
-                        GetOrCreateSchema(o).Default = new OpenApiString(n.GetScalarValue());
+                        GetOrCreateSchema(o).Default = n.CreateAny();
                     }
                 },
                 {

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiParameterTests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using FluentAssertions;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
 using Microsoft.OpenApi.Readers.V2;
@@ -137,6 +138,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                     Description = "token to be passed as a header",
                     Required = true,
                     Style = ParameterStyle.Simple,
+                   
                     Schema = new OpenApiSchema
                     {
                         Type = "array",
@@ -144,6 +146,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                         {
                             Type = "integer",
                             Format = "int64"
+                        },
+                        Default = new OpenApiArray() {
+                            new OpenApiInteger(1),
+                            new OpenApiInteger(2)
                         }
                     }
                 });

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiParameterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
@@ -145,11 +146,24 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                         Items = new OpenApiSchema
                         {
                             Type = "integer",
-                            Format = "int64"
+                            Format = "int64",
+                            Enum = new List<IOpenApiAny>
+                            {
+                                new OpenApiInteger(1),
+                                new OpenApiInteger(2),
+                                new OpenApiInteger(3),
+                                new OpenApiInteger(4),
+                            }
                         },
                         Default = new OpenApiArray() {
                             new OpenApiInteger(1),
                             new OpenApiInteger(2)
+                        },
+                        Enum = new List<IOpenApiAny>
+                        {
+                            new OpenApiArray() { new OpenApiInteger(1), new OpenApiInteger(2) },
+                            new OpenApiArray() { new OpenApiInteger(2), new OpenApiInteger(3) },
+                            new OpenApiArray() { new OpenApiInteger(3), new OpenApiInteger(4) }
                         }
                     }
                 });

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/headerParameter.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/headerParameter.yaml
@@ -4,6 +4,7 @@ in: header
 description: token to be passed as a header
 required: true
 type: array
+default: [1,2]
 items:
   type: integer
   format: int64

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/headerParameter.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/headerParameter.yaml
@@ -8,4 +8,9 @@ default: [1,2]
 items:
   type: integer
   format: int64
+  enum: [1,2,3,4]
 collectionFormat: csv
+enum: 
+  - [1,2]
+  - [2,3]
+  - [3,4]


### PR DESCRIPTION
Several fields were not supported and some were supported that don't exist in V2.  I also re-ordered the parsing code to match the spec order.