### PR TITLE
Added parsing externalValue to Examples Object

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiExampleDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiExampleDeserializer.cs
@@ -33,6 +33,13 @@ namespace Microsoft.OpenApi.Readers.V3
                     o.Value = n.CreateAny();
                 }
             },
+            {
+                "externalValue", (o, n) =>
+                {
+                    o.ExternalValue = n.GetScalarValue();
+                }
+            },
+
         };
 
         private static readonly PatternFieldMap<OpenApiExample> _examplePatternFields =


### PR DESCRIPTION
Added missing property in Examples Object.  This is a quick fix for the Docs team.  In 1.1 we will add support for reading external files.