### PR TITLE
A variety of bug fixes for 1.1 preview

### DIFF
--- a/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiUnsupportedSpecVersionException.cs
+++ b/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiUnsupportedSpecVersionException.cs
@@ -12,7 +12,7 @@ namespace Microsoft.OpenApi.Readers.Exceptions
     [Serializable]
     public class OpenApiUnsupportedSpecVersionException : OpenApiReaderException
     {
-        const string messagePattern = "OpenAPI specification version {0} is not supported.";
+        const string messagePattern = "OpenAPI specification version '{0}' is not supported.";
 
         /// <summary>
         /// Initializes the <see cref="OpenApiUnsupportedSpecVersionException"/> class with a specification version.
@@ -21,11 +21,6 @@ namespace Microsoft.OpenApi.Readers.Exceptions
         public OpenApiUnsupportedSpecVersionException(string specificationVersion)
             : base(string.Format(CultureInfo.InvariantCulture, messagePattern, specificationVersion))
         {
-            if (string.IsNullOrWhiteSpace(specificationVersion))
-            {
-                throw new ArgumentException("Value cannot be null or white space.", nameof(specificationVersion));
-            }
-
             this.SpecificationVersion = specificationVersion;
         }
 
@@ -38,11 +33,6 @@ namespace Microsoft.OpenApi.Readers.Exceptions
         public OpenApiUnsupportedSpecVersionException(string specificationVersion, Exception innerException)
             : base(string.Format(CultureInfo.InvariantCulture, messagePattern, specificationVersion), innerException)
         {
-            if (string.IsNullOrWhiteSpace(specificationVersion))
-            {
-                throw new ArgumentException("Value cannot be null or white space.", nameof(specificationVersion));
-            }
-
             this.SpecificationVersion = specificationVersion;
         }
 

--- a/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+++ b/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi.Readers</Title>
         <PackageId>Microsoft.OpenApi.Readers</PackageId>
-        <Version>1.1.0-preview.1</Version>
+        <Version>1.1.0-preview.4</Version>
         <Description>OpenAPI.NET Readers for JSON and YAML documents</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+++ b/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi.Readers</Title>
         <PackageId>Microsoft.OpenApi.Readers</PackageId>
-        <Version>1.1.0-preview.4</Version>
+        <Version>1.1.0-preview.1</Version>
         <Description>OpenAPI.NET Readers for JSON and YAML documents</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
@@ -49,5 +49,9 @@ namespace Microsoft.OpenApi.Readers
         /// </summary>
         public ValidationRuleSet RuleSet { get; set; } = ValidationRuleSet.GetDefaultRuleSet();
 
+        /// <summary>
+        /// URL where relative references should be resolved from if the description does not contain Server definitions
+        /// </summary>
+        public Uri BaseUrl { get; internal set; } = new Uri("https://example.org/");
     }
 }

--- a/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
@@ -52,6 +52,6 @@ namespace Microsoft.OpenApi.Readers
         /// <summary>
         /// URL where relative references should be resolved from if the description does not contain Server definitions
         /// </summary>
-        public Uri BaseUrl { get; internal set; } = new Uri("https://example.org/");
+        public Uri BaseUrl { get; set; } = new Uri("https://example.org/");
     }
 }

--- a/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
@@ -52,6 +52,6 @@ namespace Microsoft.OpenApi.Readers
         /// <summary>
         /// URL where relative references should be resolved from if the description does not contain Server definitions
         /// </summary>
-        public Uri BaseUrl { get; set; } = new Uri("https://example.org/");
+        public Uri BaseUrl { get; set; } 
     }
 }

--- a/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
@@ -57,7 +57,8 @@ namespace Microsoft.OpenApi.Readers
 
             context = new ParsingContext
             {
-                ExtensionParsers = _settings.ExtensionParsers
+                ExtensionParsers = _settings.ExtensionParsers,
+                BaseUrl = _settings.BaseUrl
             };
 
             OpenApiDocument document = null;

--- a/src/Microsoft.OpenApi.Readers/ParsingContext.cs
+++ b/src/Microsoft.OpenApi.Readers/ParsingContext.cs
@@ -28,6 +28,7 @@ namespace Microsoft.OpenApi.Readers
         internal Dictionary<string, Func<IOpenApiAny, IOpenApiExtension>> ExtensionParsers { get; set; }  = new Dictionary<string, Func<IOpenApiAny, IOpenApiExtension>>();
         internal RootNode RootNode { get; set; }
         internal List<OpenApiTag> Tags { get; private set; } = new List<OpenApiTag>();
+        internal Uri BaseUrl { get; set; }
 
         /// <summary>
         /// Initiates the parsing process.  Not thread safe and should only be called once on a parsing context

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
@@ -136,15 +136,28 @@ namespace Microsoft.OpenApi.Readers.V2
             basePath = basePath ?? defaultUrl.GetComponents(UriComponents.Path, UriFormat.SafeUnescaped);
             schemes = schemes ?? new List<string> { defaultUrl.GetComponents(UriComponents.Scheme, UriFormat.SafeUnescaped) };
 
+            
             // Create the Server objects
             if (schemes != null)
             {
                 foreach (var scheme in schemes)
                 {
+                    var ub = new UriBuilder(scheme, host)
+                    {
+                        Path = basePath
+                    };
+
                     var server = new OpenApiServer
                     {
-                        Url = $"{scheme}://{host}{basePath}"
+                        Url = ub.ToString()
                     };
+
+                    // Server Urls are always appended to Paths and Paths must start with /
+                    // so removing the slash prevents a double slash.
+                    if (server.Url.EndsWith("/"))
+                    {
+                        server.Url = server.Url.Substring(0, server.Url.Length - 1);
+                    }
                     servers.Add(server);
                 }
             } 

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
@@ -137,7 +137,8 @@ namespace Microsoft.OpenApi.Readers.V2
                 host = host ?? defaultUrl.GetComponents(UriComponents.NormalizedHost, UriFormat.SafeUnescaped);
                 basePath = basePath ?? defaultUrl.GetComponents(UriComponents.Path, UriFormat.SafeUnescaped);
                 schemes = schemes ?? new List<string> { defaultUrl.GetComponents(UriComponents.Scheme, UriFormat.SafeUnescaped) };
-            } else if (String.IsNullOrEmpty(host) && String.IsNullOrEmpty(basePath))
+            }
+            else if (String.IsNullOrEmpty(host) && String.IsNullOrEmpty(basePath))
             {
                 return;  // Can't make a server object out of just a Scheme
             }
@@ -147,6 +148,11 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 foreach (var scheme in schemes)
                 {
+                    if (String.IsNullOrEmpty(scheme))
+                    {
+                        host = "//" + host;  // The double slash prefix creates a relative url where the scheme is defined by the BaseUrl
+                    }
+
                     var uriBuilder = new UriBuilder(scheme, host)
                     {
                         Path = basePath
@@ -164,7 +170,7 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 if (!String.IsNullOrEmpty(host))
                 {
-                    host = "//" + host;
+                    host = "//" + host;  // The double slash prefix creates a relative url where the scheme is defined by the BaseUrl
                 }
                 var uriBuilder = new UriBuilder()
                 {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiOperationDeserializer.cs
@@ -131,7 +131,12 @@ namespace Microsoft.OpenApi.Readers.V2
                     operation.RequestBody = CreateFormBody(node.Context, formParameters);
                 }
             }
-            
+
+            foreach (var response in operation.Responses.Values)
+            {
+                ProcessProduces(response, node.Context);
+            }
+
             return operation;
         }
 

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
@@ -53,15 +53,22 @@ namespace Microsoft.OpenApi.Readers.V2
             var produces = context.GetFromTempStorage<List<string>>(TempStorageKeys.OperationProduces) ??
                 context.GetFromTempStorage<List<string>>(TempStorageKeys.GlobalProduces) ?? new List<string>();
 
-            response.Content = new Dictionary<string, OpenApiMediaType>();
+            if (response.Content == null)
+            {
+                response.Content = new Dictionary<string, OpenApiMediaType>();
+            }
+
             foreach (var produce in produces)
             {
-                var mediaType = new OpenApiMediaType
+                if (!response.Content.ContainsKey(produce))
                 {
-                    Schema = context.GetFromTempStorage<OpenApiSchema>(TempStorageKeys.ResponseSchema)
-                };
+                    var mediaType = new OpenApiMediaType
+                    {
+                        Schema = context.GetFromTempStorage<OpenApiSchema>(TempStorageKeys.ResponseSchema)
+                    };
 
-                response.Content.Add(produce, mediaType);
+                    response.Content.Add(produce, mediaType);
+                }
             }
         }
 

--- a/src/Microsoft.OpenApi/Extensions/OpenApiSerializableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiSerializableExtensions.cs
@@ -115,6 +115,42 @@ namespace Microsoft.OpenApi.Extensions
         }
 
         /// <summary>
+        /// Serializes the <see cref="IOpenApiSerializable"/> to Open API document using the given specification version and writer.
+        /// </summary>
+        /// <typeparam name="T">the <see cref="IOpenApiSerializable"/></typeparam>
+        /// <param name="element">The Open API element.</param>
+        /// <param name="writer">The output writer.</param>
+        public static void Serialize<T>(this T element, IOpenApiWriter writer)
+            where T : IOpenApiSerializable
+        {
+            if (element == null)
+            {
+                throw Error.ArgumentNull(nameof(element));
+            }
+
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            switch (writer.Settings.SpecVersion)
+            {
+                case OpenApiSpecVersion.OpenApi3_0:
+                    element.SerializeAsV3(writer);
+                    break;
+
+                case OpenApiSpecVersion.OpenApi2_0:
+                    element.SerializeAsV2(writer);
+                    break;
+
+                default:
+                    throw new OpenApiException(string.Format(SRResource.OpenApiSpecVersionNotSupported, writer.Settings.SpecVersion));
+            }
+
+            writer.Flush();
+        }
+
+        /// <summary>
         /// Serializes the <see cref="IOpenApiSerializable"/> to the Open API document as a string in JSON format.
         /// </summary>
         /// <typeparam name="T">the <see cref="IOpenApiSerializable"/></typeparam>

--- a/src/Microsoft.OpenApi/Extensions/OpenApiSerializableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiSerializableExtensions.cs
@@ -123,31 +123,7 @@ namespace Microsoft.OpenApi.Extensions
         public static void Serialize<T>(this T element, IOpenApiWriter writer)
             where T : IOpenApiSerializable
         {
-            if (element == null)
-            {
-                throw Error.ArgumentNull(nameof(element));
-            }
-
-            if (writer == null)
-            {
-                throw Error.ArgumentNull(nameof(writer));
-            }
-
-            switch (writer.Settings.SpecVersion)
-            {
-                case OpenApiSpecVersion.OpenApi3_0:
-                    element.SerializeAsV3(writer);
-                    break;
-
-                case OpenApiSpecVersion.OpenApi2_0:
-                    element.SerializeAsV2(writer);
-                    break;
-
-                default:
-                    throw new OpenApiException(string.Format(SRResource.OpenApiSpecVersionNotSupported, writer.Settings.SpecVersion));
-            }
-
-            writer.Flush();
+            element.Serialize(writer, writer.Settings.SpecVersion);
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi</Title>
         <PackageId>Microsoft.OpenApi</PackageId>
-        <Version>1.1.0-preview.2</Version>
+        <Version>1.1.0-preview.1</Version>
         <Description>.NET models with JSON and YAML writers for OpenAPI specification</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi</Title>
         <PackageId>Microsoft.OpenApi</PackageId>
-        <Version>1.1.0-preview.1</Version>
+        <Version>1.1.0-preview.2</Version>
         <Description>.NET models with JSON and YAML writers for OpenAPI specification</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -240,7 +240,10 @@ namespace Microsoft.OpenApi.Models
                 firstServerUrl.GetComponents(UriComponents.Host | UriComponents.Port, UriFormat.SafeUnescaped));
 
             // basePath
-            writer.WriteProperty(OpenApiConstants.BasePath, firstServerUrl.AbsolutePath);
+            if (firstServerUrl.AbsolutePath != "/")
+            {
+                writer.WriteProperty(OpenApiConstants.BasePath, firstServerUrl.AbsolutePath);
+            }
 
             // Consider all schemes of the URLs in the server list that have the same
             // host, port, and base path as the first server.

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -29,7 +29,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// REQUIRED. The available paths and operations for the API.
         /// </summary>
-        public OpenApiPaths Paths { get; set; } = new OpenApiPaths();
+        public OpenApiPaths Paths { get; set; }
 
         /// <summary>
         /// An element to hold various schemas for the specification.

--- a/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
@@ -136,12 +136,20 @@ namespace Microsoft.OpenApi.Models
                         (w, s) => s.SerializeAsV2(w));
 
                     // examples
-                    if (mediatype.Value.Example != null)
+                    if (Content.Values.Any(m => m.Example != null))
                     {
                         writer.WritePropertyName(OpenApiConstants.Examples);
                         writer.WriteStartObject();
-                        writer.WritePropertyName(mediatype.Key);
-                        writer.WriteAny(mediatype.Value.Example);
+
+                        foreach (var mediaTypePair in Content)
+                        {
+                            if (mediaTypePair.Value.Example != null)
+                            {
+                                writer.WritePropertyName(mediaTypePair.Key);
+                                writer.WriteAny(mediaTypePair.Value.Example);
+                            }
+                        }
+
                         writer.WriteEndObject();
                     }
                 }

--- a/src/Microsoft.OpenApi/Writers/IOpenApiWriter.cs
+++ b/src/Microsoft.OpenApi/Writers/IOpenApiWriter.cs
@@ -9,6 +9,11 @@ namespace Microsoft.OpenApi.Writers
     public interface IOpenApiWriter
     {
         /// <summary>
+        /// Returns the settings being used the Writer for controlling serialization
+        /// </summary>
+        OpenApiSerializerSettings Settings { get; }
+
+        /// <summary>
         /// Write the start object.
         /// </summary>
         void WriteStartObject();

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
@@ -49,6 +49,11 @@ namespace Microsoft.OpenApi.Writers
         }
 
         /// <summary>
+        /// Returns the settings being used the Writer for controlling serialization
+        /// </summary>
+        public OpenApiSerializerSettings Settings { get; }
+
+        /// <summary>
         /// Base Indentation Level.
         /// This denotes how many indentations are needed for the property in the base object.
         /// </summary>

--- a/src/Microsoft.OpenApi/Writers/SpecialCharacterStringExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/SpecialCharacterStringExtensions.cs
@@ -196,6 +196,11 @@ namespace Microsoft.OpenApi.Writers
         /// </summary>
         internal static string GetJsonCompatibleString(this string value)
         {
+            if (value == null)
+            {
+                return "null";
+            }
+
             // Show the control characters as strings
             // http://json.org/
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiServerTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiServerTests.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.V2Tests
+{
+    public class OpenApiServerTests
+    {
+        [Fact]
+        public void NoServer()
+        {
+            var input = @"
+swagger: 2.0
+info: 
+  title: test
+  version: 1.0.0
+paths: {}
+";
+            var reader = new OpenApiStringReader(new OpenApiReaderSettings() {
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
+            Assert.Empty(doc.Servers);
+        }
+
+        [Fact]
+        public void JustScheme()
+        {
+            var input = @"
+swagger: 2.0
+info: 
+  title: test
+  version: 1.0.0
+schemes:
+  - http
+paths: {}
+";
+            var reader = new OpenApiStringReader(new OpenApiReaderSettings()
+            {
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
+            var server = doc.Servers.First();
+            Assert.Equal(1,doc.Servers.Count);
+            Assert.Equal("http://example.org", server.Url);
+        }
+
+        [Fact]
+        public void JustSchemeWithCustomHost()
+        {
+            var input = @"
+swagger: 2.0
+info: 
+  title: test
+  version: 1.0.0
+schemes:
+  - http
+paths: {}
+";
+            var reader = new OpenApiStringReader(new OpenApiReaderSettings()
+            {
+                BaseUrl = new Uri("https://bing.com/foo")
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
+            var server = doc.Servers.First();
+            Assert.Equal(1, doc.Servers.Count);
+            Assert.Equal("http://bing.com/foo", server.Url);
+        }
+
+        [Fact]
+        public void JustSchemeWithCustomHostWithEmptyPath()
+        {
+            var input = @"
+swagger: 2.0
+info: 
+  title: test
+  version: 1.0.0
+schemes:
+  - http
+paths: {}
+";
+            var reader = new OpenApiStringReader(new OpenApiReaderSettings()
+            {
+                BaseUrl = new Uri("https://bing.com")
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
+            var server = doc.Servers.First();
+            Assert.Equal(1, doc.Servers.Count);
+            Assert.Equal("http://bing.com", server.Url);
+        }
+
+        [Fact]
+        public void JustBasePathWithCustomHost()
+        {
+            var input = @"
+swagger: 2.0
+info: 
+  title: test
+  version: 1.0.0
+basePath: /api
+paths: {}
+";
+            var reader = new OpenApiStringReader(new OpenApiReaderSettings()
+            {
+                BaseUrl = new Uri("https://bing.com")
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
+            var server = doc.Servers.First();
+            Assert.Equal(1, doc.Servers.Count);
+            Assert.Equal("https://bing.com/api", server.Url);
+        }
+
+        [Fact]
+        public void JustHostWithCustomHost()
+        {
+            var input = @"
+swagger: 2.0
+info: 
+  title: test
+  version: 1.0.0
+host: www.example.com
+paths: {}
+";
+            var reader = new OpenApiStringReader(new OpenApiReaderSettings()
+            {
+                BaseUrl = new Uri("https://bing.com")
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
+            var server = doc.Servers.First();
+            Assert.Equal(1, doc.Servers.Count);
+            Assert.Equal("https://www.example.com", server.Url);
+        }
+
+        [Fact]
+        public void JustHostWithCustomHostWithApi()
+        {
+            var input = @"
+swagger: 2.0
+info: 
+  title: test
+  version: 1.0.0
+host: prod.bing.com
+paths: {}
+";
+            var reader = new OpenApiStringReader(new OpenApiReaderSettings()
+            {
+                BaseUrl = new Uri("https://dev.bing.com/api")
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
+            var server = doc.Servers.First();
+            Assert.Equal(1, doc.Servers.Count);
+            Assert.Equal("https://prod.bing.com/api", server.Url);
+        }
+
+        [Fact]
+        public void MultipleServers()
+        {
+            var input = @"
+swagger: 2.0
+info: 
+  title: test
+  version: 1.0.0
+schemes:
+  - http
+  - https
+paths: {}
+";
+            var reader = new OpenApiStringReader(new OpenApiReaderSettings()
+            {
+                BaseUrl = new Uri("https://dev.bing.com/api")
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
+            var server = doc.Servers.First();
+            Assert.Equal(2, doc.Servers.Count);
+            Assert.Equal("http://dev.bing.com/api", server.Url);
+            Assert.Equal("https://dev.bing.com/api", doc.Servers.Last().Url);
+        }
+
+    }
+}

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiServerTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiServerTests.cs
@@ -28,7 +28,7 @@ paths: {}
         }
 
         [Fact]
-        public void JustScheme()
+        public void JustSchemeNoDefault()
         {
             var input = @"
 swagger: 2.0
@@ -45,9 +45,51 @@ paths: {}
 
             var doc = reader.Read(input, out var diagnostic);
 
+            Assert.Equal(0, doc.Servers.Count);
+        }
+
+        [Fact]
+        public void JustHostNoDefault()
+        {
+            var input = @"
+swagger: 2.0
+info: 
+  title: test
+  version: 1.0.0
+host: www.foo.com
+paths: {}
+";
+            var reader = new OpenApiStringReader(new OpenApiReaderSettings()
+            {
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
             var server = doc.Servers.First();
-            Assert.Equal(1,doc.Servers.Count);
-            Assert.Equal("http://example.org", server.Url);
+            Assert.Equal(1, doc.Servers.Count);
+            Assert.Equal("//www.foo.com", server.Url);
+        }
+
+        [Fact]
+        public void JustBasePathNoDefault()
+        {
+            var input = @"
+swagger: 2.0
+info: 
+  title: test
+  version: 1.0.0
+basePath: /baz
+paths: {}
+";
+            var reader = new OpenApiStringReader(new OpenApiReaderSettings()
+            {
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
+            var server = doc.Servers.First();
+            Assert.Equal(1, doc.Servers.Count);
+            Assert.Equal("/baz", server.Url);
         }
 
         [Fact]

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -46,7 +46,8 @@ paths: {}",
                     {
                         Title = "Simple Document",
                         Version = "0.9.1"
-                    }
+                    },
+                    Paths = new OpenApiPaths()
                 });
 
             context.ShouldBeEquivalentTo(
@@ -83,7 +84,8 @@ paths: {}",
                                 Url = new Uri("https://www.example.org/api").ToString(),
                                 Description = "The https endpoint"
                             }
-                        }
+                        },
+                        Paths = new OpenApiPaths()
                     });
             }
         }
@@ -101,7 +103,8 @@ paths: {}",
                         Info = new OpenApiInfo
                         {
                             Version = "0.9"
-                        }
+                        },
+                        Paths = new OpenApiPaths()
                     });
 
                 diagnostic.ShouldBeEquivalentTo(
@@ -130,7 +133,8 @@ paths: {}",
                         {
                             Title = "Simple Document",
                             Version = "0.9.1"
-                        }
+                        },
+                        Paths = new OpenApiPaths()
                     });
 
                 diagnostic.ShouldBeEquivalentTo(

--- a/test/Microsoft.OpenApi.Tests/Services/OpenApiValidatorTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Services/OpenApiValidatorTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.OpenApi.Tests.Services
                 Title = "foo",
                 Version = "1.2.2"
             };
+            openApiDocument.Paths = new OpenApiPaths();
             openApiDocument.Paths.Add(
                 "/test",
                 new OpenApiPathItem
@@ -66,13 +67,14 @@ namespace Microsoft.OpenApi.Tests.Services
         [Fact]
         public void ServersShouldBeReferencedByIndex()
         {
-            var openApiDocument = new OpenApiDocument();
-            openApiDocument.Info = new OpenApiInfo()
+            var openApiDocument = new OpenApiDocument
             {
-                Title = "foo",
-                Version = "1.2.2"
-            };
-            openApiDocument.Servers = new List<OpenApiServer> {
+                Info = new OpenApiInfo()
+                {
+                    Title = "foo",
+                    Version = "1.2.2"
+                },
+                Servers = new List<OpenApiServer> {
                 new OpenApiServer
                 {
                     Url = "http://example.org"
@@ -80,9 +82,11 @@ namespace Microsoft.OpenApi.Tests.Services
                 new OpenApiServer
                 {
 
-                }
+                },
+            },
+                Paths = new OpenApiPaths()
             };
-            
+
             var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
             var walker = new OpenApiWalker(validator);
             walker.Walk(openApiDocument);
@@ -111,11 +115,14 @@ namespace Microsoft.OpenApi.Tests.Services
                      }
                  }));
 
-            var openApiDocument = new OpenApiDocument();
-            openApiDocument.Info = new OpenApiInfo()
+            var openApiDocument = new OpenApiDocument
             {
-                Title = "foo",
-                Version = "1.2.2"
+                Info = new OpenApiInfo()
+                {
+                    Title = "foo",
+                    Version = "1.2.2"
+                },
+                Paths = new OpenApiPaths()
             };
 
             var fooExtension = new FooExtension()

--- a/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
@@ -23,7 +23,6 @@ namespace Microsoft.OpenApi.Tests.Walkers
 
             locator.Locations.ShouldBeEquivalentTo(new List<string> {
                 "#/servers",
-                "#/paths",
                 "#/tags"
             });
         }
@@ -37,6 +36,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
                     new OpenApiServer(),
                     new OpenApiServer()
                 },
+                Paths = new OpenApiPaths(),
                 Tags = new List<OpenApiTag>()
                 {
                     new OpenApiTag()
@@ -61,6 +61,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
         public void LocatePathOperationContentSchema()
         {
             var doc = new OpenApiDocument();
+            doc.Paths = new OpenApiPaths();
             doc.Paths.Add("/test", new OpenApiPathItem()
             {
                 Operations = new Dictionary<OperationType, OpenApiOperation>()
@@ -124,6 +125,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
 
             var doc = new OpenApiDocument()
             {
+                Paths = new OpenApiPaths(),
                 Components = new OpenApiComponents()
                 {
                     Schemas = new Dictionary<string, OpenApiSchema>


### PR DESCRIPTION
- Merged fixes from 1.0 release into 1.1
- Added validation to 
- Made Paths null by default to fix error reporting
- Do not include default basePath in output. 
- Handle V2 import when produces comes after responses 
- Fix MakeServers for V2 
- Add settings parameter for BaseUrl
- Add support for null to GetJsonCompatibleString 
- Output multiple examples in V2 
- Exposed Settings in IOpenApiWriter interface to allow access to selected version when writing extensions. (Potentially a breaking change?)