### PR TITLE
Fixed exposing writer Settings object

### DIFF
--- a/src/Microsoft.OpenApi/Extensions/OpenApiSerializableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiSerializableExtensions.cs
@@ -74,7 +74,9 @@ namespace Microsoft.OpenApi.Extensions
                     throw new OpenApiException(string.Format(SRResource.OpenApiFormatNotSupported, format));
             }
 
-            element.Serialize(writer, specVersion);
+            writer.Settings.SpecVersion = specVersion;
+
+            element.Serialize(writer);
         }
 
         /// <summary>
@@ -87,31 +89,8 @@ namespace Microsoft.OpenApi.Extensions
         public static void Serialize<T>(this T element, IOpenApiWriter writer, OpenApiSpecVersion specVersion)
             where T : IOpenApiSerializable
         {
-            if (element == null)
-            {
-                throw Error.ArgumentNull(nameof(element));
-            }
-
-            if (writer == null)
-            {
-                throw Error.ArgumentNull(nameof(writer));
-            }
-
-            switch (specVersion)
-            {
-                case OpenApiSpecVersion.OpenApi3_0:
-                    element.SerializeAsV3(writer);
-                    break;
-
-                case OpenApiSpecVersion.OpenApi2_0:
-                    element.SerializeAsV2(writer);
-                    break;
-
-                default:
-                    throw new OpenApiException(string.Format(SRResource.OpenApiSpecVersionNotSupported, specVersion));
-            }
-
-            writer.Flush();
+            writer.Settings.SpecVersion = specVersion;
+            element.Serialize(writer);
         }
 
         /// <summary>
@@ -123,7 +102,31 @@ namespace Microsoft.OpenApi.Extensions
         public static void Serialize<T>(this T element, IOpenApiWriter writer)
             where T : IOpenApiSerializable
         {
-            element.Serialize(writer, writer.Settings.SpecVersion);
+            if (element == null)
+            {
+                throw Error.ArgumentNull(nameof(element));
+            }
+
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            switch (writer.Settings.SpecVersion)
+            {
+                case OpenApiSpecVersion.OpenApi3_0:
+                    element.SerializeAsV3(writer);
+                    break;
+
+                case OpenApiSpecVersion.OpenApi2_0:
+                    element.SerializeAsV2(writer);
+                    break;
+
+                default:
+                    throw new OpenApiException(string.Format(SRResource.OpenApiSpecVersionNotSupported, writer.Settings.SpecVersion));
+            }
+
+            writer.Flush();
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
@@ -51,7 +51,12 @@ namespace Microsoft.OpenApi.Writers
         /// <summary>
         /// Returns the settings being used the Writer for controlling serialization
         /// </summary>
-        public OpenApiSerializerSettings Settings { get; }
+        public OpenApiSerializerSettings Settings {
+            get
+            {
+                return _settings; 
+            }
+        }
 
         /// <summary>
         /// Base Indentation Level.

--- a/src/Microsoft.OpenApi/Writers/OpenApiYamlWriter.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiYamlWriter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OpenApi.Writers
         /// </summary>
         /// <param name="textWriter">The text writer.</param>
         public OpenApiYamlWriter(TextWriter textWriter)
-            : this(textWriter, new OpenApiSerializerSettings())
+            : this(textWriter, new OpenApiSerializerSettings() { Format = OpenApiFormat.Yaml })
         {
         }
 


### PR DESCRIPTION
I completely messed up exposing the Settings object in OpenApiWriterBase, so that's fixed.  And now all parameters passed to Serialize methods are copied into the settings object so that there is no discrepancy.  It is important that the Settings object hold the format and version so that when you serialize custom extensions, you can re-use existing model elements and they will be serialized in a consistent way.