### PR TITLE
Added ContextKeys object to VisitorBase

### DIFF
--- a/src/Microsoft.OpenApi/Services/OpenApiVisitorBase.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiVisitorBase.cs
@@ -15,20 +15,11 @@ namespace Microsoft.OpenApi.Services
     public abstract class OpenApiVisitorBase
     {
         private readonly Stack<string> _path = new Stack<string>();
-        private CurrentKeys _currentKeys = new CurrentKeys();
-
-
 
         /// <summary>
         /// Properties available to identify context of where an object is within OpenAPI Document
         /// </summary>
-        public CurrentKeys CurrentKeys
-        {
-            get
-            {
-                return _currentKeys;
-            }
-        }
+        public CurrentKeys CurrentKeys { get; } = new CurrentKeys();
 
         /// <summary>
         /// Allow Rule to indicate validation error occured at a deeper context level.  
@@ -57,17 +48,6 @@ namespace Microsoft.OpenApi.Services
                 return "#/" + String.Join("/", _path.Reverse());
             }
         }
-
-        internal void AttachCurrentKeys(CurrentKeys currentKeys)
-        {
-
-        }
-
-        internal void ClearCurrentKeys()
-        {
-
-        }
-    
 
         /// <summary>
         /// Visits <see cref="OpenApiDocument"/>

--- a/src/Microsoft.OpenApi/Services/OpenApiVisitorBase.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiVisitorBase.cs
@@ -15,7 +15,21 @@ namespace Microsoft.OpenApi.Services
     public abstract class OpenApiVisitorBase
     {
         private readonly Stack<string> _path = new Stack<string>();
-       
+        private CurrentKeys _currentKeys = new CurrentKeys();
+
+
+
+        /// <summary>
+        /// Properties available to identify context of where an object is within OpenAPI Document
+        /// </summary>
+        public CurrentKeys CurrentKeys
+        {
+            get
+            {
+                return _currentKeys;
+            }
+        }
+
         /// <summary>
         /// Allow Rule to indicate validation error occured at a deeper context level.  
         /// </summary>
@@ -44,6 +58,15 @@ namespace Microsoft.OpenApi.Services
             }
         }
 
+        internal void AttachCurrentKeys(CurrentKeys currentKeys)
+        {
+
+        }
+
+        internal void ClearCurrentKeys()
+        {
+
+        }
     
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
@@ -18,6 +18,8 @@ namespace Microsoft.OpenApi.Services
         private readonly OpenApiVisitorBase _visitor;
         private readonly Stack<OpenApiSchema> _schemaLoop = new Stack<OpenApiSchema>();
         private readonly Stack<OpenApiPathItem> _pathItemLoop = new Stack<OpenApiPathItem>();
+        private Dictionary<string, string> _currentKeys = new Dictionary<string, string>();
+
         private bool _inComponents = false;
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
@@ -222,8 +222,8 @@ namespace Microsoft.OpenApi.Services
                 {
                     _visitor.CurrentKeys.Path = pathItem.Key;
                     Walk(pathItem.Key, () => Walk(pathItem.Value));// JSON Pointer uses ~1 as an escape character for /
+                    _visitor.CurrentKeys.Path = null;
                 }
-                _visitor.CurrentKeys.Path = null;
             }
         }
 
@@ -285,8 +285,8 @@ namespace Microsoft.OpenApi.Services
                 {
                     _visitor.CurrentKeys.Extension = item.Key;
                     Walk(item.Key, () => Walk(item.Value));
+                    _visitor.CurrentKeys.Extension = null;
                 }
-                _visitor.CurrentKeys.Extension = null;
             }
         }
 
@@ -348,8 +348,8 @@ namespace Microsoft.OpenApi.Services
                     _visitor.CurrentKeys.Callback = item.Key.ToString();
                     var pathItem = item.Value;
                     Walk(item.Key.ToString(), () => Walk(pathItem));
+                    _visitor.CurrentKeys.Callback = null;
                 }
-                _visitor.CurrentKeys.Callback = null;
             }
         }
 
@@ -401,8 +401,8 @@ namespace Microsoft.OpenApi.Services
                 {
                     _visitor.CurrentKeys.ServerVariable = variable.Key;
                     Walk(variable.Key, () => Walk(variable.Value));
+                    _visitor.CurrentKeys.ServerVariable = null;
                 }
-                _visitor.CurrentKeys.ServerVariable = null;
             }
         }
 
@@ -468,8 +468,8 @@ namespace Microsoft.OpenApi.Services
                 {
                     _visitor.CurrentKeys.Operation = operation.Key;
                     Walk(operation.Key.GetDisplayName(), () => Walk(operation.Value));
+                    _visitor.CurrentKeys.Operation = null;
                 }
-                _visitor.CurrentKeys.Operation = null;
             }
         }
 
@@ -574,8 +574,8 @@ namespace Microsoft.OpenApi.Services
                 {
                     _visitor.CurrentKeys.Response = response.Key;
                     Walk(response.Key, () => Walk(response.Value));
+                    _visitor.CurrentKeys.Response = null;
                 }
-                _visitor.CurrentKeys.Response = null;
             }
             Walk(responses as IOpenApiExtensible);
         }
@@ -637,8 +637,8 @@ namespace Microsoft.OpenApi.Services
                 {
                     _visitor.CurrentKeys.Header = header.Key;
                     Walk(header.Key, () => Walk(header.Value));
+                    _visitor.CurrentKeys.Header = null;
                 }
-                _visitor.CurrentKeys.Header = null;
             }
         }
 
@@ -659,8 +659,8 @@ namespace Microsoft.OpenApi.Services
                 {
                     _visitor.CurrentKeys.Callback = callback.Key;
                     Walk(callback.Key, () => Walk(callback.Value));
+                    _visitor.CurrentKeys.Callback = null;
                 }
-                _visitor.CurrentKeys.Callback = null;
             }
         }
 
@@ -681,8 +681,8 @@ namespace Microsoft.OpenApi.Services
                 {
                     _visitor.CurrentKeys.Content = mediaType.Key;
                     Walk(mediaType.Key, () => Walk(mediaType.Value));
+                    _visitor.CurrentKeys.Content = null;
                 }
-                _visitor.CurrentKeys.Content = null;
             }
         }
 
@@ -722,8 +722,8 @@ namespace Microsoft.OpenApi.Services
                 {
                     _visitor.CurrentKeys.Encoding = item.Key;
                     Walk(item.Key, () => Walk(item.Value));
+                    _visitor.CurrentKeys.Encoding = null;
                 }
-                _visitor.CurrentKeys.Encoding = null;
             }
         }
 
@@ -810,6 +810,7 @@ namespace Microsoft.OpenApi.Services
                 {
                     _visitor.CurrentKeys.Example = example.Key;
                     Walk(example.Key, () => Walk(example.Value));
+                    _visitor.CurrentKeys.Example = null;
                 }
             }
         }
@@ -928,8 +929,8 @@ namespace Microsoft.OpenApi.Services
                 {
                     _visitor.CurrentKeys.Link = item.Key;
                     Walk(item.Key, () => Walk(item.Value));
+                    _visitor.CurrentKeys.Link = null;
                 }
-                _visitor.CurrentKeys.Link = null;
             }
         }
 
@@ -1070,18 +1071,64 @@ namespace Microsoft.OpenApi.Services
         }
     }
 
+    /// <summary>
+    /// Object containing contextual information based on where the walker is currently referencing in an OpenApiDocument
+    /// </summary>
     public class CurrentKeys
     {
+        /// <summary>
+        /// Current Path key
+        /// </summary>
         public string Path { get; set; }
+
+        /// <summary>
+        /// Current Operation Type
+        /// </summary>
         public OperationType? Operation { get; set; }
+
+        /// <summary>
+        /// Current Response Status Code
+        /// </summary>
         public string Response { get; set; }
+
+        /// <summary>
+        /// Current Content Media Type
+        /// </summary>
         public string Content { get; set; }
+
+        /// <summary>
+        /// Current Callback Key
+        /// </summary>
         public string Callback { get; set; }
+
+        /// <summary>
+        /// Current Link Key
+        /// </summary>
         public string Link { get; set; }
+
+        /// <summary>
+        /// Current Header Key
+        /// </summary>
         public string Header { get; internal set; }
+
+        /// <summary>
+        /// Current Encoding Key
+        /// </summary>
         public string Encoding { get; internal set; }
+
+        /// <summary>
+        /// Current Example Key
+        /// </summary>
         public string Example { get; internal set; }
+
+        /// <summary>
+        /// Current Extension Key
+        /// </summary>
         public string Extension { get; internal set; }
+
+        /// <summary>
+        /// Current ServerVariable
+        /// </summary>
         public string ServerVariable { get; internal set; }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
@@ -107,6 +107,8 @@ namespace Microsoft.OpenApi.Tests.Walkers
                 "#/paths/~1test/get/responses/200/content/application~1json/schema",
 
             });
+
+            locator.Keys.ShouldAllBeEquivalentTo(new List<string> { "/test","Get","200", "application/json" });
         }
 
         [Fact]
@@ -153,6 +155,8 @@ namespace Microsoft.OpenApi.Tests.Walkers
     internal class LocatorVisitor : OpenApiVisitorBase
     {
         public List<string> Locations = new List<string>();
+        public List<string> Keys = new List<string>();
+
         public override void Visit(OpenApiInfo info)
         {
             Locations.Add(this.PathString);
@@ -175,6 +179,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
 
         public override void Visit(OpenApiPathItem pathItem)
         {
+            Keys.Add(CurrentKeys.Path);
             Locations.Add(this.PathString);
         }
 
@@ -185,10 +190,12 @@ namespace Microsoft.OpenApi.Tests.Walkers
 
         public override void Visit(OpenApiOperation operation)
         {
+            Keys.Add(CurrentKeys.Operation.ToString());
             Locations.Add(this.PathString);
         }
         public override void Visit(OpenApiResponse response)
         {
+            Keys.Add(CurrentKeys.Response);
             Locations.Add(this.PathString);
         }
 
@@ -199,6 +206,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
 
         public override void Visit(OpenApiMediaType mediaType)
         {
+            Keys.Add(CurrentKeys.Content);
             Locations.Add(this.PathString);
         }
 


### PR DESCRIPTION
This allows visitors to process the OpenAPIDocument based on context of where an object exists within the document.