### PR TITLE
Added spec version to signature of custom extension parsers

### DIFF
--- a/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
@@ -42,7 +42,7 @@ namespace Microsoft.OpenApi.Readers
         /// <summary>
         /// Dictionary of parsers for converting extensions into strongly typed classes
         /// </summary>
-        public Dictionary<string, Func<IOpenApiAny , IOpenApiExtension>> ExtensionParsers { get; set; } = new Dictionary<string, Func<IOpenApiAny, IOpenApiExtension>>();
+        public Dictionary<string, Func<IOpenApiAny , OpenApiSpecVersion, IOpenApiExtension>> ExtensionParsers { get; set; } = new Dictionary<string, Func<IOpenApiAny, OpenApiSpecVersion, IOpenApiExtension>>();
 
         /// <summary>
         /// Rules to use for validating OpenAPI specification.  If none are provided a default set of rules are applied.

--- a/src/Microsoft.OpenApi.Readers/ParsingContext.cs
+++ b/src/Microsoft.OpenApi.Readers/ParsingContext.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OpenApi.Readers
         private readonly Dictionary<string, object> _tempStorage = new Dictionary<string, object>();
         private IOpenApiVersionService _versionService;
         private readonly Dictionary<string, Stack<string>> _loopStacks = new Dictionary<string, Stack<string>>();        
-        internal Dictionary<string, Func<IOpenApiAny, IOpenApiExtension>> ExtensionParsers { get; set; }  = new Dictionary<string, Func<IOpenApiAny, IOpenApiExtension>>();
+        internal Dictionary<string, Func<IOpenApiAny, OpenApiSpecVersion, IOpenApiExtension>> ExtensionParsers { get; set; }  = new Dictionary<string, Func<IOpenApiAny, OpenApiSpecVersion, IOpenApiExtension>>();
         internal RootNode RootNode { get; set; }
         internal List<OpenApiTag> Tags { get; private set; } = new List<OpenApiTag>();
         internal Uri BaseUrl { get; set; }

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.Readers.V2
         {
             if (node.Context.ExtensionParsers.TryGetValue(name, out var parser))
             {
-                return parser(node.CreateAny());
+                return parser(node.CreateAny(), OpenApiSpecVersion.OpenApi2_0);
             }
             else
             {

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiV3Deserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiV3Deserializer.cs
@@ -68,7 +68,7 @@ namespace Microsoft.OpenApi.Readers.V3
         {
             if (node.Context.ExtensionParsers.TryGetValue(name, out var parser))
             {
-                return parser(node.CreateAny());
+                return parser(node.CreateAny(), OpenApiSpecVersion.OpenApi3_0);
             }
             else
             {

--- a/test/Microsoft.OpenApi.Readers.Tests/TestCustomExtension.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/TestCustomExtension.cs
@@ -26,7 +26,7 @@ paths: {}
 ";
             var settings = new OpenApiReaderSettings()
             {
-                ExtensionParsers = { { "x-foo", (a) => {
+                ExtensionParsers = { { "x-foo", (a,v) => {
                         var fooNode = (OpenApiObject)a;
                         return new FooExtension() {
                               Bar = (fooNode["bar"] as OpenApiString)?.Value,


### PR DESCRIPTION
When extensions use existing OpenAPI objects within there definition we need to know what version of the spec the document is.