### PR TITLE
enable SourceLink

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 if "%~1"=="" goto :error
 
-SET %VERSION%=%~1
+SET VERSION=%~1
 
 Echo Building Microsoft.OpenApi
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All"/>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Replaces #284 with a pull request for `vnext`. See the SourceLink section of:
https://blogs.msdn.microsoft.com/dotnet/2018/05/30/announcing-net-core-2-1/

And the home page:
https://github.com/dotnet/sourcelink/
