### PR TITLE
Update SharpYaml package to 1.6.4 to enable support for .net standard…

### DIFF
--- a/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+++ b/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
@@ -26,7 +26,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="SharpYaml" Version="1.6.1" />
+        <PackageReference Include="SharpYaml" Version="1.6.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -159,7 +159,7 @@
         </PackageReference>
         <PackageReference Include="Newtonsoft.Json" Version="10.0.3">
         </PackageReference>
-        <PackageReference Include="SharpYaml" Version="1.6.1">
+        <PackageReference Include="SharpYaml" Version="1.6.4">
         </PackageReference>
         <PackageReference Include="xunit" Version="2.3.0">
         </PackageReference>


### PR DESCRIPTION
Update SharpYaml package to 1.6.4 to enable support for .net standard 2.0