### PR TITLE
Fix WriteValue for DateTimeOffset to write as string (i.e. with quotes)

### DIFF
--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
@@ -157,13 +157,21 @@ namespace Microsoft.OpenApi.Writers
         }
 
         /// <summary>
-        /// Write dateTimeOffset value.
+        /// Write DateTime value.
         /// </summary>
-        /// <param name="value">The decimal value.</param>
+        /// <param name="value">The DateTime value.</param>
+        public virtual void WriteValue(DateTime value)
+        {
+            this.WriteValue(value.ToString("o"));
+        }
+
+        /// <summary>
+        /// Write DateTimeOffset value.
+        /// </summary>
+        /// <param name="value">The DateTimeOffset value.</param>
         public virtual void WriteValue(DateTimeOffset value)
         {
-            WriteValueSeparator();
-            Writer.Write(value.ToString("o"));
+            this.WriteValue(value.ToString("o"));
         }
 
         /// <summary>
@@ -217,6 +225,10 @@ namespace Microsoft.OpenApi.Writers
             else if (type == typeof(decimal) || type == typeof(decimal?))
             {
                 WriteValue((decimal)value);
+            }
+            else if ( type == typeof(DateTime) || type == typeof(DateTime?) )
+            {
+                WriteValue((DateTime)value);
             }
             else if (type == typeof(DateTimeOffset) || type == typeof(DateTimeOffset?))
             {

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterAnyExtensionsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterAnyExtensionsTests.cs
@@ -97,9 +97,10 @@ namespace Microsoft.OpenApi.Tests.Writers
             var dateTimeValue = new OpenApiDateTime(input);
 
             var json = WriteAsJson(dateTimeValue);
+            var expectedJson = "\"" + input.ToString("o") + "\"";
 
             // Assert
-            json.Should().Be(input.ToString("o"));
+            json.Should().Be(expectedJson);
         }
 
         [Theory]


### PR DESCRIPTION
- Add WriteValue for DateTime type
- Fix WriteValue for DateTimeOffset type to convert to write as string with specific format. This will force it to be written just like string (ie. with double-quotes in JSON and single-quotes in YAML.)
- Add Tests

Fix #291 