### PR TITLE
Parse decimals and ints with InvariantCulture since JSON/YAML doesn't vary by culture.

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
@@ -191,7 +192,7 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 var pieces = host.Split(':');
                 host = pieces.First();
-                port = int.Parse(pieces.Last());
+                port = int.Parse(pieces.Last(), CultureInfo.InvariantCulture);
             }
 
             var uriBuilder = new UriBuilder()

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System;
+using System.Globalization;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
@@ -54,10 +55,10 @@ namespace Microsoft.OpenApi.Readers.V2
                     GetOrCreateSchema(o).Default = n.CreateAny();
                 }
             },
-                        {
+            {
                 "maximum", (o, n) =>
                 {
-                    GetOrCreateSchema(o).Maximum = decimal.Parse(n.GetScalarValue());
+                    GetOrCreateSchema(o).Maximum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -69,7 +70,7 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "minimum", (o, n) =>
                 {
-                    GetOrCreateSchema(o).Minimum = decimal.Parse(n.GetScalarValue());
+                    GetOrCreateSchema(o).Minimum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -81,13 +82,13 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "maxLength", (o, n) =>
                 {
-                    GetOrCreateSchema(o).MaxLength = int.Parse(n.GetScalarValue());
+                    GetOrCreateSchema(o).MaxLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
                 "minLength", (o, n) =>
                 {
-                    GetOrCreateSchema(o).MinLength = int.Parse(n.GetScalarValue());
+                    GetOrCreateSchema(o).MinLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -99,13 +100,13 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "maxItems", (o, n) =>
                 {
-                    GetOrCreateSchema(o).MaxItems = int.Parse(n.GetScalarValue());
+                    GetOrCreateSchema(o).MaxItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
                 "minItems", (o, n) =>
                 {
-                    GetOrCreateSchema(o).MinItems = int.Parse(n.GetScalarValue());
+                    GetOrCreateSchema(o).MinItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -117,7 +118,7 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "multipleOf", (o, n) =>
                 {
-                    GetOrCreateSchema(o).MultipleOf = decimal.Parse(n.GetScalarValue());
+                    GetOrCreateSchema(o).MultipleOf = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
@@ -90,25 +91,25 @@ namespace Microsoft.OpenApi.Readers.V2
                 {
                     "minimum", (o, n) =>
                     {
-                        GetOrCreateSchema(o).Minimum = decimal.Parse(n.GetScalarValue());
+                        GetOrCreateSchema(o).Minimum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                     }
                 },
                 {
                     "maximum", (o, n) =>
                     {
-                        GetOrCreateSchema(o).Maximum = decimal.Parse(n.GetScalarValue());
+                        GetOrCreateSchema(o).Maximum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                     }
                 },
                 {
                     "maxLength", (o, n) =>
                     {
-                        GetOrCreateSchema(o).MaxLength = int.Parse(n.GetScalarValue());
+                        GetOrCreateSchema(o).MaxLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                     }
                 },
                 {
                     "minLength", (o, n) =>
                     {
-                        GetOrCreateSchema(o).MinLength = int.Parse(n.GetScalarValue());
+                        GetOrCreateSchema(o).MinLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                     }
                 },
                 {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
@@ -6,6 +6,7 @@ using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Microsoft.OpenApi.Readers.V2
 {
@@ -26,13 +27,13 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "multipleOf", (o, n) =>
                 {
-                    o.MultipleOf = decimal.Parse(n.GetScalarValue());
+                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
                 "maximum", (o, n) =>
                 {
-                    o.Maximum = decimal.Parse(n.GetScalarValue());
+                    o.Maximum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -44,7 +45,7 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "minimum", (o, n) =>
                 {
-                    o.Minimum = decimal.Parse(n.GetScalarValue());
+                    o.Minimum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -56,13 +57,13 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "maxLength", (o, n) =>
                 {
-                    o.MaxLength = int.Parse(n.GetScalarValue());
+                    o.MaxLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
                 "minLength", (o, n) =>
                 {
-                    o.MinLength = int.Parse(n.GetScalarValue());
+                    o.MinLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -74,13 +75,13 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "maxItems", (o, n) =>
                 {
-                    o.MaxItems = int.Parse(n.GetScalarValue());
+                    o.MaxItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
                 "minItems", (o, n) =>
                 {
-                    o.MinItems = int.Parse(n.GetScalarValue());
+                    o.MinItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -92,13 +93,13 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "maxProperties", (o, n) =>
                 {
-                    o.MaxProperties = int.Parse(n.GetScalarValue());
+                    o.MaxProperties = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
                 "minProperties", (o, n) =>
                 {
-                    o.MinProperties = int.Parse(n.GetScalarValue());
+                    o.MinProperties = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -6,6 +6,7 @@ using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Microsoft.OpenApi.Readers.V3
 {
@@ -26,13 +27,13 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "multipleOf", (o, n) =>
                 {
-                    o.MultipleOf = decimal.Parse(n.GetScalarValue());
+                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
                 "maximum", (o, n) =>
                 {
-                    o.Maximum = decimal.Parse(n.GetScalarValue());
+                    o.Maximum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -44,7 +45,7 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "minimum", (o, n) =>
                 {
-                    o.Minimum = decimal.Parse(n.GetScalarValue());
+                    o.Minimum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -56,13 +57,13 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "maxLength", (o, n) =>
                 {
-                    o.MaxLength = int.Parse(n.GetScalarValue());
+                    o.MaxLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
                 "minLength", (o, n) =>
                 {
-                    o.MinLength = int.Parse(n.GetScalarValue());
+                    o.MinLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -74,13 +75,13 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "maxItems", (o, n) =>
                 {
-                    o.MaxItems = int.Parse(n.GetScalarValue());
+                    o.MaxItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
                 "minItems", (o, n) =>
                 {
-                    o.MinItems = int.Parse(n.GetScalarValue());
+                    o.MinItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -92,13 +93,13 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "maxProperties", (o, n) =>
                 {
-                    o.MaxProperties = int.Parse(n.GetScalarValue());
+                    o.MaxProperties = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {
                 "minProperties", (o, n) =>
                 {
-                    o.MinProperties = int.Parse(n.GetScalarValue());
+                    o.MinProperties = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
                 }
             },
             {

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
 using FluentAssertions;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Models;
@@ -65,6 +67,77 @@ paths:
             diagnostic.Errors.ShouldBeEquivalentTo(new List<OpenApiError> {
                 new OpenApiError( new OpenApiException("Invalid Reference identifier 'doesnotexist'.")) });
             doc.Should().NotBeNull();
+        }
+
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("hi-IN")]
+        // The equivalent of English 1,000.36 in French and Danish is 1.000,36
+        [InlineData("fr-FR")]
+        [InlineData("da-DK")]
+        public void ParseDocumentWithDifferentCultureShouldSucceed(string culture)
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo(culture);
+
+            var openApiDoc = new OpenApiStringReader().Read(
+                @"
+swagger: 2.0
+info: 
+  title: Simple Document
+  version: 0.9.1
+definitions:
+  sampleSchema:
+    type: object
+    properties:
+      sampleProperty:
+        type: double
+        minimum: 100.54
+        maximum: 60,000,000.35
+        exclusiveMaximum: true
+        exclusiveMinimum: false
+paths: {}",
+                out var context);
+
+            openApiDoc.ShouldBeEquivalentTo(
+                new OpenApiDocument
+                {
+                    Info = new OpenApiInfo
+                    {
+                        Title = "Simple Document",
+                        Version = "0.9.1"
+                    },
+                    Components = new OpenApiComponents()
+                    {
+                        Schemas =
+                        {
+                            ["sampleSchema"] = new OpenApiSchema()
+                            {
+                                Type = "object",
+                                Properties =
+                                {
+                                    ["sampleProperty"] = new OpenApiSchema()
+                                    {
+                                        Type = "double",
+                                        Minimum = (decimal)100.54,
+                                        Maximum = (decimal)60000000.35,
+                                        ExclusiveMaximum = true,
+                                        ExclusiveMinimum = false
+                                    }
+                                },
+                                Reference = new OpenApiReference()
+                                {
+                                    Id = "sampleSchema",
+                                    Type = ReferenceType.Schema
+                                }
+                            }
+                        }
+                    },
+                    Paths = new OpenApiPaths()
+                });
+
+            context.ShouldBeEquivalentTo(
+                new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi2_0 });
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiAnyTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiAnyTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
@@ -43,7 +44,7 @@ aDateTime: 2017-01-01
                     ["aString"] = new OpenApiString("fooBar"),
                     ["aInteger"] = new OpenApiInteger(10),
                     ["aDouble"] = new OpenApiDouble(2.34),
-                    ["aDateTime"] = new OpenApiDateTime(DateTimeOffset.Parse("2017-01-01"))
+                    ["aDateTime"] = new OpenApiDateTime(DateTimeOffset.Parse("2017-01-01", CultureInfo.InvariantCulture))
                 });
         }
 
@@ -75,7 +76,7 @@ aDateTime: 2017-01-01
                     new OpenApiString("fooBar"),
                     new OpenApiInteger(10),
                     new OpenApiDouble(2.34),
-                    new OpenApiDateTime(DateTimeOffset.Parse("2017-01-01"))
+                    new OpenApiDateTime(DateTimeOffset.Parse("2017-01-01", CultureInfo.InvariantCulture))
                 });
         }
 
@@ -123,7 +124,7 @@ aDateTime: 2017-01-01
             diagnostic.Errors.Should().BeEmpty();
 
             any.ShouldBeEquivalentTo(
-                new OpenApiDateTime(DateTimeOffset.Parse("2012-07-23T12:33:00"))
+                new OpenApiDateTime(DateTimeOffset.Parse("2012-07-23T12:33:00", CultureInfo.InvariantCulture))
             );
         }
     }

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterAnyExtensionsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterAnyExtensionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System;
+using System.Globalization;
 using System.IO;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
@@ -93,7 +94,7 @@ namespace Microsoft.OpenApi.Tests.Writers
         public void WriteOpenApiDateTimeAsJsonWorks(string inputString)
         {
             // Arrange
-            var input = DateTimeOffset.Parse(inputString);
+            var input = DateTimeOffset.Parse(inputString, CultureInfo.InvariantCulture);
             var dateTimeValue = new OpenApiDateTime(input);
 
             var json = WriteAsJson(dateTimeValue);


### PR DESCRIPTION
Parse decimals and ints with InvariantCulture since JSON/YAML doesn't vary by culture.

For example, the parser should always treat 100.000 as one hundred, not one hundred thousand, even if the operating system on the machine is set to use French.

Fix #323 