### PR TITLE
Ensure parsing null in "in" in Parameter does not fail

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
@@ -73,11 +73,12 @@ namespace Microsoft.OpenApi.Readers.V2
 
                     o.Components.RequestBodies = n.CreateMapWithReference(ReferenceType.RequestBody, p => 
                             {
-                                var parameter = LoadParameter(p, evenBody: true);
-                                if (parameter.In == null)
+                                var parameter = LoadParameter(p, loadRequestBody: true);
+                                if (parameter != null)
                                 {
-                                    return CreateRequestBody(n.Context,parameter); 
+                                    return CreateRequestBody(n.Context, parameter); 
                                 }
+
                                 return null;
                             }
                       );

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiParameterDeserializer.cs
@@ -27,7 +27,15 @@ namespace Microsoft.OpenApi.Readers.V3
                 {
                     "in", (o, n) =>
                     {
-                        o.In = n.GetScalarValue().GetEnumFromDisplayName<ParameterLocation>();
+                        var inString = n.GetScalarValue();
+                        if ( inString == null || inString == "null" )
+                        {
+                            o.In = null;
+                        }
+                        else
+                        {
+                            o.In = n.GetScalarValue().GetEnumFromDisplayName<ParameterLocation>();
+                        }
                     }
                 },
                 {

--- a/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
+++ b/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
@@ -114,6 +114,12 @@ namespace Microsoft.OpenApi.Validations
         public override void Visit(OpenApiTag item) => Validate(item);
 
         /// <summary>
+        /// Execute validation rules against an <see cref="OpenApiParameter"/>
+        /// </summary>
+        /// <param name="item">The object to be validated</param>
+        public override void Visit(OpenApiParameter item) => Validate(item);
+
+        /// <summary>
         /// Execute validation rules against an <see cref="OpenApiSchema"/>
         /// </summary>
         /// <param name="item">The object to be validated</param>

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiParameterRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiParameterRules.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiParameter"/>.
+    /// </summary>
+    [OpenApiRule]
+    public static class OpenApiParameterRules
+    {
+        /// <summary>
+        /// Validate the field is required.
+        /// </summary>
+        public static ValidationRule<OpenApiParameter> ParameterRequiredFields =>
+            new ValidationRule<OpenApiParameter>(
+                (context, item) =>
+                {
+                    // name
+                    context.Enter("name");
+                    if (item.Name == null)
+                    {
+                        context.CreateError(nameof(ParameterRequiredFields),
+                            String.Format(SRResource.Validation_FieldIsRequired, "name", "parameter"));
+                    }
+                    context.Exit();
+
+                    // in
+                    context.Enter("in");
+                    if (item.In == null)
+                    {
+                        context.CreateError(nameof(ParameterRequiredFields), 
+                            String.Format(SRResource.Validation_FieldIsRequired, "in", "parameter"));
+                    }
+                    context.Exit();
+                });
+
+        /// <summary>
+        /// Validate the "required" field is true when "in" is path.
+        /// </summary>
+        public static ValidationRule<OpenApiParameter> RequiredMustBeTrueWhenInIsPath =>
+            new ValidationRule<OpenApiParameter>(
+                (context, item) =>
+                {
+                    // required
+                    context.Enter("required");
+                    if ( item.In == ParameterLocation.Path && !item.Required )
+                    {
+                        context.CreateError(
+                            nameof(RequiredMustBeTrueWhenInIsPath),
+                            "\"required\" must be true when parameter location is path");
+                    }
+
+                    context.Exit();
+                });
+
+        // add more rule.
+    }
+}

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -46,6 +46,12 @@
       <EmbeddedResource Include="V2Tests\Samples\OpenApiParameter\formDataParameter.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiParameter\parameterWithNoLocation.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiParameter\parameterWithNullLocation.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
       <EmbeddedResource Include="V2Tests\Samples\OpenApiParameter\headerParameter.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
@@ -114,6 +120,27 @@
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
       <EmbeddedResource Include="V3Tests\Samples\OpenApiOperation\securedOperation.yaml" />
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiParameter\headerParameter.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiParameter\parameterWithNoLocation.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiParameter\parameterWithNullLocation.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiParameter\pathParameter.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiParameter\queryParameterWithObjectTypeAndContent.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiParameter\queryParameterWithObjectType.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiParameter\queryParameter.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
       <EmbeddedResource Include="V3Tests\Samples\OpenApiSchema\advancedSchemaWithReference.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/headerParameter.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/headerParameter.yaml
@@ -1,4 +1,4 @@
-﻿# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
+﻿# modified from https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
 name: token
 in: header
 description: token to be passed as a header

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/parameterWithNoLocation.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/parameterWithNoLocation.yaml
@@ -1,0 +1,4 @@
+﻿name: username
+description: username to fetch
+required: true
+type: string

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/parameterWithNullLocation.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/parameterWithNullLocation.yaml
@@ -1,0 +1,5 @@
+﻿name: username
+in: null
+description: username to fetch
+required: true
+type: string

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiParameterTests.cs
@@ -1,40 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Collections.Generic;
 using System.IO;
 using FluentAssertions;
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
-using Microsoft.OpenApi.Readers.V2;
+using Microsoft.OpenApi.Readers.V3;
 using Xunit;
 
-namespace Microsoft.OpenApi.Readers.Tests.V2Tests
+namespace Microsoft.OpenApi.Readers.Tests.V3Tests
 {
     [Collection("DefaultSettings")]
     public class OpenApiParameterTests
     {
-        private const string SampleFolderPath = "V2Tests/Samples/OpenApiParameter/";
-
-        [Fact]
-        public void ParseBodyParameterShouldSucceed()
-        {
-            // Arrange
-            MapNode node;
-            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "bodyParameter.yaml")))
-            {
-                node = TestHelper.CreateYamlMapNode(stream);
-            }
-
-            // Act
-            var parameter = OpenApiV2Deserializer.LoadParameter(node);
-
-            // Assert
-            // Body parameter is currently not translated via LoadParameter.
-            // This design may be revisited and this unit test may likely change.
-            parameter.Should().BeNull();
-        }
+        private const string SampleFolderPath = "V3Tests/Samples/OpenApiParameter/";
 
         [Fact]
         public void ParsePathParameterShouldSucceed()
@@ -47,7 +26,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             }
 
             // Act
-            var parameter = OpenApiV2Deserializer.LoadParameter(node);
+            var parameter = OpenApiV3Deserializer.LoadParameter(node);
 
             // Assert
             parameter.ShouldBeEquivalentTo(
@@ -75,7 +54,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             }
 
             // Act
-            var parameter = OpenApiV2Deserializer.LoadParameter(node);
+            var parameter = OpenApiV3Deserializer.LoadParameter(node);
 
             // Assert
             parameter.ShouldBeEquivalentTo(
@@ -99,22 +78,82 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         }
 
         [Fact]
-        public void ParseFormDataParameterShouldSucceed()
+        public void ParseQueryParameterWithObjectTypeShouldSucceed()
         {
             // Arrange
             MapNode node;
-            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "formDataParameter.yaml")))
+            using ( var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "queryParameterWithObjectType.yaml")) )
             {
                 node = TestHelper.CreateYamlMapNode(stream);
             }
 
             // Act
-            var parameter = OpenApiV2Deserializer.LoadParameter(node);
+            var parameter = OpenApiV3Deserializer.LoadParameter(node);
 
             // Assert
-            // Form data parameter is currently not translated via LoadParameter.
-            // This design may be revisited and this unit test may likely change.
-            parameter.Should().BeNull();
+            parameter.ShouldBeEquivalentTo(
+                new OpenApiParameter
+                {
+                    In = ParameterLocation.Query,
+                    Name = "freeForm",
+                    Schema = new OpenApiSchema
+                    {
+                        Type = "object",
+                        AdditionalProperties = new OpenApiSchema
+                        {
+                            Type = "integer"
+                        }
+                    },
+                    Style = ParameterStyle.Form
+                });
+        }
+
+        [Fact]
+        public void ParseQueryParameterWithObjectTypeAndContentShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using ( var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "queryParameterWithObjectTypeAndContent.yaml")) )
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var parameter = OpenApiV3Deserializer.LoadParameter(node);
+
+            // Assert
+            parameter.ShouldBeEquivalentTo(
+                new OpenApiParameter
+                {
+                    In = ParameterLocation.Query,
+                    Name = "coordinates",
+                    Content =
+                    {
+                        ["application/json"] = new OpenApiMediaType
+                        {
+                            Schema = new OpenApiSchema
+                            {
+                                Type = "object",
+                                Required =
+                                {
+                                    "lat",
+                                    "long"
+                                },
+                                Properties =
+                                {
+                                    ["lat"] = new OpenApiSchema
+                                    {
+                                        Type = "number"
+                                    },
+                                    ["long"] = new OpenApiSchema
+                                    {
+                                        Type = "number"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
         }
 
         [Fact]
@@ -128,7 +167,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             }
 
             // Act
-            var parameter = OpenApiV2Deserializer.LoadParameter(node);
+            var parameter = OpenApiV3Deserializer.LoadParameter(node);
 
             // Assert
             parameter.ShouldBeEquivalentTo(
@@ -147,23 +186,6 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                         {
                             Type = "integer",
                             Format = "int64",
-                            Enum = new List<IOpenApiAny>
-                            {
-                                new OpenApiInteger(1),
-                                new OpenApiInteger(2),
-                                new OpenApiInteger(3),
-                                new OpenApiInteger(4),
-                            }
-                        },
-                        Default = new OpenApiArray() {
-                            new OpenApiInteger(1),
-                            new OpenApiInteger(2)
-                        },
-                        Enum = new List<IOpenApiAny>
-                        {
-                            new OpenApiArray() { new OpenApiInteger(1), new OpenApiInteger(2) },
-                            new OpenApiArray() { new OpenApiInteger(2), new OpenApiInteger(3) },
-                            new OpenApiArray() { new OpenApiInteger(3), new OpenApiInteger(4) }
                         }
                     }
                 });
@@ -180,7 +202,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             }
 
             // Act
-            var parameter = OpenApiV2Deserializer.LoadParameter(node);
+            var parameter = OpenApiV3Deserializer.LoadParameter(node);
 
             // Assert
             parameter.ShouldBeEquivalentTo(
@@ -208,7 +230,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             }
 
             // Act
-            var parameter = OpenApiV2Deserializer.LoadParameter(node);
+            var parameter = OpenApiV3Deserializer.LoadParameter(node);
 
             // Assert
             parameter.ShouldBeEquivalentTo(

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/headerParameter.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/headerParameter.yaml
@@ -1,0 +1,11 @@
+﻿# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameter-object-examples
+name: token
+in: header
+description: token to be passed as a header
+required: true
+schema:
+  type: array
+  items:
+    type: integer
+    format: int64
+style: simple

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/parameterWithNoLocation.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/parameterWithNoLocation.yaml
@@ -1,0 +1,5 @@
+﻿name: username
+description: username to fetch
+required: true
+schema:
+  type: string

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/parameterWithNullLocation.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/parameterWithNullLocation.yaml
@@ -1,0 +1,6 @@
+﻿name: username
+in: null
+description: username to fetch
+required: true
+schema:
+  type: string

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/pathParameter.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/pathParameter.yaml
@@ -1,0 +1,7 @@
+﻿# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameter-object-examples
+name: username
+in: path
+description: username to fetch
+required: true
+schema:
+  type: string

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/queryParameter.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/queryParameter.yaml
@@ -1,0 +1,11 @@
+﻿# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameter-object-examples
+name: id
+in: query
+description: ID of the object to fetch
+required: false
+schema:
+  type: array
+  items:
+    type: string
+style: form
+explode: true

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/queryParameterWithObjectType.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/queryParameterWithObjectType.yaml
@@ -1,0 +1,8 @@
+﻿# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameter-object-examples
+in: query
+name: freeForm
+schema:
+  type: object
+  additionalProperties:
+    type: integer
+style: form

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/queryParameterWithObjectTypeAndContent.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/queryParameterWithObjectTypeAndContent.yaml
@@ -1,0 +1,15 @@
+﻿# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameter-object-examples
+in: query
+name: coordinates
+content:
+  application/json:
+    schema:
+      type: object
+      required:
+        - lat
+        - long
+      properties:
+        lat:
+          type: number
+        long:
+          type: number

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiInfoValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiInfoValidationTests.cs
@@ -18,9 +18,9 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateFieldIsRequiredInInfo()
         {
             // Arrange
-            string urlError = String.Format(SRResource.Validation_FieldIsRequired, "title", "info");
+            string titleError = String.Format(SRResource.Validation_FieldIsRequired, "title", "info");
             string versionError = String.Format(SRResource.Validation_FieldIsRequired, "version", "info");
-            OpenApiInfo info = new OpenApiInfo();
+            var info = new OpenApiInfo();
 
             // Act
             var errors = info.Validate(ValidationRuleSet.GetDefaultRuleSet());
@@ -32,7 +32,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.False(result);
             Assert.NotNull(errors);
 
-            Assert.Equal(new[] { urlError, versionError }, errors.Select(e => e.Message));
+            Assert.Equal(new[] { titleError, versionError }, errors.Select(e => e.Message));
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiParameterValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiParameterValidationTests.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+using Xunit;
+
+namespace Microsoft.OpenApi.Validations.Tests
+{
+    public class OpenApiParameterValidationTests
+    {
+        [Fact]
+        public void ValidateFieldIsRequiredInParameter()
+        {
+            // Arrange
+            string nameError = String.Format(SRResource.Validation_FieldIsRequired, "name", "parameter");
+            string inError = String.Format(SRResource.Validation_FieldIsRequired, "in", "parameter");
+            var parameter = new OpenApiParameter();
+
+            // Act
+            var errors = parameter.Validate(ValidationRuleSet.GetDefaultRuleSet());
+
+            // Assert
+            errors.Should().NotBeEmpty();
+            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            {
+                nameError,
+                inError
+            });
+        }
+
+        [Fact]
+        public void ValidateRequiredIsTrueWhenInIsPathInParameter()
+        {
+            // Arrange
+            var parameter = new OpenApiParameter()
+            {
+                Name = "name",
+                In = ParameterLocation.Path
+            };
+
+            // Act
+            var errors = parameter.Validate(ValidationRuleSet.GetDefaultRuleSet());
+
+            // Assert
+            errors.Should().NotBeEmpty();
+            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            {
+                "\"required\" must be true when parameter location is path"
+            });
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.NotEmpty(rules);
 
             // Update the number if you add new default rule(s).
-            Assert.Equal(14, rules.Count);
+            Assert.Equal(16, rules.Count);
         }
     }
 }


### PR DESCRIPTION
Fix #309

- Ensure that null in "in" in parameter object is parsed to a null Im in the DOM.

- Add validation rule to validate the required fields in Parameter.