### PR TITLE
Parsing IOpenApiAny should respect format and type

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ParseNodes/AnyFieldMap.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/AnyFieldMap.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using System.Collections.Generic;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Readers.ParseNodes
+{
+    internal class AnyFieldMap<T> : Dictionary<string, AnyFieldMapParameter<T>>
+    {
+
+    }
+
+    internal class AnyFieldMapParameter<T>
+    {
+        public AnyFieldMapParameter(
+            Func<T, IOpenApiAny> propertyGetter,
+            Func<T, IOpenApiAny, IOpenApiAny> propertySetter,
+            Func<T, OpenApiSchema> schemaGetter)
+        {
+            this.PropertyGetter = propertyGetter;
+            this.PropertySetter = propertySetter;
+            this.SchemaGetter = schemaGetter;
+        }
+
+        public Func<T, IOpenApiAny> PropertyGetter { get; }
+
+        public Func<T, IOpenApiAny, IOpenApiAny> PropertySetter { get; }
+
+        public Func<T, OpenApiSchema> SchemaGetter { get; }
+    }
+}

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/AnyFieldMap.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/AnyFieldMap.cs
@@ -1,34 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System;
 using System.Collections.Generic;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Readers.ParseNodes
 {
     internal class AnyFieldMap<T> : Dictionary<string, AnyFieldMapParameter<T>>
     {
-
-    }
-
-    internal class AnyFieldMapParameter<T>
-    {
-        public AnyFieldMapParameter(
-            Func<T, IOpenApiAny> propertyGetter,
-            Func<T, IOpenApiAny, IOpenApiAny> propertySetter,
-            Func<T, OpenApiSchema> schemaGetter)
-        {
-            this.PropertyGetter = propertyGetter;
-            this.PropertySetter = propertySetter;
-            this.SchemaGetter = schemaGetter;
-        }
-
-        public Func<T, IOpenApiAny> PropertyGetter { get; }
-
-        public Func<T, IOpenApiAny, IOpenApiAny> PropertySetter { get; }
-
-        public Func<T, OpenApiSchema> SchemaGetter { get; }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/AnyFieldMapParameter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/AnyFieldMapParameter.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Readers.ParseNodes
+{
+    internal class AnyFieldMapParameter<T>
+    {
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public AnyFieldMapParameter(
+            Func<T, IOpenApiAny> propertyGetter,
+            Func<T, IOpenApiAny, IOpenApiAny> propertySetter,
+            Func<T, OpenApiSchema> schemaGetter)
+        {
+            this.PropertyGetter = propertyGetter;
+            this.PropertySetter = propertySetter;
+            this.SchemaGetter = schemaGetter;
+        }
+
+        /// <summary>
+        /// Function to retrieve the value of the property.
+        /// </summary>
+        public Func<T, IOpenApiAny> PropertyGetter { get; }
+
+        /// <summary>
+        /// Function to set the value of the property.
+        /// </summary>
+        public Func<T, IOpenApiAny, IOpenApiAny> PropertySetter { get; }
+
+        /// <summary>
+        /// Function to get the schema to apply to the property.
+        /// </summary>
+        public Func<T, OpenApiSchema> SchemaGetter { get; }
+    }
+}

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/AnyFieldMapParameter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/AnyFieldMapParameter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
         /// </summary>
         public AnyFieldMapParameter(
             Func<T, IOpenApiAny> propertyGetter,
-            Func<T, IOpenApiAny, IOpenApiAny> propertySetter,
+            Action<T, IOpenApiAny> propertySetter,
             Func<T, OpenApiSchema> schemaGetter)
         {
             this.PropertyGetter = propertyGetter;
@@ -30,7 +30,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
         /// <summary>
         /// Function to set the value of the property.
         /// </summary>
-        public Func<T, IOpenApiAny, IOpenApiAny> PropertySetter { get; }
+        public Action<T, IOpenApiAny> PropertySetter { get; }
 
         /// <summary>
         /// Function to get the schema to apply to the property.

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/AnyListFieldMap.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/AnyListFieldMap.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using System.Collections.Generic;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Readers.ParseNodes
+{
+    internal class AnyListFieldMap<T> : Dictionary<string, AnyListFieldMapParameter<T>>
+    {
+
+    }
+
+    internal class AnyListFieldMapParameter<T>
+    {
+        public AnyListFieldMapParameter(
+            Func<T, IList<IOpenApiAny>> propertyGetter,
+            Func<T, IList<IOpenApiAny>, IList<IOpenApiAny>> propertySetter,
+            Func<T, OpenApiSchema> schemaGetter)
+        {
+            this.PropertyGetter = propertyGetter;
+            this.PropertySetter = propertySetter;
+            this.SchemaGetter = schemaGetter;
+        }
+
+        public Func<T, IList<IOpenApiAny>> PropertyGetter { get; }
+
+        public Func<T, IList<IOpenApiAny>, IList<IOpenApiAny>> PropertySetter { get; }
+
+        public Func<T, OpenApiSchema> SchemaGetter { get; }
+    }
+}

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/AnyListFieldMap.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/AnyListFieldMap.cs
@@ -1,34 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System;
 using System.Collections.Generic;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Readers.ParseNodes
 {
     internal class AnyListFieldMap<T> : Dictionary<string, AnyListFieldMapParameter<T>>
     {
 
-    }
-
-    internal class AnyListFieldMapParameter<T>
-    {
-        public AnyListFieldMapParameter(
-            Func<T, IList<IOpenApiAny>> propertyGetter,
-            Func<T, IList<IOpenApiAny>, IList<IOpenApiAny>> propertySetter,
-            Func<T, OpenApiSchema> schemaGetter)
-        {
-            this.PropertyGetter = propertyGetter;
-            this.PropertySetter = propertySetter;
-            this.SchemaGetter = schemaGetter;
-        }
-
-        public Func<T, IList<IOpenApiAny>> PropertyGetter { get; }
-
-        public Func<T, IList<IOpenApiAny>, IList<IOpenApiAny>> PropertySetter { get; }
-
-        public Func<T, OpenApiSchema> SchemaGetter { get; }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/AnyListFieldMapParameter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/AnyListFieldMapParameter.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using System.Collections.Generic;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Readers.ParseNodes
+{
+    internal class AnyListFieldMapParameter<T>
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public AnyListFieldMapParameter(
+            Func<T, IList<IOpenApiAny>> propertyGetter,
+            Func<T, IList<IOpenApiAny>, IList<IOpenApiAny>> propertySetter,
+            Func<T, OpenApiSchema> schemaGetter)
+        {
+            this.PropertyGetter = propertyGetter;
+            this.PropertySetter = propertySetter;
+            this.SchemaGetter = schemaGetter;
+        }
+
+        /// <summary>
+        /// Function to retrieve the value of the property.
+        /// </summary>
+        public Func<T, IList<IOpenApiAny>> PropertyGetter { get; }
+
+        /// <summary>
+        /// Function to set the value of the property.
+        /// </summary>
+        public Func<T, IList<IOpenApiAny>, IList<IOpenApiAny>> PropertySetter { get; }
+
+        /// <summary>
+        /// Function to get the schema to apply to the property.
+        /// </summary>
+        public Func<T, OpenApiSchema> SchemaGetter { get; }
+    }
+}

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/AnyMapFieldMap.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/AnyMapFieldMap.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System.Collections.Generic;
+
+namespace Microsoft.OpenApi.Readers.ParseNodes
+{
+    internal class AnyMapFieldMap<T, U> : Dictionary<string, AnyMapFieldMapParameter<T, U>>
+    {
+
+    }
+}

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/AnyMapFieldMapParameter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/AnyMapFieldMapParameter.cs
@@ -4,34 +4,42 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Readers.ParseNodes
 {
-    internal class AnyListFieldMapParameter<T>
+    internal class AnyMapFieldMapParameter<T, U>
     {
         /// <summary>
         /// Constructor
         /// </summary>
-        public AnyListFieldMapParameter(
-            Func<T, IList<IOpenApiAny>> propertyGetter,
-            Action<T, IList<IOpenApiAny>> propertySetter,
+        public AnyMapFieldMapParameter(
+            Func<T, IDictionary<string, U>> propertyMapGetter,
+            Func<U, IOpenApiAny> propertyGetter,
+            Action<U, IOpenApiAny> propertySetter,
             Func<T, OpenApiSchema> schemaGetter)
         {
+            this.PropertyMapGetter = propertyMapGetter;
             this.PropertyGetter = propertyGetter;
             this.PropertySetter = propertySetter;
             this.SchemaGetter = schemaGetter;
         }
 
         /// <summary>
-        /// Function to retrieve the value of the property.
+        /// Function to retrieve the property that is a map from string to an inner element containing IOpenApiAny.
         /// </summary>
-        public Func<T, IList<IOpenApiAny>> PropertyGetter { get; }
+        public Func<T, IDictionary<string, U>> PropertyMapGetter { get; }
+
+        /// <summary>
+        /// Function to retrieve the value of the property from an inner element.
+        /// </summary>
+        public Func<U, IOpenApiAny> PropertyGetter { get; }
 
         /// <summary>
         /// Function to set the value of the property.
         /// </summary>
-        public Action<T, IList<IOpenApiAny>> PropertySetter { get; }
+        public Action<U, IOpenApiAny> PropertySetter { get; }
 
         /// <summary>
         /// Function to get the schema to apply to the property.

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/IOpenApiAnyExtensions.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/IOpenApiAnyExtensions.cs
@@ -1,0 +1,239 @@
+﻿using System;
+using System.Linq;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Exceptions;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Readers.ParseNodes
+{
+    internal static class OpenApiStringConverter
+    {
+        public static IOpenApiAny GetSpecificOpenApiAny(IOpenApiAny openApiAny)
+        {
+            if ( !(openApiAny is OpenApiString))
+            {
+                return openApiAny;
+            }
+
+            var value = ((OpenApiString)openApiAny).Value;
+
+            if (value == null || value == "null")
+            {
+                return new OpenApiNull();
+            }
+
+            if (value == "true")
+            {
+                return new OpenApiBoolean(true);
+            }
+
+            if (value == "false")
+            {
+                return new OpenApiBoolean(false);
+            }
+
+            if (int.TryParse(value, out var intValue))
+            {
+                return new OpenApiInteger(intValue);
+            }
+
+            if (long.TryParse(value, out var longValue))
+            {
+                return new OpenApiLong(longValue);
+            }
+
+            if (double.TryParse(value, out var doubleValue))
+            {
+                return new OpenApiDouble(doubleValue);
+            }
+
+            if (DateTimeOffset.TryParse(value, out var dateTimeValue))
+            {
+                return new OpenApiDateTime(dateTimeValue);
+            }
+
+            // if we can't identify the type of value, return it as string.
+            return new OpenApiString(value);
+        }
+
+        public static IOpenApiAny GetSpecificOpenApiAny(IOpenApiAny openApiAny, OpenApiSchema schema)
+        {
+            var type = schema.Type;
+            var format = schema.Format;
+
+            if (openApiAny is OpenApiArray openApiArray)
+            {
+                var newArray = new OpenApiArray();
+                foreach (var element in openApiArray)
+                {
+                    newArray.Add(GetSpecificOpenApiAny(element, schema.Items));
+                }
+
+                return newArray;
+            }
+
+            if (openApiAny is OpenApiObject openApiObject)
+            {
+                var newObject = new OpenApiObject();
+
+                foreach (var key in openApiObject.Keys.ToList())
+                {
+                    newObject[key] = GetSpecificOpenApiAny(openApiObject[key], schema.AdditionalProperties);
+                }
+
+                return newObject;
+            }
+
+            if (!(openApiAny is OpenApiString))
+            {
+                return openApiAny;
+            }
+
+            if (type == null && format == null)
+            {
+                GetSpecificOpenApiAny(openApiAny);
+            }
+
+            var value = ((OpenApiString)openApiAny).Value;
+
+            if (value == null || value == "null")
+            {
+                return new OpenApiNull();
+            }
+
+            if (type == "integer" && format == "int32")
+            {
+                if (int.TryParse(value, out var intValue))
+                {
+                    return new OpenApiInteger(intValue);
+                }
+                else
+                {
+                    throw new OpenApiException("The value is not compatible with the given type and format.");
+                }
+            }
+
+            if (type == "integer" && format == "int64")
+            {
+                if (long.TryParse(value, out var longValue))
+                {
+                    return new OpenApiLong(longValue);
+                }
+                else
+                {
+                    throw new OpenApiException("The value is not compatible with the given type and format.");
+                }
+            }
+
+            if (type == "integer")
+            {
+                if (long.TryParse(value, out var longValue))
+                {
+                    return new OpenApiLong(longValue);
+                }
+                else
+                {
+                    throw new OpenApiException("The value is not compatible with the given type and format.");
+                }
+            }
+
+            if (type == "number" && format == "float")
+            {
+                if ( float.TryParse(value, out var floatValue))
+                {
+                    return new OpenApiFloat(floatValue);
+                }
+                else
+                {
+                    throw new OpenApiException("The value is not compatible with the given type and format.");
+                }
+            }
+
+            if (type == "number" && format == "double" )
+            {
+                if (double.TryParse(value, out var doubleValue))
+                {
+                    return new OpenApiDouble(doubleValue);
+                }
+                else
+                {
+                    throw new OpenApiException("The value is not compatible with the given type and format.");
+                }
+            }
+
+            if (type == "number")
+            {
+                if (double.TryParse(value, out var doubleValue))
+                {
+                    return new OpenApiDouble(doubleValue);
+                }
+                else
+                {
+                    throw new OpenApiException("The value is not compatible with the given type and format.");
+                }
+            }
+
+            if (type == "string" && format == "byte")
+            {
+                if ( byte.TryParse(value, out var byteValue))
+                {
+                    return new OpenApiByte(byteValue);
+                }
+                else
+                {
+                    throw new OpenApiException("The value is not compatible with the given type and format.");
+                }
+            }
+
+            // TODO: Parse byte array to OpenApiBinary type.
+
+            if (type == "string" && format == "date")
+            {
+                if (DateTime.TryParse(value, out var dateValue))
+                {
+                    return new OpenApiDate(dateValue.Date);
+                }
+                else
+                {
+                    throw new OpenApiException("The value is not compatible with the given type and format.");
+                }
+            }
+
+            if (type == "string" && format == "date-time")
+            {
+                if (DateTime.TryParse(value, out var dateTimeValue))
+                {
+                    return new OpenApiDateTime(dateTimeValue);
+                }
+                else
+                {
+                    throw new OpenApiException("The value is not compatible with the given type and format.");
+                }
+            }
+
+            if (type == "string" && format == "password")
+            {
+                return new OpenApiPassword(value);
+            }
+
+            if (type == "string")
+            {
+                return new OpenApiString(value);
+            }
+
+            if (type == "boolean")
+            {
+                if (bool.TryParse(value, out var booleanValue))
+                {
+                    return new OpenApiBoolean(booleanValue);
+                }
+                else
+                {
+                    throw new OpenApiException("The value is not compatible with the given type and format.");
+                }
+            }
+
+            throw new OpenApiException("The specified type is not supported.");
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
 using System.Linq;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Exceptions;
@@ -6,8 +9,12 @@ using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Readers.ParseNodes
 {
-    internal static class OpenApiStringConverter
+    internal static class OpenApiAnyConverter
     {
+        /// <summary>
+        /// Converts the <see cref="OpenApiString"/>s in the given <see cref="IOpenApiAny"/>
+        /// into the most specific <see cref="IOpenApiPrimitive"/> type based on the value.
+        /// </summary>
         public static IOpenApiAny GetSpecificOpenApiAny(IOpenApiAny openApiAny)
         {
             if (openApiAny is OpenApiArray openApiArray)
@@ -79,6 +86,12 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             return new OpenApiString(value);
         }
 
+        /// <summary>
+        /// Converts the <see cref="OpenApiString"/>s in the given <see cref="IOpenApiAny"/>
+        /// into the appropriate <see cref="IOpenApiPrimitive"/> type based on the given <see cref="OpenApiSchema"/>.
+        /// For those strings that the schema does not specify the type for, convert them into
+        /// the most specific type based on the value.
+        /// </summary>
         public static IOpenApiAny GetSpecificOpenApiAny(IOpenApiAny openApiAny, OpenApiSchema schema)
         {
             if (openApiAny is OpenApiArray openApiArray)

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
@@ -199,10 +199,6 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 {
                     return new OpenApiDouble(doubleValue);
                 }
-                else
-                {
-                    throw new OpenApiException("The value is not compatible with the given type and format.");
-                }
             }
 
             if (type == "number")
@@ -211,10 +207,6 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 {
                     return new OpenApiDouble(doubleValue);
                 }
-                else
-                {
-                    throw new OpenApiException("The value is not compatible with the given type and format.");
-                }
             }
 
             if (type == "string" && format == "byte")
@@ -222,10 +214,6 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 if ( byte.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var byteValue))
                 {
                     return new OpenApiByte(byteValue);
-                }
-                else
-                {
-                    throw new OpenApiException("The value is not compatible with the given type and format.");
                 }
             }
 
@@ -237,10 +225,6 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 {
                     return new OpenApiDate(dateValue.Date);
                 }
-                else
-                {
-                    throw new OpenApiException("The value is not compatible with the given type and format.");
-                }
             }
 
             if (type == "string" && format == "date-time")
@@ -248,10 +232,6 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTimeValue))
                 {
                     return new OpenApiDateTime(dateTimeValue);
-                }
-                else
-                {
-                    throw new OpenApiException("The value is not compatible with the given type and format.");
                 }
             }
 
@@ -271,13 +251,12 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 {
                     return new OpenApiBoolean(booleanValue);
                 }
-                else
-                {
-                    throw new OpenApiException("The value is not compatible with the given type and format.");
-                }
             }
 
-            throw new OpenApiException("The specified type is not supported.");
+            // If data conflicts with the given type, return a string.
+            // This converter is used in the parser, so it does not perform any validations, 
+            // but the validator can be used to validate whether the data and given type conflicts.
+            return new OpenApiString(value);
         }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
@@ -151,10 +151,6 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 {
                     return new OpenApiInteger(intValue);
                 }
-                else
-                {
-                    throw new OpenApiException("The value is not compatible with the given type and format.");
-                }
             }
 
             if (type == "integer" && format == "int64")
@@ -162,10 +158,6 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue))
                 {
                     return new OpenApiLong(longValue);
-                }
-                else
-                {
-                    throw new OpenApiException("The value is not compatible with the given type and format.");
                 }
             }
 
@@ -175,10 +167,6 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 {
                     return new OpenApiInteger(intValue);
                 }
-                else
-                {
-                    throw new OpenApiException("The value is not compatible with the given type and format.");
-                }
             }
 
             if (type == "number" && format == "float")
@@ -186,10 +174,6 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 if (float.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var floatValue))
                 {
                     return new OpenApiFloat(floatValue);
-                }
-                else
-                {
-                    throw new OpenApiException("The value is not compatible with the given type and format.");
                 }
             }
 

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
@@ -170,9 +170,9 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
             if (type == "integer")
             {
-                if (long.TryParse(value, out var longValue))
+                if (int.TryParse(value, out var intValue))
                 {
-                    return new OpenApiLong(longValue);
+                    return new OpenApiInteger(intValue);
                 }
                 else
                 {

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System;
+using System.Globalization;
 using System.Linq;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Exceptions;
@@ -62,22 +63,22 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 return new OpenApiBoolean(false);
             }
 
-            if (int.TryParse(value, out var intValue))
+            if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
             {
                 return new OpenApiInteger(intValue);
             }
 
-            if (long.TryParse(value, out var longValue))
+            if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue))
             {
                 return new OpenApiLong(longValue);
             }
 
-            if (double.TryParse(value, out var doubleValue))
+            if (double.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var doubleValue))
             {
                 return new OpenApiDouble(doubleValue);
             }
 
-            if (DateTimeOffset.TryParse(value, out var dateTimeValue))
+            if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTimeValue))
             {
                 return new OpenApiDateTime(dateTimeValue);
             }
@@ -146,7 +147,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
             if (type == "integer" && format == "int32")
             {
-                if (int.TryParse(value, out var intValue))
+                if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
                 {
                     return new OpenApiInteger(intValue);
                 }
@@ -158,7 +159,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
             if (type == "integer" && format == "int64")
             {
-                if (long.TryParse(value, out var longValue))
+                if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue))
                 {
                     return new OpenApiLong(longValue);
                 }
@@ -170,7 +171,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
             if (type == "integer")
             {
-                if (int.TryParse(value, out var intValue))
+                if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
                 {
                     return new OpenApiInteger(intValue);
                 }
@@ -182,7 +183,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
             if (type == "number" && format == "float")
             {
-                if ( float.TryParse(value, out var floatValue))
+                if (float.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var floatValue))
                 {
                     return new OpenApiFloat(floatValue);
                 }
@@ -194,7 +195,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
             if (type == "number" && format == "double" )
             {
-                if (double.TryParse(value, out var doubleValue))
+                if (double.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var doubleValue))
                 {
                     return new OpenApiDouble(doubleValue);
                 }
@@ -206,7 +207,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
             if (type == "number")
             {
-                if (double.TryParse(value, out var doubleValue))
+                if (double.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var doubleValue))
                 {
                     return new OpenApiDouble(doubleValue);
                 }
@@ -218,7 +219,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
             if (type == "string" && format == "byte")
             {
-                if ( byte.TryParse(value, out var byteValue))
+                if ( byte.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var byteValue))
                 {
                     return new OpenApiByte(byteValue);
                 }
@@ -232,7 +233,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
             if (type == "string" && format == "date")
             {
-                if (DateTime.TryParse(value, out var dateValue))
+                if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateValue))
                 {
                     return new OpenApiDate(dateValue.Date);
                 }
@@ -244,7 +245,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
             if (type == "string" && format == "date-time")
             {
-                if (DateTime.TryParse(value, out var dateTimeValue))
+                if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTimeValue))
                 {
                     return new OpenApiDateTime(dateTimeValue);
                 }

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/ValueNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/ValueNode.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Readers.Exceptions;
 using SharpYaml.Serialization;
 
@@ -27,7 +26,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
         public override string GetScalarValue()
         {
             return _node.Value;
-       }
+        }
 
         /// <summary>
         /// Create a <see cref="IOpenApiPrimitive"/>
@@ -36,47 +35,6 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
         public override IOpenApiAny CreateAny()
         {
             var value = GetScalarValue();
-
-            if (value == null || value == "null")
-            {
-                return new OpenApiNull();
-            }
-
-            if (value == "true")
-            {
-                return new OpenApiBoolean(true);
-            }
-
-            if (value == "false")
-            {
-                return new OpenApiBoolean(false);
-            }
-
-            if (int.TryParse(value, out var intValue))
-            {
-                return new OpenApiInteger(intValue);
-            }
-
-            if (long.TryParse(value, out var longValue))
-            {
-                return
-                    new OpenApiLong(
-                        longValue); 
-            }
-
-            if (double.TryParse(value, out var dblValue))
-            {
-                return
-                    new OpenApiDouble(
-                        dblValue); // Note(darrmi): This may be better as decimal. Further investigation required.
-            }
-
-            if (DateTimeOffset.TryParse(value, out var datetimeValue))
-            {
-                return new OpenApiDateTime(datetimeValue);
-            }
-
-            // if we can't identify the type of value, return it as string.
             return new OpenApiString(value);
         }
     }

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
@@ -134,6 +134,31 @@ namespace Microsoft.OpenApi.Readers.V2
             {s => s.StartsWith("x-"), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
         };
 
+        private static readonly AnyFieldMap<OpenApiHeader> _headerAnyFields =
+            new AnyFieldMap<OpenApiHeader>
+            {
+                {
+                    "default",
+                    new AnyFieldMapParameter<OpenApiHeader>(
+                        p => p.Schema.Default,
+                        (p, v) => p.Schema.Default = v,
+                        p => p.Schema)
+                }
+            };
+
+        private static readonly AnyListFieldMap<OpenApiHeader> _headerAnyListFields =
+            new AnyListFieldMap<OpenApiHeader>
+            {
+                {
+                    "enum",
+                    new AnyListFieldMapParameter<OpenApiHeader>(
+                        p => p.Schema.Enum,
+                        (p, v) => p.Schema.Enum = v,
+                        p => p.Schema)
+                },
+            };
+
+
         public static OpenApiHeader LoadHeader(ParseNode node)
         {
             var mapNode = node.CheckMapNode("header");
@@ -149,6 +174,9 @@ namespace Microsoft.OpenApi.Readers.V2
                 header.Schema = schema;
                 node.Context.SetTempStorage("schema", null);
             }
+
+            ProcessAnyFields(mapNode, header, _headerAnyFields);
+            ProcessAnyListFields(mapNode, header, _headerAnyListFields);
 
             return header;
         }

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.Exceptions;
@@ -157,7 +156,6 @@ namespace Microsoft.OpenApi.Readers.V2
                         p => p.Schema)
                 },
             };
-
 
         public static OpenApiHeader LoadHeader(ParseNode node)
         {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
@@ -137,7 +137,7 @@ namespace Microsoft.OpenApi.Readers.V2
             new AnyFieldMap<OpenApiHeader>
             {
                 {
-                    "default",
+                    OpenApiConstants.Default,
                     new AnyFieldMapParameter<OpenApiHeader>(
                         p => p.Schema.Default,
                         (p, v) => p.Schema.Default = v,
@@ -149,7 +149,7 @@ namespace Microsoft.OpenApi.Readers.V2
             new AnyListFieldMap<OpenApiHeader>
             {
                 {
-                    "enum",
+                    OpenApiConstants.Enum,
                     new AnyListFieldMapParameter<OpenApiHeader>(
                         p => p.Schema.Enum,
                         (p, v) => p.Schema.Enum = v,

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
@@ -147,7 +147,7 @@ namespace Microsoft.OpenApi.Readers.V2
             new AnyFieldMap<OpenApiParameter>
             {
                 {
-                    "default",
+                    OpenApiConstants.Default,
                     new AnyFieldMapParameter<OpenApiParameter>(
                         p => p.Schema.Default,
                         (p, v) => p.Schema.Default = v,
@@ -159,7 +159,7 @@ namespace Microsoft.OpenApi.Readers.V2
             new AnyListFieldMap<OpenApiParameter>
             {
                 {
-                    "enum",
+                    OpenApiConstants.Enum,
                     new AnyListFieldMapParameter<OpenApiParameter>(
                         p => p.Schema.Enum,
                         (p, v) => p.Schema.Enum = v,

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
@@ -59,12 +59,6 @@ namespace Microsoft.OpenApi.Readers.V2
                     }
                 },
                 {
-                    "example", (o, n) =>
-                    {
-                        o.Example = n.CreateAny();
-                    }
-                },
-                {
                     "type", (o, n) =>
                     {
                         GetOrCreateSchema(o).Type = n.GetScalarValue();
@@ -148,6 +142,30 @@ namespace Microsoft.OpenApi.Readers.V2
             new PatternFieldMap<OpenApiParameter>
             {
                 {s => s.StartsWith("x-"), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
+            };
+
+        private static readonly AnyFieldMap<OpenApiParameter> _parameterAnyFields =
+            new AnyFieldMap<OpenApiParameter>
+            {
+                {
+                    "default",
+                    new AnyFieldMapParameter<OpenApiParameter>(
+                        p => p.Schema.Default,
+                        (p, v) => p.Schema.Default = v,
+                        p => p.Schema)
+                }
+            };
+
+        private static readonly AnyListFieldMap<OpenApiParameter> _parameterAnyListFields =
+            new AnyListFieldMap<OpenApiParameter>
+            {
+                {
+                    "enum",
+                    new AnyListFieldMapParameter<OpenApiParameter>(
+                        p => p.Schema.Enum,
+                        (p, v) => p.Schema.Enum = v,
+                        p => p.Schema)
+                },
             };
 
         private static void LoadStyle(OpenApiParameter p, string v)
@@ -242,10 +260,13 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 return mapNode.GetReferencedObject<OpenApiParameter>(ReferenceType.Parameter, pointer);
             }
-            
+
             var parameter = new OpenApiParameter();
 
             ParseMap(mapNode, parameter, _parameterFixedFields, _parameterPatternFields);
+
+            ProcessAnyFields(mapNode, parameter, _parameterAnyFields);
+            ProcessAnyListFields(mapNode, parameter, _parameterAnyListFields);
 
             var schema = node.Context.GetFromTempStorage<OpenApiSchema>("schema");
             if (schema != null)

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
@@ -83,7 +83,7 @@ namespace Microsoft.OpenApi.Readers.V2
 
         private static void LoadExample(OpenApiResponse response, string mediaType, ParseNode node)
         {
-            var exampleNode = OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny());
+            var exampleNode = OpenApiAnyConverter.GetSpecificOpenApiAny(node.CreateAny());
 
             if (response.Content == null)
             {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
@@ -83,7 +83,7 @@ namespace Microsoft.OpenApi.Readers.V2
 
         private static void LoadExample(OpenApiResponse response, string mediaType, ParseNode node)
         {
-            var exampleNode = node.CreateAny();
+            var exampleNode = OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny());
 
             if (response.Content == null)
             {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
@@ -48,6 +48,19 @@ namespace Microsoft.OpenApi.Readers.V2
                 {s => s.StartsWith("x-"), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
             };
 
+        private static readonly AnyMapFieldMap<OpenApiMediaType, OpenApiExample> _mediaTypeAnyMapOpenApiExampleFields =
+            new AnyMapFieldMap<OpenApiMediaType, OpenApiExample>
+        {
+            {
+                OpenApiConstants.Examples,
+                new AnyMapFieldMapParameter<OpenApiMediaType, OpenApiExample>(
+                    m => m.Examples,
+                    e => e.Value,
+                    (e, v) => e.Value = v,
+                    m => m.Schema)
+            }
+        };
+
         private static void ProcessProduces(OpenApiResponse response, ParsingContext context)
         {
             var produces = context.GetFromTempStorage<List<string>>(TempStorageKeys.OperationProduces) ??
@@ -121,6 +134,11 @@ namespace Microsoft.OpenApi.Readers.V2
             }
 
             ProcessProduces(response, node.Context);
+
+            foreach( var mediaType in response.Content.Values)
+            {
+                ProcessAnyMapFields(mapNode, mediaType, _mediaTypeAnyMapOpenApiExampleFields);
+            }
 
             return response;
         }

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
@@ -211,13 +211,30 @@ namespace Microsoft.OpenApi.Readers.V2
 
         private static readonly AnyFieldMap<OpenApiSchema> _schemaAnyFields = new AnyFieldMap<OpenApiSchema>
         {
-            { "default", new AnyFieldMapParameter<OpenApiSchema>(s => s.Default, (s, v) => s.Default = v, s => s) },
-            { "example", new AnyFieldMapParameter<OpenApiSchema>(s => s.Example, (s, v) => s.Example = v, s => s) }
+            {
+                OpenApiConstants.Default,
+                new AnyFieldMapParameter<OpenApiSchema>(
+                    s => s.Default, 
+                    (s, v) => s.Default = v, 
+                    s => s)
+            },
+            {
+                OpenApiConstants.Example,
+                new AnyFieldMapParameter<OpenApiSchema>(
+                    s => s.Example, 
+                    (s, v) => s.Example = v, 
+                    s => s) }
         };
 
         private static readonly AnyListFieldMap<OpenApiSchema> _schemaAnyListFields = new AnyListFieldMap<OpenApiSchema>
         {
-            { "enum", new AnyListFieldMapParameter<OpenApiSchema>(s => s.Enum, (s, v) => s.Enum = v, s => s) }
+            {
+                OpenApiConstants.Enum,
+                new AnyListFieldMapParameter<OpenApiSchema>(
+                    s => s.Enum, 
+                    (s, v) => s.Enum = v, 
+                    s => s)
+            }
         };
 
         public static OpenApiSchema LoadSchema(ParseNode node)

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Any;
@@ -48,7 +47,7 @@ namespace Microsoft.OpenApi.Readers.V2
                 {
                     mapNode.Context.StartObject(anyFieldName);
 
-                    var convertedOpenApiAny = OpenApiStringConverter.GetSpecificOpenApiAny(
+                    var convertedOpenApiAny = OpenApiAnyConverter.GetSpecificOpenApiAny(
                         anyFieldMap[anyFieldName].PropertyGetter(domainObject),
                         anyFieldMap[anyFieldName].SchemaGetter(domainObject));
 
@@ -82,7 +81,7 @@ namespace Microsoft.OpenApi.Readers.V2
                     foreach (var propertyElement in anyListFieldMap[anyListFieldName].PropertyGetter(domainObject))
                     {
                         newProperty.Add(
-                            OpenApiStringConverter.GetSpecificOpenApiAny(
+                            OpenApiAnyConverter.GetSpecificOpenApiAny(
                                 propertyElement,
                                 anyListFieldMap[anyListFieldName].SchemaGetter(domainObject)));
                     }
@@ -103,7 +102,7 @@ namespace Microsoft.OpenApi.Readers.V2
 
         public static IOpenApiAny LoadAny(ParseNode node)
         {
-            return OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny());
+            return OpenApiAnyConverter.GetSpecificOpenApiAny(node.CreateAny());
         }
 
         private static IOpenApiExtension LoadExtension(string name, ParseNode node)
@@ -111,12 +110,12 @@ namespace Microsoft.OpenApi.Readers.V2
             if (node.Context.ExtensionParsers.TryGetValue(name, out var parser))
             {
                 return parser(
-                    OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny()),
+                    OpenApiAnyConverter.GetSpecificOpenApiAny(node.CreateAny()),
                     OpenApiSpecVersion.OpenApi2_0);
             }
             else
             {
-                return OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny());
+                return OpenApiAnyConverter.GetSpecificOpenApiAny(node.CreateAny());
             }
         }
 

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
 
 namespace Microsoft.OpenApi.Readers.V2
@@ -34,6 +37,70 @@ namespace Microsoft.OpenApi.Readers.V2
             }
         }
 
+        private static void ProcessAnyFields<T>(
+            MapNode mapNode,
+            T domainObject,
+            AnyFieldMap<T> anyFieldMap)
+        {
+            foreach (var anyFieldName in anyFieldMap.Keys.ToList())
+            {
+                try
+                {
+                    mapNode.Context.StartObject(anyFieldName);
+
+                    var convertedOpenApiAny = OpenApiStringConverter.GetSpecificOpenApiAny(
+                        anyFieldMap[anyFieldName].PropertyGetter(domainObject),
+                        anyFieldMap[anyFieldName].SchemaGetter(domainObject));
+
+                    anyFieldMap[anyFieldName].PropertySetter(domainObject, convertedOpenApiAny);
+                }
+                catch (OpenApiException exception)
+                {
+                    exception.Pointer = mapNode.Context.GetLocation();
+                    mapNode.Diagnostic.Errors.Add(new OpenApiError(exception));
+                }
+                finally
+                {
+                    mapNode.Context.EndObject();
+                }
+            }
+        }
+
+        private static void ProcessAnyListFields<T>(
+            MapNode mapNode,
+            T domainObject,
+            AnyListFieldMap<T> anyListFieldMap)
+        {
+            foreach (var anyListFieldName in anyListFieldMap.Keys.ToList())
+            {
+                try
+                {
+                    var newProperty = new List<IOpenApiAny>();
+
+                    mapNode.Context.StartObject(anyListFieldName);
+
+                    foreach (var propertyElement in anyListFieldMap[anyListFieldName].PropertyGetter(domainObject))
+                    {
+                        newProperty.Add(
+                            OpenApiStringConverter.GetSpecificOpenApiAny(
+                                propertyElement,
+                                anyListFieldMap[anyListFieldName].SchemaGetter(domainObject)));
+                    }
+
+                    anyListFieldMap[anyListFieldName].PropertySetter(domainObject, newProperty);
+                }
+                catch (OpenApiException exception)
+                {
+                    exception.Pointer = mapNode.Context.GetLocation();
+                    mapNode.Diagnostic.Errors.Add(new OpenApiError(exception));
+                }
+                finally
+                {
+                    mapNode.Context.EndObject();
+                }
+            }
+        }
+
         public static IOpenApiAny LoadAny(ParseNode node)
         {
             return node.CreateAny();
@@ -43,11 +110,13 @@ namespace Microsoft.OpenApi.Readers.V2
         {
             if (node.Context.ExtensionParsers.TryGetValue(name, out var parser))
             {
-                return parser(node.CreateAny(), OpenApiSpecVersion.OpenApi2_0);
+                return parser(
+                    OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny()),
+                    OpenApiSpecVersion.OpenApi2_0);
             }
             else
             {
-                return node.CreateAny();
+                return OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny());
             }
         }
 

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
@@ -103,7 +103,7 @@ namespace Microsoft.OpenApi.Readers.V2
 
         public static IOpenApiAny LoadAny(ParseNode node)
         {
-            return node.CreateAny();
+            return OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny());
         }
 
         private static IOpenApiExtension LoadExtension(string name, ParseNode node)

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiMediaTypeDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiMediaTypeDeserializer.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
@@ -60,6 +63,20 @@ namespace Microsoft.OpenApi.Readers.V3
             }
         };
 
+
+        private static readonly AnyMapFieldMap<OpenApiMediaType, OpenApiExample> _mediaTypeAnyMapOpenApiExampleFields = 
+            new AnyMapFieldMap<OpenApiMediaType, OpenApiExample>
+        {
+            {
+                OpenApiConstants.Examples,
+                new AnyMapFieldMapParameter<OpenApiMediaType, OpenApiExample>(
+                    m => m.Examples,
+                    e => e.Value,
+                    (e, v) => e.Value = v,
+                    m => m.Schema)
+            }
+        };
+
         public static OpenApiMediaType LoadMediaType(ParseNode node)
         {
             var mapNode = node.CheckMapNode(OpenApiConstants.Content);
@@ -74,6 +91,7 @@ namespace Microsoft.OpenApi.Readers.V3
             ParseMap(mapNode, mediaType, _mediaTypeFixedFields, _mediaTypePatternFields);
 
             ProcessAnyFields(mapNode, mediaType, _mediaTypeAnyFields);
+            ProcessAnyMapFields(mapNode, mediaType, _mediaTypeAnyMapOpenApiExampleFields);
 
             return mediaType;
         }

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiMediaTypeDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiMediaTypeDeserializer.cs
@@ -49,6 +49,17 @@ namespace Microsoft.OpenApi.Readers.V3
                 {s => s.StartsWith("x-"), (o, p, n) => o.AddExtension(p, LoadExtension(p,n))}
             };
 
+        private static readonly AnyFieldMap<OpenApiMediaType> _mediaTypeAnyFields = new AnyFieldMap<OpenApiMediaType>
+        {
+            {
+                OpenApiConstants.Example,
+                new AnyFieldMapParameter<OpenApiMediaType>(
+                    s => s.Example,
+                    (s, v) => s.Example = v,
+                    s => s.Schema)
+            }
+        };
+
         public static OpenApiMediaType LoadMediaType(ParseNode node)
         {
             var mapNode = node.CheckMapNode(OpenApiConstants.Content);
@@ -61,6 +72,8 @@ namespace Microsoft.OpenApi.Readers.V3
             var mediaType = new OpenApiMediaType();
 
             ParseMap(mapNode, mediaType, _mediaTypeFixedFields, _mediaTypePatternFields);
+
+            ProcessAnyFields(mapNode, mediaType, _mediaTypeAnyFields);
 
             return mediaType;
         }

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiParameterDeserializer.cs
@@ -126,6 +126,19 @@ namespace Microsoft.OpenApi.Readers.V3
             }
         };
 
+        private static readonly AnyMapFieldMap<OpenApiParameter, OpenApiExample> _parameterAnyMapOpenApiExampleFields =
+            new AnyMapFieldMap<OpenApiParameter, OpenApiExample>
+        {
+            {
+                OpenApiConstants.Examples,
+                new AnyMapFieldMapParameter<OpenApiParameter, OpenApiExample>(
+                    m => m.Examples,
+                    e => e.Value,
+                    (e, v) => e.Value = v,
+                    m => m.Schema)
+            }
+        };
+
         public static OpenApiParameter LoadParameter(ParseNode node)
         {
             var mapNode = node.CheckMapNode("parameter");
@@ -140,6 +153,7 @@ namespace Microsoft.OpenApi.Readers.V3
 
             ParseMap(mapNode, parameter, _parameterFixedFields, _parameterPatternFields);
             ProcessAnyFields(mapNode, parameter, _parameterAnyFields);
+            ProcessAnyMapFields(mapNode, parameter, _parameterAnyMapOpenApiExampleFields);
 
             return parameter;
         }

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiParameterDeserializer.cs
@@ -115,6 +115,17 @@ namespace Microsoft.OpenApi.Readers.V3
                 {s => s.StartsWith("x-"), (o, p, n) => o.AddExtension(p, LoadExtension(p,n))}
             };
 
+        private static readonly AnyFieldMap<OpenApiParameter> _parameterAnyFields = new AnyFieldMap<OpenApiParameter>
+        {
+            {
+                OpenApiConstants.Example,
+                new AnyFieldMapParameter<OpenApiParameter>(
+                    s => s.Example,
+                    (s, v) => s.Example = v,
+                    s => s.Schema)
+            }
+        };
+
         public static OpenApiParameter LoadParameter(ParseNode node)
         {
             var mapNode = node.CheckMapNode("parameter");
@@ -128,6 +139,7 @@ namespace Microsoft.OpenApi.Readers.V3
             var parameter = new OpenApiParameter();
 
             ParseMap(mapNode, parameter, _parameterFixedFields, _parameterPatternFields);
+            ProcessAnyFields(mapNode, parameter, _parameterAnyFields);
 
             return parameter;
         }

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -246,14 +246,14 @@ namespace Microsoft.OpenApi.Readers.V3
         private static readonly AnyFieldMap<OpenApiSchema> _schemaAnyFields = new AnyFieldMap<OpenApiSchema>
         {
             {
-                "default",
+                OpenApiConstants.Default,
                 new AnyFieldMapParameter<OpenApiSchema>(
                     s => s.Default,
                     (s, v) => s.Default = v,
                     s => s)
             },
             {
-                "example",
+                 OpenApiConstants.Example,
                 new AnyFieldMapParameter<OpenApiSchema>(
                     s => s.Example, 
                     (s, v) => s.Example = v, 
@@ -263,7 +263,13 @@ namespace Microsoft.OpenApi.Readers.V3
 
         private static readonly AnyListFieldMap<OpenApiSchema> _schemaAnyListFields = new AnyListFieldMap<OpenApiSchema>
         {
-            { "enum", new AnyListFieldMapParameter<OpenApiSchema>(s => s.Enum, (s, v) => s.Enum = v, s => s) }
+            {
+                OpenApiConstants.Enum,
+                new AnyListFieldMapParameter<OpenApiSchema>(
+                    s => s.Enum, 
+                    (s, v) => s.Enum = v,
+                    s => s)
+            }
         };
 
         public static OpenApiSchema LoadSchema(ParseNode node)

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -243,6 +243,17 @@ namespace Microsoft.OpenApi.Readers.V3
             {s => s.StartsWith("x-"), (o, p, n) => o.AddExtension(p, LoadExtension(p,n))}
         };
 
+        private static readonly AnyFieldMap<OpenApiSchema> _schemaAnyFields = new AnyFieldMap<OpenApiSchema>
+        {
+            { "default", new AnyFieldMapParameter<OpenApiSchema>(s => s.Default, (s, v) => s.Default = v, s => s) },
+            { "example", new AnyFieldMapParameter<OpenApiSchema>(s => s.Example, (s, v) => s.Example = v, s => s) }
+        };
+
+        private static readonly AnyListFieldMap<OpenApiSchema> _schemaAnyListFields = new AnyListFieldMap<OpenApiSchema>
+        {
+            { "enum", new AnyListFieldMapParameter<OpenApiSchema>(s => s.Enum, (s, v) => s.Enum = v, s => s) }
+        };
+
         public static OpenApiSchema LoadSchema(ParseNode node)
         {
             var mapNode = node.CheckMapNode(OpenApiConstants.Schema);

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -269,17 +269,17 @@ namespace Microsoft.OpenApi.Readers.V3
                     };
             }
 
-            var domainObject = new OpenApiSchema();
+            var schema = new OpenApiSchema();
 
             foreach (var propertyNode in mapNode)
             {
-                propertyNode.ParseField(domainObject, _schemaFixedFields, _schemaPatternFields);
+                propertyNode.ParseField(schema, _schemaFixedFields, _schemaPatternFields);
             }
 
-            ProcessAnyFields(mapNode, domainObject, _schemaAnyFields);
-            ProcessAnyListFields(mapNode, domainObject, _schemaAnyListFields);
+            ProcessAnyFields(mapNode, schema, _schemaAnyFields);
+            ProcessAnyListFields(mapNode, schema, _schemaAnyListFields);
 
-            return domainObject;
+            return schema;
         }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -276,6 +276,9 @@ namespace Microsoft.OpenApi.Readers.V3
                 propertyNode.ParseField(domainObject, _schemaFixedFields, _schemaPatternFields);
             }
 
+            ProcessAnyFields(mapNode, domainObject, _schemaAnyFields);
+            ProcessAnyListFields(mapNode, domainObject, _schemaAnyListFields);
+
             return domainObject;
         }
     }

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -245,8 +245,20 @@ namespace Microsoft.OpenApi.Readers.V3
 
         private static readonly AnyFieldMap<OpenApiSchema> _schemaAnyFields = new AnyFieldMap<OpenApiSchema>
         {
-            { "default", new AnyFieldMapParameter<OpenApiSchema>(s => s.Default, (s, v) => s.Default = v, s => s) },
-            { "example", new AnyFieldMapParameter<OpenApiSchema>(s => s.Example, (s, v) => s.Example = v, s => s) }
+            {
+                "default",
+                new AnyFieldMapParameter<OpenApiSchema>(
+                    s => s.Default,
+                    (s, v) => s.Default = v,
+                    s => s)
+            },
+            {
+                "example",
+                new AnyFieldMapParameter<OpenApiSchema>(
+                    s => s.Example, 
+                    (s, v) => s.Example = v, 
+                    s => s)
+            }
         };
 
         private static readonly AnyListFieldMap<OpenApiSchema> _schemaAnyListFields = new AnyListFieldMap<OpenApiSchema>

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiV3Deserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiV3Deserializer.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Expressions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
@@ -35,6 +36,70 @@ namespace Microsoft.OpenApi.Readers.V3
 
         }
 
+        private static void ProcessAnyFields<T>(
+            MapNode mapNode,
+            T domainObject,
+            AnyFieldMap<T> anyFieldMap)
+        {
+            foreach (var anyFieldName in anyFieldMap.Keys.ToList())
+            {
+                try
+                {
+                    mapNode.Context.StartObject(anyFieldName);
+
+                    var convertedOpenApiAny = OpenApiStringConverter.GetSpecificOpenApiAny(
+                        anyFieldMap[anyFieldName].PropertyGetter(domainObject),
+                        anyFieldMap[anyFieldName].SchemaGetter(domainObject));
+
+                    anyFieldMap[anyFieldName].PropertySetter(domainObject, convertedOpenApiAny);
+                }
+                catch (OpenApiException exception)
+                {
+                    exception.Pointer = mapNode.Context.GetLocation();
+                    mapNode.Diagnostic.Errors.Add(new OpenApiError(exception));
+                }
+                finally
+                {
+                    mapNode.Context.EndObject();
+                }
+            }
+        }
+
+        private static void ProcessAnyListFields<T>(
+            MapNode mapNode,
+            T domainObject,
+            AnyListFieldMap<T> anyListFieldMap)
+        {
+            foreach (var anyListFieldName in anyListFieldMap.Keys.ToList())
+            {
+                try
+                {
+                    var newProperty = new List<IOpenApiAny>();
+
+                    mapNode.Context.StartObject(anyListFieldName);
+
+                    foreach (var propertyElement in anyListFieldMap[anyListFieldName].PropertyGetter(domainObject))
+                    {
+                        newProperty.Add(
+                            OpenApiStringConverter.GetSpecificOpenApiAny(
+                                propertyElement,
+                                anyListFieldMap[anyListFieldName].SchemaGetter(domainObject)));
+                    }
+
+                    anyListFieldMap[anyListFieldName].PropertySetter(domainObject, newProperty);
+                }
+                catch (OpenApiException exception)
+                {
+                    exception.Pointer = mapNode.Context.GetLocation();
+                    mapNode.Diagnostic.Errors.Add(new OpenApiError(exception));
+                }
+                finally
+                {
+                    mapNode.Context.EndObject();
+                }
+            }
+        }
+
         private static RuntimeExpression LoadRuntimeExpression(ParseNode node)
         {
             var value = node.GetScalarValue();
@@ -55,7 +120,7 @@ namespace Microsoft.OpenApi.Readers.V3
 
             return new RuntimeExpressionAnyWrapper
             {
-                Any = node.CreateAny()
+                Any = OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny())
             };
         }
 
@@ -68,11 +133,13 @@ namespace Microsoft.OpenApi.Readers.V3
         {
             if (node.Context.ExtensionParsers.TryGetValue(name, out var parser))
             {
-                return parser(node.CreateAny(), OpenApiSpecVersion.OpenApi3_0);
+                return parser(
+                    OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny()),
+                    OpenApiSpecVersion.OpenApi3_0);
             }
             else
             {
-                return node.CreateAny();
+                return OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny());
             }
         }
 

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiV3Deserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiV3Deserializer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.OpenApi.Readers.V3
                 {
                     mapNode.Context.StartObject(anyFieldName);
 
-                    var convertedOpenApiAny = OpenApiStringConverter.GetSpecificOpenApiAny(
+                    var convertedOpenApiAny = OpenApiAnyConverter.GetSpecificOpenApiAny(
                         anyFieldMap[anyFieldName].PropertyGetter(domainObject),
                         anyFieldMap[anyFieldName].SchemaGetter(domainObject));
 
@@ -81,7 +81,7 @@ namespace Microsoft.OpenApi.Readers.V3
                     foreach (var propertyElement in anyListFieldMap[anyListFieldName].PropertyGetter(domainObject))
                     {
                         newProperty.Add(
-                            OpenApiStringConverter.GetSpecificOpenApiAny(
+                            OpenApiAnyConverter.GetSpecificOpenApiAny(
                                 propertyElement,
                                 anyListFieldMap[anyListFieldName].SchemaGetter(domainObject)));
                     }
@@ -120,13 +120,13 @@ namespace Microsoft.OpenApi.Readers.V3
 
             return new RuntimeExpressionAnyWrapper
             {
-                Any = OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny())
+                Any = OpenApiAnyConverter.GetSpecificOpenApiAny(node.CreateAny())
             };
         }
 
         public static IOpenApiAny LoadAny(ParseNode node)
         {
-            return OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny());
+            return OpenApiAnyConverter.GetSpecificOpenApiAny(node.CreateAny());
         }
 
         private static IOpenApiExtension LoadExtension(string name, ParseNode node)
@@ -134,12 +134,12 @@ namespace Microsoft.OpenApi.Readers.V3
             if (node.Context.ExtensionParsers.TryGetValue(name, out var parser))
             {
                 return parser(
-                    OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny()),
+                    OpenApiAnyConverter.GetSpecificOpenApiAny(node.CreateAny()),
                     OpenApiSpecVersion.OpenApi3_0);
             }
             else
             {
-                return OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny());
+                return OpenApiAnyConverter.GetSpecificOpenApiAny(node.CreateAny());
             }
         }
 

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiV3Deserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiV3Deserializer.cs
@@ -126,7 +126,7 @@ namespace Microsoft.OpenApi.Readers.V3
 
         public static IOpenApiAny LoadAny(ParseNode node)
         {
-            return node.CreateAny();
+            return OpenApiStringConverter.GetSpecificOpenApiAny(node.CreateAny());
         }
 
         private static IOpenApiExtension LoadExtension(string name, ParseNode node)

--- a/src/Microsoft.OpenApi/Validations/IValidationContext.cs
+++ b/src/Microsoft.OpenApi/Validations/IValidationContext.cs
@@ -1,13 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Services;
-using Microsoft.OpenApi.Validations.Rules;
-
 namespace Microsoft.OpenApi.Validations
 {
     /// <summary>
@@ -20,7 +13,6 @@ namespace Microsoft.OpenApi.Validations
         /// </summary>
         /// <param name="error">Error to register.</param>
         void AddError(OpenApiValidatorError error);
-
 
         /// <summary>
         /// Allow Rule to indicate validation error occured at a deeper context level.  

--- a/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
+++ b/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
@@ -84,6 +84,12 @@ namespace Microsoft.OpenApi.Validations
         public override void Visit(OpenApiResponse item) => Validate(item);
 
         /// <summary>
+        /// Execute validation rules against an <see cref="OpenApiMediaType"/>
+        /// </summary>
+        /// <param name="item">The object to be validated</param>
+        public override void Visit(OpenApiMediaType item) => Validate(item);
+
+        /// <summary>
         /// Execute validation rules against an <see cref="OpenApiResponses"/>
         /// </summary>
         /// <param name="item">The object to be validated</param>

--- a/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
+++ b/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
@@ -78,6 +78,12 @@ namespace Microsoft.OpenApi.Validations
         public override void Visit(OpenApiComponents item) => Validate(item);
 
         /// <summary>
+        /// Execute validation rules against an <see cref="OpenApiHeader"/>
+        /// </summary>
+        /// <param name="item">The object to be validated</param>
+        public override void Visit(OpenApiHeader item) => Validate(item);
+
+        /// <summary>
         /// Execute validation rules against an <see cref="OpenApiResponse"/>
         /// </summary>
         /// <param name="item">The object to be validated</param>

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiHeaderRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiHeaderRules.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiHeader"/>.
+    /// </summary>
+    [OpenApiRule]
+    public static class OpenApiHeaderRules
+    {
+        /// <summary>
+        /// Validate the data matches with the given data type.
+        /// </summary>
+        public static ValidationRule<OpenApiHeader> HeaderMismatchedDataType =>
+            new ValidationRule<OpenApiHeader>(
+                (context, header) =>
+                {
+                    // example
+                    context.Enter("example");
+
+                    if (header.Example != null)
+                    {
+                        RuleHelpers.ValidateDataTypeMismatch(context, nameof(HeaderMismatchedDataType), header.Example, header.Schema);
+                    }
+
+                    context.Exit();
+
+
+                    // examples
+                    context.Enter("examples");
+
+                    if (header.Examples != null)
+                    {
+                        foreach (var key in header.Examples.Keys)
+                        {
+                            if (header.Examples[key] != null)
+                            {
+                                context.Enter(key);
+                                context.Enter("value");
+                                RuleHelpers.ValidateDataTypeMismatch(context, nameof(HeaderMismatchedDataType), header.Examples[key]?.Value, header.Schema);
+                                context.Exit();
+                                context.Exit();
+                            }
+                        }
+                    }
+
+                    context.Exit();
+                });
+
+        // add more rule.
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiHeaderRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiHeaderRules.cs
@@ -30,7 +30,6 @@ namespace Microsoft.OpenApi.Validations.Rules
 
                     context.Exit();
 
-
                     // examples
                     context.Enter("examples");
 

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiMediaTypeRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiMediaTypeRules.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiMediaType"/>.
+    /// </summary>
+    [OpenApiRule]
+    public static class OpenApiMediaTypeRules
+    {
+        /// <summary>
+        /// Validate the data matches with the given data type.
+        /// </summary>
+        public static ValidationRule<OpenApiMediaType> MediaTypeMismatchedDataType =>
+            new ValidationRule<OpenApiMediaType>(
+                (context, mediaType) =>
+                {
+                    // example
+                    context.Enter("example");
+
+                    if (mediaType.Example != null)
+                    {
+                        RuleHelpers.ValidateDataTypeMismatch(context, nameof(MediaTypeMismatchedDataType), mediaType.Example, mediaType.Schema);
+                    }
+
+                    context.Exit();
+
+
+                    // enum
+                    context.Enter("examples");
+
+                    if (mediaType.Examples != null)
+                    {
+                        foreach (var key in mediaType.Examples.Keys)
+                        {
+                            if (mediaType.Examples[key] != null)
+                            {
+                                context.Enter(key);
+                                context.Enter("value");
+                                RuleHelpers.ValidateDataTypeMismatch(context, nameof(MediaTypeMismatchedDataType), mediaType.Examples[key]?.Value, mediaType.Schema);
+                                context.Exit();
+                                context.Exit();
+                            }
+                        }
+                    }
+
+                    context.Exit();
+                });
+
+        // add more rule.
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiParameterRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiParameterRules.cs
@@ -76,7 +76,7 @@ namespace Microsoft.OpenApi.Validations.Rules
                     context.Exit();
 
 
-                    // enum
+                    // examples
                     context.Enter("examples");
 
                     if (parameter.Examples != null)

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiParameterRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiParameterRules.cs
@@ -75,7 +75,6 @@ namespace Microsoft.OpenApi.Validations.Rules
 
                     context.Exit();
 
-
                     // examples
                     context.Enter("examples");
 

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiParameterRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiParameterRules.cs
@@ -58,6 +58,45 @@ namespace Microsoft.OpenApi.Validations.Rules
                     context.Exit();
                 });
 
+        /// <summary>
+        /// Validate the data matches with the given data type.
+        /// </summary>
+        public static ValidationRule<OpenApiParameter> ParameterMismatchedDataType =>
+            new ValidationRule<OpenApiParameter>(
+                (context, parameter) =>
+                {
+                    // example
+                    context.Enter("example");
+
+                    if (parameter.Example != null)
+                    {
+                        RuleHelpers.ValidateDataTypeMismatch(context, nameof(ParameterMismatchedDataType), parameter.Example, parameter.Schema);
+                    }
+
+                    context.Exit();
+
+
+                    // enum
+                    context.Enter("examples");
+
+                    if (parameter.Examples != null)
+                    {
+                        foreach (var key in parameter.Examples.Keys)
+                        {
+                            if (parameter.Examples[key] != null)
+                            {
+                                context.Enter(key);
+                                context.Enter("value");
+                                RuleHelpers.ValidateDataTypeMismatch(context, nameof(ParameterMismatchedDataType), parameter.Examples[key]?.Value, parameter.Schema);
+                                context.Exit();
+                                context.Exit();
+                            }
+                        }
+                    }
+
+                    context.Exit();
+                });
+
         // add more rule.
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiSchemaRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiSchemaRules.cs
@@ -1,0 +1,275 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+
+namespace Microsoft.OpenApi.Validations.Rules
+{
+    /// <summary>
+    /// The validation rules for <see cref="OpenApiSchema"/>.
+    /// </summary>
+    [OpenApiRule]
+    public static class OpenApiSchemaRules
+    {
+        internal const string DataTypeMismatchedErrorMessage = "Data and type mismatch found in \"default\". ";
+
+        private static void ValidateDataTypeMismatch(IValidationContext context, IOpenApiAny value, OpenApiSchema schema)
+        {
+            if (schema == null)
+            {
+                return;
+            }
+
+            var type = schema.Type;
+            var format = schema.Format;
+
+            if (type == "object")
+            {
+                if (!(value is OpenApiObject))
+                {
+                    context.CreateError(
+                        nameof(SchemaMismatchedDataType),
+                        DataTypeMismatchedErrorMessage);
+                    return;
+                }
+
+                var anyObject = (OpenApiObject)value;
+
+                foreach (var key in anyObject.Keys)
+                {
+                    context.Enter(key);
+
+                    if (schema.Properties != null && schema.Properties.ContainsKey(key))
+                    {
+                        ValidateDataTypeMismatch(context, anyObject[key], schema.Properties[key]);
+                    }
+                    else
+                    {
+                        ValidateDataTypeMismatch(context, anyObject[key], schema.AdditionalProperties);
+                    }
+                    
+                    context.Exit();
+                }
+
+                return;
+            }
+
+            if (type == "array")
+            {
+                if (!(value is OpenApiArray))
+                {
+                    context.CreateError(
+                        nameof(SchemaMismatchedDataType),
+                        DataTypeMismatchedErrorMessage);
+                    return;
+                }
+
+                var anyArray = (OpenApiArray)value;
+
+                for (int i = 0; i < anyArray.Count; i++)
+                {
+                    context.Enter(i.ToString());
+
+                    ValidateDataTypeMismatch(context, anyArray[i], schema.Items);
+
+                    context.Exit();
+                }
+
+                return;
+            }
+
+            if (type == "integer" && format == "int32" )
+            {
+                if (!(value is OpenApiInteger))
+                {
+                    context.CreateError(
+                        nameof(SchemaMismatchedDataType),
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "integer" && format == "int64")
+            {
+                if (!(value is OpenApiLong))
+                {
+                    context.CreateError(
+                       nameof(SchemaMismatchedDataType),
+                       DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "integer" && !(value is OpenApiInteger))
+            {
+                if (!(value is OpenApiInteger))
+                {
+                    context.CreateError(
+                        nameof(SchemaMismatchedDataType),
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "number" && format == "float")
+            {
+                if (!(value is OpenApiFloat))
+                {
+                    context.CreateError(
+                        nameof(SchemaMismatchedDataType),
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "number" && format == "double")
+            {
+                if (!(value is OpenApiDouble))
+                {
+                    context.CreateError(
+                        nameof(SchemaMismatchedDataType),
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "number")
+            {
+                if (!(value is OpenApiDouble))
+                {
+                    context.CreateError(
+                        nameof(SchemaMismatchedDataType),
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "string" && format == "byte")
+            {
+                if (!(value is OpenApiByte))
+                {
+                    context.CreateError(
+                        nameof(SchemaMismatchedDataType),
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "string" && format == "date")
+            {
+                if (!(value is OpenApiDate))
+                {
+                    context.CreateError(
+                        nameof(SchemaMismatchedDataType),
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "string" && format == "date-time")
+            {
+                if (!(value is OpenApiDateTime))
+                {
+                    context.CreateError(
+                        nameof(SchemaMismatchedDataType),
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "string" && format == "password")
+            {
+                if (!(value is OpenApiPassword))
+                {
+                    context.CreateError(
+                        nameof(SchemaMismatchedDataType),
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "string")
+            {
+                if (!(value is OpenApiString))
+                {
+                    context.CreateError(
+                        nameof(SchemaMismatchedDataType),
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "boolean" )
+            {
+                if (!(value is OpenApiBoolean))
+                {
+                    context.CreateError(
+                        nameof(SchemaMismatchedDataType),
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+        }
+
+        /// <summary>
+        /// Validate the field is required.
+        /// </summary>
+        public static ValidationRule<OpenApiSchema> SchemaMismatchedDataType =>
+            new ValidationRule<OpenApiSchema>(
+                (context, schema) =>
+                {
+                    // default
+                    context.Enter("default");
+
+                    if (schema.Default != null)
+                    {
+                        ValidateDataTypeMismatch(context, schema.Default, schema);
+                    }
+
+                    context.Exit();
+
+                    // example
+                    context.Enter("example");
+
+                    if (schema.Example != null)
+                    {
+                        ValidateDataTypeMismatch(context, schema.Example, schema);
+                    }
+
+                    context.Exit();
+
+
+                    // enum
+                    context.Enter("enum");
+
+                    if (schema.Enum != null)
+                    {
+                        for (int i = 0; i < schema.Enum.Count; i++)
+                        {
+                            context.Enter(i.ToString());
+                            ValidateDataTypeMismatch(context, schema.Enum[i], schema);
+                            context.Exit();
+                        }
+                    }
+
+                    context.Exit();
+                });
+
+        // add more rule.
+    }
+}

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiSchemaRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiSchemaRules.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Properties;
 
 namespace Microsoft.OpenApi.Validations.Rules
 {
@@ -14,220 +12,8 @@ namespace Microsoft.OpenApi.Validations.Rules
     [OpenApiRule]
     public static class OpenApiSchemaRules
     {
-        internal const string DataTypeMismatchedErrorMessage = "Data and type mismatch found in \"default\". ";
-
-        private static void ValidateDataTypeMismatch(IValidationContext context, IOpenApiAny value, OpenApiSchema schema)
-        {
-            if (schema == null)
-            {
-                return;
-            }
-
-            var type = schema.Type;
-            var format = schema.Format;
-
-            if (type == "object")
-            {
-                if (!(value is OpenApiObject))
-                {
-                    context.CreateError(
-                        nameof(SchemaMismatchedDataType),
-                        DataTypeMismatchedErrorMessage);
-                    return;
-                }
-
-                var anyObject = (OpenApiObject)value;
-
-                foreach (var key in anyObject.Keys)
-                {
-                    context.Enter(key);
-
-                    if (schema.Properties != null && schema.Properties.ContainsKey(key))
-                    {
-                        ValidateDataTypeMismatch(context, anyObject[key], schema.Properties[key]);
-                    }
-                    else
-                    {
-                        ValidateDataTypeMismatch(context, anyObject[key], schema.AdditionalProperties);
-                    }
-                    
-                    context.Exit();
-                }
-
-                return;
-            }
-
-            if (type == "array")
-            {
-                if (!(value is OpenApiArray))
-                {
-                    context.CreateError(
-                        nameof(SchemaMismatchedDataType),
-                        DataTypeMismatchedErrorMessage);
-                    return;
-                }
-
-                var anyArray = (OpenApiArray)value;
-
-                for (int i = 0; i < anyArray.Count; i++)
-                {
-                    context.Enter(i.ToString());
-
-                    ValidateDataTypeMismatch(context, anyArray[i], schema.Items);
-
-                    context.Exit();
-                }
-
-                return;
-            }
-
-            if (type == "integer" && format == "int32" )
-            {
-                if (!(value is OpenApiInteger))
-                {
-                    context.CreateError(
-                        nameof(SchemaMismatchedDataType),
-                        DataTypeMismatchedErrorMessage);
-                }
-
-                return;
-            }
-
-            if (type == "integer" && format == "int64")
-            {
-                if (!(value is OpenApiLong))
-                {
-                    context.CreateError(
-                       nameof(SchemaMismatchedDataType),
-                       DataTypeMismatchedErrorMessage);
-                }
-
-                return;
-            }
-
-            if (type == "integer" && !(value is OpenApiInteger))
-            {
-                if (!(value is OpenApiInteger))
-                {
-                    context.CreateError(
-                        nameof(SchemaMismatchedDataType),
-                        DataTypeMismatchedErrorMessage);
-                }
-
-                return;
-            }
-
-            if (type == "number" && format == "float")
-            {
-                if (!(value is OpenApiFloat))
-                {
-                    context.CreateError(
-                        nameof(SchemaMismatchedDataType),
-                        DataTypeMismatchedErrorMessage);
-                }
-
-                return;
-            }
-
-            if (type == "number" && format == "double")
-            {
-                if (!(value is OpenApiDouble))
-                {
-                    context.CreateError(
-                        nameof(SchemaMismatchedDataType),
-                        DataTypeMismatchedErrorMessage);
-                }
-
-                return;
-            }
-
-            if (type == "number")
-            {
-                if (!(value is OpenApiDouble))
-                {
-                    context.CreateError(
-                        nameof(SchemaMismatchedDataType),
-                        DataTypeMismatchedErrorMessage);
-                }
-
-                return;
-            }
-
-            if (type == "string" && format == "byte")
-            {
-                if (!(value is OpenApiByte))
-                {
-                    context.CreateError(
-                        nameof(SchemaMismatchedDataType),
-                        DataTypeMismatchedErrorMessage);
-                }
-
-                return;
-            }
-
-            if (type == "string" && format == "date")
-            {
-                if (!(value is OpenApiDate))
-                {
-                    context.CreateError(
-                        nameof(SchemaMismatchedDataType),
-                        DataTypeMismatchedErrorMessage);
-                }
-
-                return;
-            }
-
-            if (type == "string" && format == "date-time")
-            {
-                if (!(value is OpenApiDateTime))
-                {
-                    context.CreateError(
-                        nameof(SchemaMismatchedDataType),
-                        DataTypeMismatchedErrorMessage);
-                }
-
-                return;
-            }
-
-            if (type == "string" && format == "password")
-            {
-                if (!(value is OpenApiPassword))
-                {
-                    context.CreateError(
-                        nameof(SchemaMismatchedDataType),
-                        DataTypeMismatchedErrorMessage);
-                }
-
-                return;
-            }
-
-            if (type == "string")
-            {
-                if (!(value is OpenApiString))
-                {
-                    context.CreateError(
-                        nameof(SchemaMismatchedDataType),
-                        DataTypeMismatchedErrorMessage);
-                }
-
-                return;
-            }
-
-            if (type == "boolean" )
-            {
-                if (!(value is OpenApiBoolean))
-                {
-                    context.CreateError(
-                        nameof(SchemaMismatchedDataType),
-                        DataTypeMismatchedErrorMessage);
-                }
-
-                return;
-            }
-        }
-
         /// <summary>
-        /// Validate the field is required.
+        /// Validate the data matches with the given data type.
         /// </summary>
         public static ValidationRule<OpenApiSchema> SchemaMismatchedDataType =>
             new ValidationRule<OpenApiSchema>(
@@ -238,7 +24,7 @@ namespace Microsoft.OpenApi.Validations.Rules
 
                     if (schema.Default != null)
                     {
-                        ValidateDataTypeMismatch(context, schema.Default, schema);
+                        RuleHelpers.ValidateDataTypeMismatch(context, nameof(SchemaMismatchedDataType), schema.Default, schema);
                     }
 
                     context.Exit();
@@ -248,7 +34,7 @@ namespace Microsoft.OpenApi.Validations.Rules
 
                     if (schema.Example != null)
                     {
-                        ValidateDataTypeMismatch(context, schema.Example, schema);
+                        RuleHelpers.ValidateDataTypeMismatch(context, nameof(SchemaMismatchedDataType), schema.Example, schema);
                     }
 
                     context.Exit();
@@ -262,7 +48,7 @@ namespace Microsoft.OpenApi.Validations.Rules
                         for (int i = 0; i < schema.Enum.Count; i++)
                         {
                             context.Enter(i.ToString());
-                            ValidateDataTypeMismatch(context, schema.Enum[i], schema);
+                            RuleHelpers.ValidateDataTypeMismatch(context, nameof(SchemaMismatchedDataType), schema.Enum[i], schema);
                             context.Exit();
                         }
                     }

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiSchemaRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiSchemaRules.cs
@@ -39,7 +39,6 @@ namespace Microsoft.OpenApi.Validations.Rules
 
                     context.Exit();
 
-
                     // enum
                     context.Enter("enum");
 

--- a/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
@@ -2,11 +2,15 @@
 // Licensed under the MIT license. 
 
 using System;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Validations.Rules
 {
     internal static class RuleHelpers
     {
+        internal const string DataTypeMismatchedErrorMessage = "Data and type mismatch found.";
+
         /// <summary>
         /// Input string must be in the format of an email address
         /// </summary>
@@ -33,6 +37,238 @@ namespace Microsoft.OpenApi.Validations.Rules
             // Add more rules.
 
             return true;
+        }
+
+        public static void ValidateDataTypeMismatch(
+            IValidationContext context, 
+            string ruleName, 
+            IOpenApiAny value, 
+            OpenApiSchema schema)
+        {
+            if (schema == null)
+            {
+                return;
+            }
+
+            var type = schema.Type;
+            var format = schema.Format;
+
+            if (type == "object")
+            {
+                // It is not against the spec to have a string representing an object value.
+                // To represent examples of media types that cannot naturally be represented in JSON or YAML,
+                // a string value can contain the example with escaping where necessary
+                if (value is OpenApiString)
+                {
+                    return;
+                }
+
+                // If value is not a string and also not an object, there is a data mismatch.
+                if (!(value is OpenApiObject))
+                {
+                    context.CreateError(
+                        ruleName,
+                        DataTypeMismatchedErrorMessage);
+                    return;
+                }
+
+                var anyObject = (OpenApiObject)value;
+
+                foreach (var key in anyObject.Keys)
+                {
+                    context.Enter(key);
+
+                    if (schema.Properties != null && schema.Properties.ContainsKey(key))
+                    {
+                        ValidateDataTypeMismatch(context, ruleName, anyObject[key], schema.Properties[key]);
+                    }
+                    else
+                    {
+                        ValidateDataTypeMismatch(context, ruleName, anyObject[key], schema.AdditionalProperties);
+                    }
+
+                    context.Exit();
+                }
+
+                return;
+            }
+
+            if (type == "array")
+            {
+                // It is not against the spec to have a string representing an array value.
+                // To represent examples of media types that cannot naturally be represented in JSON or YAML,
+                // a string value can contain the example with escaping where necessary
+                if (value is OpenApiString)
+                {
+                    return;
+                }
+
+                // If value is not a string and also not an array, there is a data mismatch.
+                if (!(value is OpenApiArray))
+                {
+                    context.CreateError(
+                        ruleName,
+                        DataTypeMismatchedErrorMessage);
+                    return;
+                }
+
+                var anyArray = (OpenApiArray)value;
+
+                for (int i = 0; i < anyArray.Count; i++)
+                {
+                    context.Enter(i.ToString());
+
+                    ValidateDataTypeMismatch(context, ruleName, anyArray[i], schema.Items);
+
+                    context.Exit();
+                }
+
+                return;
+            }
+
+            if (type == "integer" && format == "int32")
+            {
+                if (!(value is OpenApiInteger))
+                {
+                    context.CreateError(
+                        ruleName,
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "integer" && format == "int64")
+            {
+                if (!(value is OpenApiLong))
+                {
+                    context.CreateError(
+                       ruleName,
+                       DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "integer" && !(value is OpenApiInteger))
+            {
+                if (!(value is OpenApiInteger))
+                {
+                    context.CreateError(
+                        ruleName,
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "number" && format == "float")
+            {
+                if (!(value is OpenApiFloat))
+                {
+                    context.CreateError(
+                        ruleName,
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "number" && format == "double")
+            {
+                if (!(value is OpenApiDouble))
+                {
+                    context.CreateError(
+                        ruleName,
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "number")
+            {
+                if (!(value is OpenApiDouble))
+                {
+                    context.CreateError(
+                        ruleName,
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "string" && format == "byte")
+            {
+                if (!(value is OpenApiByte))
+                {
+                    context.CreateError(
+                        ruleName,
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "string" && format == "date")
+            {
+                if (!(value is OpenApiDate))
+                {
+                    context.CreateError(
+                        ruleName,
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "string" && format == "date-time")
+            {
+                if (!(value is OpenApiDateTime))
+                {
+                    context.CreateError(
+                        ruleName,
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "string" && format == "password")
+            {
+                if (!(value is OpenApiPassword))
+                {
+                    context.CreateError(
+                        ruleName,
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "string")
+            {
+                if (!(value is OpenApiString))
+                {
+                    context.CreateError(
+                        ruleName,
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
+
+            if (type == "boolean")
+            {
+                if (!(value is OpenApiBoolean))
+                {
+                    context.CreateError(
+                        ruleName,
+                        DataTypeMismatchedErrorMessage);
+                }
+
+                return;
+            }
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/DefaultSettingsFixture.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/DefaultSettingsFixture.cs
@@ -19,7 +19,10 @@ namespace Microsoft.OpenApi.Readers.Tests
             // given that there are multiple types that can be used for the declared type OpenApiAny.
             // Without this option, properties specific to those types would not be compared.
             AssertionOptions.AssertEquivalencyUsing(
-                o => o.AllowingInfiniteRecursion().RespectingRuntimeTypes());
+                o => o
+                    .AllowingInfiniteRecursion()
+                    .RespectingRuntimeTypes()
+                    .WithStrictOrdering());
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -13,14 +13,6 @@
         <AssemblyOriginatorKeyFile>..\..\src\Microsoft.OpenApi.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
     <ItemGroup>
-      <None Remove="V2Tests\Samples\OpenApiParameter\parameterWithDefault.yaml" />
-      <None Remove="V2Tests\Samples\OpenApiParameter\parameterWithEnum.yaml" />
-      <None Remove="V3Tests\Samples\OpenApiMediaType\mediaTypeWithExample.yaml" />
-      <None Remove="V3Tests\Samples\OpenApiMediaType\mediaTypeWithExamples.yaml" />
-      <None Remove="V3Tests\Samples\OpenApiParameter\parameterWithExample.yaml" />
-      <None Remove="V3Tests\Samples\OpenApiParameter\parameterWithExamples.yaml" />
-    </ItemGroup>
-    <ItemGroup>
       <EmbeddedResource Include="OpenApiReaderTests\Samples\unsupported.v1.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
@@ -84,6 +76,12 @@
       <EmbeddedResource Include="V2Tests\Samples\OpenApiPathItem\basicPathItemWithFormData.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiResponse\responseWithExamples.yaml" />
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiHeader\headerWithDefault.yaml" />
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiHeader\headerWithEnum.yaml" />
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiSchema\schemaWithDefault.yaml" />
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiSchema\schemaWithEnum.yaml" />
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiSchema\schemaWithExample.yaml" />
       <EmbeddedResource Include="V2Tests\Samples\OpenApiSecurityScheme\apiKeySecurityScheme.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -13,6 +13,14 @@
         <AssemblyOriginatorKeyFile>..\..\src\Microsoft.OpenApi.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
     <ItemGroup>
+      <None Remove="V2Tests\Samples\OpenApiParameter\parameterWithDefault.yaml" />
+      <None Remove="V2Tests\Samples\OpenApiParameter\parameterWithEnum.yaml" />
+      <None Remove="V3Tests\Samples\OpenApiMediaType\mediaTypeWithExample.yaml" />
+      <None Remove="V3Tests\Samples\OpenApiMediaType\mediaTypeWithExamples.yaml" />
+      <None Remove="V3Tests\Samples\OpenApiParameter\parameterWithExample.yaml" />
+      <None Remove="V3Tests\Samples\OpenApiParameter\parameterWithExamples.yaml" />
+    </ItemGroup>
+    <ItemGroup>
       <EmbeddedResource Include="OpenApiReaderTests\Samples\unsupported.v1.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
@@ -47,6 +55,12 @@
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
       <EmbeddedResource Include="V2Tests\Samples\OpenApiParameter\headerParameterWithIncorrectDataType.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiParameter\parameterWithDefault.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiParameter\parameterWithEnum.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
       <EmbeddedResource Include="V2Tests\Samples\OpenApiParameter\parameterWithNoLocation.yaml">
@@ -131,10 +145,22 @@
       <EmbeddedResource Include="V3Tests\Samples\OpenApiOperation\securedOperation.yaml">
        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiMediaType\mediaTypeWithExample.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiMediaType\mediaTypeWithExamples.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
       <EmbeddedResource Include="V3Tests\Samples\OpenApiParameter\headerParameter.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiParameter\parameterWithExamples.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
       <EmbeddedResource Include="V3Tests\Samples\OpenApiParameter\parameterWithNoLocation.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiParameter\parameterWithExample.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
       <EmbeddedResource Include="V3Tests\Samples\OpenApiParameter\parameterWithUnknownLocation.yaml">

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -46,6 +46,9 @@
       <EmbeddedResource Include="V2Tests\Samples\OpenApiParameter\formDataParameter.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiParameter\headerParameterWithIncorrectDataType.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
       <EmbeddedResource Include="V2Tests\Samples\OpenApiParameter\parameterWithNoLocation.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/OpenApiAnyConverterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/OpenApiAnyConverterTests.cs
@@ -1,0 +1,517 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.ParseNodes;
+using SharpYaml.Serialization;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.ParseNodes
+{
+    [Collection("DefaultSettings")]
+    public class OpenApiAnyConverterTests
+    {
+        [Fact]
+        public void ParseObjectAsAnyShouldSucceed()
+        {
+            var input = @"
+aString: fooBar
+aInteger: 10
+aDouble: 2.34
+aDateTime: 2017-01-01
+aDate: 2017-01-02
+                ";
+            var yamlStream = new YamlStream();
+            yamlStream.Load(new StringReader(input));
+            var yamlNode = yamlStream.Documents.First().RootNode;
+
+            var context = new ParsingContext();
+            var diagnostic = new OpenApiDiagnostic();
+
+            var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+
+            var anyMap = node.CreateAny();
+
+            var schema = new OpenApiSchema()
+            {
+                Type = "object",
+                Properties =
+                {
+                    ["aString"] = new OpenApiSchema()
+                    {
+                        Type = "string"
+                    },
+                    ["aInteger"] = new OpenApiSchema()
+                    {
+                        Type = "integer",
+                        Format = "int32"
+                    },
+                    ["aDouble"] = new OpenApiSchema()
+                    {
+                        Type = "number",
+                        Format = "double"
+                    },
+                    ["aDateTime"] = new OpenApiSchema()
+                    {
+                        Type = "string",
+                        Format = "date-time"
+                    },
+                    ["aDate"] = new OpenApiSchema()
+                    {
+                        Type = "string",
+                        Format = "date"
+                    }
+                }
+            };
+
+            anyMap = OpenApiAnyConverter.GetSpecificOpenApiAny(anyMap, schema);
+
+            diagnostic.Errors.Should().BeEmpty();
+
+            anyMap.ShouldBeEquivalentTo(
+                new OpenApiObject
+                {
+                    ["aString"] = new OpenApiString("fooBar"),
+                    ["aInteger"] = new OpenApiInteger(10),
+                    ["aDouble"] = new OpenApiDouble(2.34),
+                    ["aDateTime"] = new OpenApiDateTime(DateTimeOffset.Parse("2017-01-01", CultureInfo.InvariantCulture)),
+                    ["aDate"] = new OpenApiDate(DateTime.Parse("2017-01-02", CultureInfo.InvariantCulture)),
+                });
+        }
+    
+
+        [Fact]
+        public void ParseNestedObjectAsAnyShouldSucceed()
+        {
+            var input = @"
+    aString: fooBar
+    aInteger: 10
+    aArray:
+      - 1
+      - 2
+      - 3
+    aNestedArray:
+      - aFloat: 1
+        aPassword: 1234
+        aArray: [abc, def]
+        aDictionary:
+          arbitraryProperty: 1
+          arbitraryProperty2: 2
+      - aFloat: 1.6
+        aArray: [123]
+        aDictionary:
+          arbitraryProperty: 1
+          arbitraryProperty3: 20
+    aObject:
+      aDate: 2017-02-03
+    aDouble: 2.34
+    aDateTime: 2017-01-01
+                    ";
+            var yamlStream = new YamlStream();
+            yamlStream.Load(new StringReader(input));
+            var yamlNode = yamlStream.Documents.First().RootNode;
+
+            var context = new ParsingContext();
+            var diagnostic = new OpenApiDiagnostic();
+
+            var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+
+            var anyMap = node.CreateAny();
+
+            var schema = new OpenApiSchema()
+            {
+                Type = "object",
+                Properties =
+                    {
+                        ["aString"] = new OpenApiSchema()
+                        {
+                            Type = "string"
+                        },
+                        ["aInteger"] = new OpenApiSchema()
+                        {
+                            Type = "integer",
+                            Format = "int32"
+                        },
+                        ["aArray"] = new OpenApiSchema()
+                        {
+                            Type = "array",
+                            Items = new OpenApiSchema()
+                            {
+                                Type = "integer",
+                                Format = "int64"
+                            }
+                        },
+                        ["aNestedArray"] = new OpenApiSchema()
+                        {
+                            Type = "array",
+                            Items = new OpenApiSchema()
+                            {
+                                Type = "object",
+                                Properties =
+                                {
+                                    ["aFloat"] = new OpenApiSchema()
+                                    {
+                                        Type = "number",
+                                        Format = "float"
+                                    },
+                                    ["aPassword"] = new OpenApiSchema()
+                                    {
+                                        Type = "string",
+                                        Format = "password"
+                                    },
+                                    ["aArray"] = new OpenApiSchema()
+                                    {
+                                        Type = "array",
+                                        Items = new OpenApiSchema()
+                                        {
+                                            Type = "string",
+                                        }
+                                    },
+                                    ["aDictionary"] = new OpenApiSchema()
+                                    {
+                                        Type = "object",
+                                        AdditionalProperties = new OpenApiSchema()
+                                        {
+                                            Type = "integer",
+                                            Format = "int64"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        ["aObject"] = new OpenApiSchema()
+                        {
+                            Type = "array",
+                            Properties =
+                            {
+                                ["aDate"] = new OpenApiSchema()
+                                {
+                                    Type = "string",
+                                    Format = "date"
+                                }
+                            }
+                        },
+                        ["aDouble"] = new OpenApiSchema()
+                        {
+                            Type = "number",
+                            Format = "double"
+                        },
+                        ["aDateTime"] = new OpenApiSchema()
+                        {
+                            Type = "string",
+                            Format = "date-time"
+                        }
+                    }
+            };
+
+            anyMap = OpenApiAnyConverter.GetSpecificOpenApiAny(anyMap, schema);
+
+            diagnostic.Errors.Should().BeEmpty();
+
+            anyMap.ShouldBeEquivalentTo(
+                new OpenApiObject
+                {
+                    ["aString"] = new OpenApiString("fooBar"),
+                    ["aInteger"] = new OpenApiInteger(10),
+                    ["aArray"] = new OpenApiArray()
+                    {
+                        new OpenApiLong(1),
+                        new OpenApiLong(2),
+                        new OpenApiLong(3),
+                    },
+                    ["aNestedArray"] = new OpenApiArray()
+                    {
+                        new OpenApiObject()
+                        {
+                            ["aFloat"] = new OpenApiFloat(1),
+                            ["aPassword"] = new OpenApiPassword("1234"),
+                            ["aArray"] = new OpenApiArray()
+                            {
+                                new OpenApiString("abc"),
+                                new OpenApiString("def")
+                            },
+                            ["aDictionary"] = new OpenApiObject()
+                            {
+                                ["arbitraryProperty"] = new OpenApiLong(1),
+                                ["arbitraryProperty2"] = new OpenApiLong(2),
+                            }
+                        },
+                        new OpenApiObject()
+                        {
+                            ["aFloat"] = new OpenApiFloat((float)1.6),
+                            ["aArray"] = new OpenApiArray()
+                            {
+                                new OpenApiString("123"),
+                            },
+                            ["aDictionary"] = new OpenApiObject()
+                            {
+                                ["arbitraryProperty"] = new OpenApiLong(1),
+                                ["arbitraryProperty3"] = new OpenApiLong(20),
+                            }
+                        }
+                    },
+                    ["aObject"] = new OpenApiObject()
+                    {
+                        ["aDate"] = new OpenApiDate(DateTime.Parse("2017-02-03", CultureInfo.InvariantCulture))
+                    },
+                    ["aDouble"] = new OpenApiDouble(2.34),
+                    ["aDateTime"] = new OpenApiDateTime(DateTimeOffset.Parse("2017-01-01", CultureInfo.InvariantCulture))
+                });
+        }
+    
+
+        [Fact]
+        public void ParseNestedObjectAsAnyWithPartialSchemaShouldSucceed()
+        {
+            var input = @"
+        aString: fooBar
+        aInteger: 10
+        aArray:
+          - 1
+          - 2
+          - 3
+        aNestedArray:
+          - aFloat: 1
+            aPassword: 1234
+            aArray: [abc, def]
+            aDictionary:
+              arbitraryProperty: 1
+              arbitraryProperty2: 2
+          - aFloat: 1.6
+            aArray: [123]
+            aDictionary:
+              arbitraryProperty: 1
+              arbitraryProperty3: 20
+        aObject:
+          aDate: 2017-02-03
+        aDouble: 2.34
+        aDateTime: 2017-01-01
+                        ";
+            var yamlStream = new YamlStream();
+            yamlStream.Load(new StringReader(input));
+            var yamlNode = yamlStream.Documents.First().RootNode;
+
+            var context = new ParsingContext();
+            var diagnostic = new OpenApiDiagnostic();
+
+            var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+
+            var anyMap = node.CreateAny();
+
+            var schema = new OpenApiSchema()
+            {
+                Type = "object",
+                Properties =
+                        {
+                            ["aString"] = new OpenApiSchema()
+                            {
+                                Type = "string"
+                            },
+                            ["aArray"] = new OpenApiSchema()
+                            {
+                                Type = "array",
+                                Items = new OpenApiSchema()
+                                {
+                                    Type = "integer"
+                                }
+                            },
+                            ["aNestedArray"] = new OpenApiSchema()
+                            {
+                                Type = "array",
+                                Items = new OpenApiSchema()
+                                {
+                                    Type = "object",
+                                    Properties =
+                                    {
+                                        ["aFloat"] = new OpenApiSchema()
+                                        {
+                                        },
+                                        ["aPassword"] = new OpenApiSchema()
+                                        {
+                                        },
+                                        ["aArray"] = new OpenApiSchema()
+                                        {
+                                            Type = "array",
+                                            Items = new OpenApiSchema()
+                                            {
+                                                Type = "string",
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            ["aObject"] = new OpenApiSchema()
+                            {
+                                Type = "array",
+                                Properties =
+                                {
+                                    ["aDate"] = new OpenApiSchema()
+                                    {
+                                        Type = "string"
+                                    }
+                                }
+                            },
+                            ["aDouble"] = new OpenApiSchema()
+                            {
+                            },
+                            ["aDateTime"] = new OpenApiSchema()
+                            {
+                            }
+                        }
+            };
+
+            anyMap = OpenApiAnyConverter.GetSpecificOpenApiAny(anyMap, schema);
+
+            diagnostic.Errors.Should().BeEmpty();
+
+            anyMap.ShouldBeEquivalentTo(
+                new OpenApiObject
+                {
+                    ["aString"] = new OpenApiString("fooBar"),
+                    ["aInteger"] = new OpenApiInteger(10),
+                    ["aArray"] = new OpenApiArray()
+                    {
+                            new OpenApiInteger(1),
+                            new OpenApiInteger(2),
+                            new OpenApiInteger(3),
+                    },
+                    ["aNestedArray"] = new OpenApiArray()
+                    {
+                            new OpenApiObject()
+                            {
+                                ["aFloat"] = new OpenApiInteger(1),
+                                ["aPassword"] = new OpenApiInteger(1234),
+                                ["aArray"] = new OpenApiArray()
+                                {
+                                    new OpenApiString("abc"),
+                                    new OpenApiString("def")
+                                },
+                                ["aDictionary"] = new OpenApiObject()
+                                {
+                                    ["arbitraryProperty"] = new OpenApiInteger(1),
+                                    ["arbitraryProperty2"] = new OpenApiInteger(2),
+                                }
+                            },
+                            new OpenApiObject()
+                            {
+                                ["aFloat"] = new OpenApiDouble(1.6),
+                                ["aArray"] = new OpenApiArray()
+                                {
+                                    new OpenApiString("123"),
+                                },
+                                ["aDictionary"] = new OpenApiObject()
+                                {
+                                    ["arbitraryProperty"] = new OpenApiInteger(1),
+                                    ["arbitraryProperty3"] = new OpenApiInteger(20),
+                                }
+                            }
+                    },
+                    ["aObject"] = new OpenApiObject()
+                    {
+                        ["aDate"] = new OpenApiString("2017-02-03")
+                    },
+                    ["aDouble"] = new OpenApiDouble(2.34),
+                    ["aDateTime"] = new OpenApiDateTime(DateTimeOffset.Parse("2017-01-01", CultureInfo.InvariantCulture))
+                });
+        }
+
+        [Fact]
+        public void ParseNestedObjectAsAnyWithoutUsingSchemaShouldSucceed()
+        {
+            var input = @"
+        aString: fooBar
+        aInteger: 10
+        aArray:
+          - 1
+          - 2
+          - 3
+        aNestedArray:
+          - aFloat: 1
+            aPassword: 1234
+            aArray: [abc, def]
+            aDictionary:
+              arbitraryProperty: 1
+              arbitraryProperty2: 2
+          - aFloat: 1.6
+            aArray: [123]
+            aDictionary:
+              arbitraryProperty: 1
+              arbitraryProperty3: 20
+        aObject:
+          aDate: 2017-02-03
+        aDouble: 2.34
+        aDateTime: 2017-01-01
+                        ";
+            var yamlStream = new YamlStream();
+            yamlStream.Load(new StringReader(input));
+            var yamlNode = yamlStream.Documents.First().RootNode;
+
+            var context = new ParsingContext();
+            var diagnostic = new OpenApiDiagnostic();
+
+            var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+
+            var anyMap = node.CreateAny();
+
+            anyMap = OpenApiAnyConverter.GetSpecificOpenApiAny(anyMap);
+
+            diagnostic.Errors.Should().BeEmpty();
+
+            anyMap.ShouldBeEquivalentTo(
+                new OpenApiObject
+                {
+                    ["aString"] = new OpenApiString("fooBar"),
+                    ["aInteger"] = new OpenApiInteger(10),
+                    ["aArray"] = new OpenApiArray()
+                    {
+                            new OpenApiInteger(1),
+                            new OpenApiInteger(2),
+                            new OpenApiInteger(3),
+                    },
+                    ["aNestedArray"] = new OpenApiArray()
+                    {
+                            new OpenApiObject()
+                            {
+                                ["aFloat"] = new OpenApiInteger(1),
+                                ["aPassword"] = new OpenApiInteger(1234),
+                                ["aArray"] = new OpenApiArray()
+                                {
+                                    new OpenApiString("abc"),
+                                    new OpenApiString("def")
+                                },
+                                ["aDictionary"] = new OpenApiObject()
+                                {
+                                    ["arbitraryProperty"] = new OpenApiInteger(1),
+                                    ["arbitraryProperty2"] = new OpenApiInteger(2),
+                                }
+                            },
+                            new OpenApiObject()
+                            {
+                                ["aFloat"] = new OpenApiDouble(1.6),
+                                ["aArray"] = new OpenApiArray()
+                                {
+                                    new OpenApiInteger(123),
+                                },
+                                ["aDictionary"] = new OpenApiObject()
+                                {
+                                    ["arbitraryProperty"] = new OpenApiInteger(1),
+                                    ["arbitraryProperty3"] = new OpenApiInteger(20),
+                                }
+                            }
+                    },
+                    ["aObject"] = new OpenApiObject()
+                    {
+                        ["aDate"] = new OpenApiDateTime(DateTimeOffset.Parse("2017-02-03", CultureInfo.InvariantCulture))
+                    },
+                    ["aDouble"] = new OpenApiDouble(2.34),
+                    ["aDateTime"] = new OpenApiDateTime(DateTimeOffset.Parse("2017-01-01", CultureInfo.InvariantCulture))
+                });
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/OpenApiAnyConverterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/OpenApiAnyConverterTests.cs
@@ -81,7 +81,7 @@ aDate: 2017-01-02
                     ["aInteger"] = new OpenApiInteger(10),
                     ["aDouble"] = new OpenApiDouble(2.34),
                     ["aDateTime"] = new OpenApiDateTime(DateTimeOffset.Parse("2017-01-01", CultureInfo.InvariantCulture)),
-                    ["aDate"] = new OpenApiDate(DateTime.Parse("2017-01-02", CultureInfo.InvariantCulture)),
+                    ["aDate"] = new OpenApiDate(DateTimeOffset.Parse("2017-01-02", CultureInfo.InvariantCulture).Date),
                 });
         }
     
@@ -258,7 +258,7 @@ aDate: 2017-01-02
                     },
                     ["aObject"] = new OpenApiObject()
                     {
-                        ["aDate"] = new OpenApiDate(DateTime.Parse("2017-02-03", CultureInfo.InvariantCulture))
+                        ["aDate"] = new OpenApiDate(DateTimeOffset.Parse("2017-02-03", CultureInfo.InvariantCulture).Date)
                     },
                     ["aDouble"] = new OpenApiDouble(2.34),
                     ["aDateTime"] = new OpenApiDateTime(DateTimeOffset.Parse("2017-01-01", CultureInfo.InvariantCulture))

--- a/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/OpenApiAnyTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/OpenApiAnyTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using FluentAssertions;

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiHeaderTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiHeaderTests.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.ParseNodes;
+using Microsoft.OpenApi.Readers.V2;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.V2Tests
+{
+    [Collection("DefaultSettings")]
+    public class OpenApiHeaderTests
+    {
+        private const string SampleFolderPath = "V2Tests/Samples/OpenApiHeader/";
+
+        [Fact]
+        public void ParseHeaderWithDefaultShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "headerWithDefault.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var header = OpenApiV2Deserializer.LoadHeader(node);
+
+            // Assert
+            header.ShouldBeEquivalentTo(
+                new OpenApiHeader
+                {
+                    Schema = new OpenApiSchema()
+                    {
+                        Type = "number",
+                        Format = "float",
+                        Default = new OpenApiFloat(5)
+                    }
+                });
+        }
+
+        [Fact]
+        public void ParseHeaderWithEnumShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "headerWithEnum.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var header = OpenApiV2Deserializer.LoadHeader(node);
+
+            // Assert
+            header.ShouldBeEquivalentTo(
+                new OpenApiHeader
+                {
+                    Schema = new OpenApiSchema()
+                    {
+                        Type = "number",
+                        Format = "float",
+                        Enum =
+                        {
+                            new OpenApiFloat(7),
+                            new OpenApiFloat(8),
+                            new OpenApiFloat(9)
+                        }
+                    }
+                });
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiParameterTests.cs
@@ -304,5 +304,70 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                     }
                 });
         }
+
+        [Fact]
+        public void ParseParameterWithDefaultShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "parameterWithDefault.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var parameter = OpenApiV2Deserializer.LoadParameter(node);
+
+            // Assert
+            parameter.ShouldBeEquivalentTo(
+                new OpenApiParameter
+                {
+                    In = ParameterLocation.Path,
+                    Name = "username",
+                    Description = "username to fetch",
+                    Required = true,
+                    Schema = new OpenApiSchema
+                    {
+                        Type = "number",
+                        Format = "float",
+                        Default = new OpenApiFloat(5)
+                    }
+                });
+        }
+
+        [Fact]
+        public void ParseParameterWithEnumShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "parameterWithEnum.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var parameter = OpenApiV2Deserializer.LoadParameter(node);
+
+            // Assert
+            parameter.ShouldBeEquivalentTo(
+                new OpenApiParameter
+                {
+                    In = ParameterLocation.Path,
+                    Name = "username",
+                    Description = "username to fetch",
+                    Required = true,
+                    Schema = new OpenApiSchema
+                    {
+                        Type = "number",
+                        Format = "float",
+                        Enum =
+                        {
+                            new OpenApiFloat(7),
+                            new OpenApiFloat(8),
+                            new OpenApiFloat(9)
+                        }
+                    }
+                });
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiParameterTests.cs
@@ -149,21 +149,21 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                             Format = "int64",
                             Enum = new List<IOpenApiAny>
                             {
-                                new OpenApiInteger(1),
-                                new OpenApiInteger(2),
-                                new OpenApiInteger(3),
-                                new OpenApiInteger(4),
+                                new OpenApiLong(1),
+                                new OpenApiLong(2),
+                                new OpenApiLong(3),
+                                new OpenApiLong(4),
                             }
                         },
                         Default = new OpenApiArray() {
-                            new OpenApiInteger(1),
-                            new OpenApiInteger(2)
+                            new OpenApiLong(1),
+                            new OpenApiLong(2)
                         },
                         Enum = new List<IOpenApiAny>
                         {
-                            new OpenApiArray() { new OpenApiInteger(1), new OpenApiInteger(2) },
-                            new OpenApiArray() { new OpenApiInteger(2), new OpenApiInteger(3) },
-                            new OpenApiArray() { new OpenApiInteger(3), new OpenApiInteger(4) }
+                            new OpenApiArray() { new OpenApiLong(1), new OpenApiLong(2) },
+                            new OpenApiArray() { new OpenApiLong(2), new OpenApiLong(3) },
+                            new OpenApiArray() { new OpenApiLong(3), new OpenApiLong(4) }
                         }
                     }
                 });

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiParameterTests.cs
@@ -170,6 +170,58 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         }
 
         [Fact]
+        public void ParseHeaderParameterWithIncorrectDataTypeShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "headerParameterWithIncorrectDataType.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var parameter = OpenApiV2Deserializer.LoadParameter(node);
+
+            // Assert
+            parameter.ShouldBeEquivalentTo(
+                new OpenApiParameter
+                {
+                    In = ParameterLocation.Header,
+                    Name = "token",
+                    Description = "token to be passed as a header",
+                    Required = true,
+                    Style = ParameterStyle.Simple,
+
+                    Schema = new OpenApiSchema
+                    {
+                        Type = "array",
+                        Items = new OpenApiSchema
+                        {
+                            Type = "string",
+                            Format = "date-time",
+                            Enum = new List<IOpenApiAny>
+                            {
+                                new OpenApiString("1"),
+                                new OpenApiString("2"),
+                                new OpenApiString("3"),
+                                new OpenApiString("4"),
+                            }
+                        },
+                        Default = new OpenApiArray() {
+                            new OpenApiString("1"),
+                            new OpenApiString("2")
+                        },
+                        Enum = new List<IOpenApiAny>
+                        {
+                            new OpenApiArray() { new OpenApiString("1"), new OpenApiString("2") },
+                            new OpenApiArray() { new OpenApiString("2"), new OpenApiString("3") },
+                            new OpenApiArray() { new OpenApiString("3"), new OpenApiString("4") }
+                        }
+                    }
+                });
+        }
+
+        [Fact]
         public void ParseParameterWithNullLocationShouldSucceed()
         {
             // Arrange

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiResponseTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiResponseTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.ParseNodes;
+using Microsoft.OpenApi.Readers.V2;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.V2Tests
+{
+    [Collection("DefaultSettings")]
+    public class OpenApiResponseTests
+    {
+        private const string SampleFolderPath = "V2Tests/Samples/OpenApiResponse/";
+
+        [Fact]
+        public void ParseResponseWithExamplesShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "responseWithExamples.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            node.Context.SetTempStorage(TempStorageKeys.OperationProduces, new List<string>()
+            {
+                "application/json"
+            });
+
+            // Act
+            var response = OpenApiV2Deserializer.LoadResponse(node);
+
+            // Assert
+            response.ShouldBeEquivalentTo(
+                new OpenApiResponse()
+                {
+                    Description = "An array of float response",
+                    Content =
+                    {
+                        ["application/json"] = new OpenApiMediaType()
+                        {
+                            Schema = new OpenApiSchema()
+                            {
+                                Type = "array",
+                                Items = new OpenApiSchema()
+                                {
+                                    Type = "number",
+                                    Format = "float"
+                                }
+                            },
+                            Example = new OpenApiArray()
+                            {
+                                new OpenApiFloat(5),
+                                new OpenApiFloat(6),
+                                new OpenApiFloat(7),
+                            }
+                        }
+                    }
+                });
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiSchemaTests.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.ParseNodes;
+using Microsoft.OpenApi.Readers.V2;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.V2Tests
+{
+    [Collection("DefaultSettings")]
+    public class OpenApiSchemaTests
+    {
+        private const string SampleFolderPath = "V2Tests/Samples/OpenApiSchema/";
+
+        [Fact]
+        public void ParseSchemaWithDefaultShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "schemaWithDefault.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var schema = OpenApiV2Deserializer.LoadSchema(node);
+
+            // Assert
+            schema.ShouldBeEquivalentTo(
+                new OpenApiSchema
+                {
+                    Type = "number",
+                    Format = "float",
+                    Default = new OpenApiFloat(5)
+                });
+        }
+
+        [Fact]
+        public void ParseSchemaWithExampleShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "schemaWithExample.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var schema = OpenApiV2Deserializer.LoadSchema(node);
+
+            // Assert
+            schema.ShouldBeEquivalentTo(
+                new OpenApiSchema
+                {
+                    Type = "number",
+                    Format = "float",
+                    Example = new OpenApiFloat(5)
+                });
+        }
+
+        [Fact]
+        public void ParseSchemaWithEnumShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "schemaWithEnum.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var schema = OpenApiV2Deserializer.LoadSchema(node);
+
+            // Assert
+            schema.ShouldBeEquivalentTo(
+                new OpenApiSchema
+                {
+                    Type = "number",
+                    Format = "float",
+                    Enum =
+                    {
+                        new OpenApiFloat(7),
+                        new OpenApiFloat(8),
+                        new OpenApiFloat(9)
+                    }
+                });
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiHeader/headerWithDefault.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiHeader/headerWithDefault.yaml
@@ -1,0 +1,3 @@
+﻿type: number
+format: float
+default: 5

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiHeader/headerWithEnum.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiHeader/headerWithEnum.yaml
@@ -1,0 +1,6 @@
+﻿type: number
+format: float
+enum: 
+  - 7
+  - 8
+  - 9

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/headerParameterWithIncorrectDataType.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/headerParameterWithIncorrectDataType.yaml
@@ -1,0 +1,16 @@
+﻿# modified from https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameterObject
+name: token
+in: header
+description: token to be passed as a header
+required: true
+type: array
+default: [1,2]
+items:
+  type: string
+  format: date-time
+  enum: [1,2,3,4]
+collectionFormat: csv
+enum: 
+  - [1,2]
+  - [2,3]
+  - [3,4]

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/parameterWithDefault.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/parameterWithDefault.yaml
@@ -1,0 +1,7 @@
+﻿name: username
+in: path
+description: username to fetch
+required: true
+default: 5
+type: number
+format: float

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/parameterWithEnum.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiParameter/parameterWithEnum.yaml
@@ -1,0 +1,10 @@
+﻿name: username
+in: path
+description: username to fetch
+required: true
+enum: 
+  - 7
+  - 8
+  - 9
+type: number
+format: float

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiResponse/responseWithExamples.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiResponse/responseWithExamples.yaml
@@ -1,0 +1,11 @@
+﻿description: An array of float response
+schema:
+  type: array
+  items:
+    type: number
+    format: float
+examples:
+  application/json: 
+    - 5
+    - 6
+    - 7

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiSchema/schemaWithDefault.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiSchema/schemaWithDefault.yaml
@@ -1,0 +1,3 @@
+﻿type: number
+format: float
+default: 5

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiSchema/schemaWithEnum.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiSchema/schemaWithEnum.yaml
@@ -1,0 +1,6 @@
+﻿type: number
+format: float
+enum: 
+  - 7
+  - 8
+  - 9

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiSchema/schemaWithExample.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiSchema/schemaWithExample.yaml
@@ -1,0 +1,3 @@
+﻿type: number
+format: float
+example: 5

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiAnyTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiAnyTests.cs
@@ -42,9 +42,9 @@ aDateTime: 2017-01-01
                 new OpenApiObject
                 {
                     ["aString"] = new OpenApiString("fooBar"),
-                    ["aInteger"] = new OpenApiInteger(10),
-                    ["aDouble"] = new OpenApiDouble(2.34),
-                    ["aDateTime"] = new OpenApiDateTime(DateTimeOffset.Parse("2017-01-01", CultureInfo.InvariantCulture))
+                    ["aInteger"] = new OpenApiString("10"),
+                    ["aDouble"] = new OpenApiString("2.34"),
+                    ["aDateTime"] = new OpenApiString("2017-01-01")
                 });
         }
 
@@ -74,9 +74,9 @@ aDateTime: 2017-01-01
                 new OpenApiArray
                 {
                     new OpenApiString("fooBar"),
-                    new OpenApiInteger(10),
-                    new OpenApiDouble(2.34),
-                    new OpenApiDateTime(DateTimeOffset.Parse("2017-01-01", CultureInfo.InvariantCulture))
+                    new OpenApiString("10"),
+                    new OpenApiString("2.34"),
+                    new OpenApiString("2017-01-01")
                 });
         }
 
@@ -100,7 +100,7 @@ aDateTime: 2017-01-01
             diagnostic.Errors.Should().BeEmpty();
 
             any.ShouldBeEquivalentTo(
-                new OpenApiInteger(10)
+                new OpenApiString("10")
             );
         }
 
@@ -124,7 +124,7 @@ aDateTime: 2017-01-01
             diagnostic.Errors.Should().BeEmpty();
 
             any.ShouldBeEquivalentTo(
-                new OpenApiDateTime(DateTimeOffset.Parse("2012-07-23T12:33:00", CultureInfo.InvariantCulture))
+                new OpenApiString("2012-07-23T12:33:00")
             );
         }
     }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiMediaTypeTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiMediaTypeTests.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System.IO;
+using FluentAssertions;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.ParseNodes;
+using Microsoft.OpenApi.Readers.V3;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.V3Tests
+{
+    [Collection("DefaultSettings")]
+    public class OpenApiMediaTypeTests
+    {
+        private const string SampleFolderPath = "V3Tests/Samples/OpenApiMediaType/";
+
+        [Fact]
+        public void ParseMediaTypeWithExampleShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "mediaTypeWithExample.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var mediaType = OpenApiV3Deserializer.LoadMediaType(node);
+
+            // Assert
+            mediaType.ShouldBeEquivalentTo(
+                new OpenApiMediaType
+                {
+                    Example = new OpenApiFloat(5),
+                    Schema = new OpenApiSchema
+                    {
+                        Type = "number",
+                        Format = "float"
+                    }
+                });
+        }
+
+        [Fact]
+        public void ParseMediaTypeWithExamplesShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "mediaTypeWithExamples.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var mediaType = OpenApiV3Deserializer.LoadMediaType(node);
+
+            // Assert
+            mediaType.ShouldBeEquivalentTo(
+                new OpenApiMediaType
+                {
+                    Examples =
+                    {
+                        ["example1"] = new OpenApiExample()
+                        {
+                            Value = new OpenApiFloat(5),
+                        },
+                        ["example2"] = new OpenApiExample()
+                        {
+                            Value = new OpenApiFloat((float)7.5),
+                        }
+                    },
+                    Schema = new OpenApiSchema
+                    {
+                        Type = "number",
+                        Format = "float"
+                    }
+                });
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiParameterTests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using FluentAssertions;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
 using Microsoft.OpenApi.Readers.V3;
@@ -271,6 +272,76 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                     Schema = new OpenApiSchema
                     {
                         Type = "string"
+                    }
+                });
+        }
+
+        [Fact]
+        public void ParseParameterWithExampleShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "parameterWithExample.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var parameter = OpenApiV3Deserializer.LoadParameter(node);
+
+            // Assert
+            parameter.ShouldBeEquivalentTo(
+                new OpenApiParameter
+                {
+                    In = null,
+                    Name = "username",
+                    Description = "username to fetch",
+                    Required = true,
+                    Example = new OpenApiFloat(5),
+                    Schema = new OpenApiSchema
+                    {
+                        Type = "number",
+                        Format = "float"
+                    }
+                });
+        }
+
+        [Fact]
+        public void ParseParameterWithExamplesShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "parameterWithExamples.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var parameter = OpenApiV3Deserializer.LoadParameter(node);
+
+            // Assert
+            parameter.ShouldBeEquivalentTo(
+                new OpenApiParameter
+                {
+                    In = null,
+                    Name = "username",
+                    Description = "username to fetch",
+                    Required = true,
+                    Examples =
+                    {
+                        ["example1"] = new OpenApiExample()
+                        {
+                            Value = new OpenApiFloat(5),
+                        },
+                        ["example2"] = new OpenApiExample()
+                        {
+                            Value = new OpenApiFloat((float)7.5),
+                        }
+                    },
+                    Schema = new OpenApiSchema
+                    {
+                        Type = "number",
+                        Format = "float"
                     }
                 });
         }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 {
                     Type = "integer",
                     Format = "int64",
-                    Default = new OpenApiInteger(88)
+                    Default = new OpenApiLong(88)
                 });
         }
 
@@ -120,8 +120,8 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 {
                     ["foo"] = new OpenApiString("bar"),
                     ["baz"] = new OpenApiArray() { 
-                    new OpenApiInteger(1),
-                    new OpenApiInteger(2)
+                        new OpenApiInteger(1),
+                        new OpenApiInteger(2)
                     }
                 });
         }
@@ -314,7 +314,7 @@ get:
                         Example = new OpenApiObject
                         {
                             ["name"] = new OpenApiString("Puma"),
-                            ["id"] = new OpenApiInteger(1)
+                            ["id"] = new OpenApiLong(1)
                         }
                     });
             }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiMediaType/mediaTypeWithExample.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiMediaType/mediaTypeWithExample.yaml
@@ -1,0 +1,8 @@
+﻿name: username
+in: null
+description: username to fetch
+required: true
+example: 5
+schema:
+  type: number
+  format: float

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiMediaType/mediaTypeWithExamples.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiMediaType/mediaTypeWithExamples.yaml
@@ -1,0 +1,12 @@
+﻿name: username
+in: null
+description: username to fetch
+required: true
+examples: 
+  example1: 
+    value: 5
+  example2:
+    value: 7.5
+schema:
+  type: number
+  format: float

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/parameterWithExample.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/parameterWithExample.yaml
@@ -1,0 +1,8 @@
+﻿name: username
+in: null
+description: username to fetch
+required: true
+example: 5
+schema:
+  type: number
+  format: float

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/parameterWithExamples.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiParameter/parameterWithExamples.yaml
@@ -1,0 +1,12 @@
+﻿name: username
+in: null
+description: username to fetch
+required: true
+examples: 
+  example1: 
+    value: 5
+  example2:
+    value: 7.5
+schema:
+  type: number
+  format: float

--- a/test/Microsoft.OpenApi.Tests/DefaultSettingsFixture.cs
+++ b/test/Microsoft.OpenApi.Tests/DefaultSettingsFixture.cs
@@ -19,7 +19,10 @@ namespace Microsoft.OpenApi.Tests
             // given that there are multiple types that can be used for the declared type OpenApiAny.
             // Without this option, properties specific to those types would not be compared.
             AssertionOptions.AssertEquivalencyUsing(
-                o => o.AllowingInfiniteRecursion().RespectingRuntimeTypes());
+                o => o
+                    .AllowingInfiniteRecursion()
+                    .RespectingRuntimeTypes()
+                    .WithStrictOrdering());
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiHeaderValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiHeaderValidationTests.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+using Microsoft.OpenApi.Services;
+using Microsoft.OpenApi.Validations.Rules;
+using Xunit;
+
+namespace Microsoft.OpenApi.Validations.Tests
+{
+    public class OpenApiHeaderValidationTests
+    {
+        [Fact]
+        public void ValidateExampleShouldNotHaveDataTypeMismatchForSimpleSchema()
+        {
+            // Arrange
+            IEnumerable<OpenApiError> errors;
+            var header = new OpenApiHeader()
+            {
+                Required = true,
+                Example = new OpenApiInteger(55),
+                Schema = new OpenApiSchema()
+                {
+                    Type = "string",
+                }
+            };
+
+            // Act
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
+            var walker = new OpenApiWalker(validator);
+            walker.Walk(header);
+
+            errors = validator.Errors;
+            bool result = !errors.Any();
+
+            // Assert
+            result.Should().BeFalse();
+            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            {
+                RuleHelpers.DataTypeMismatchedErrorMessage
+            });
+            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            {
+                "#/example",
+            });
+        }
+
+        [Fact]
+        public void ValidateExamplesShouldNotHaveDataTypeMismatchForSimpleSchema()
+        {
+            // Arrange
+            IEnumerable<OpenApiError> errors;
+
+            var header = new OpenApiHeader()
+            {
+                Required = true,
+                Schema = new OpenApiSchema()
+                {
+                    Type = "object",
+                    AdditionalProperties = new OpenApiSchema()
+                    {
+                        Type = "integer",
+                    }
+                },
+                Examples =
+                    {
+                        ["example0"] = new OpenApiExample()
+                        {
+                            Value = new OpenApiString("1"),
+                        },
+                        ["example1"] = new OpenApiExample()
+                        {
+                           Value = new OpenApiObject()
+                            {
+                                ["x"] = new OpenApiInteger(2),
+                                ["y"] = new OpenApiString("20"),
+                                ["z"] = new OpenApiString("200")
+                            }
+                        },
+                        ["example2"] = new OpenApiExample()
+                        {
+                            Value =
+                            new OpenApiArray()
+                            {
+                                new OpenApiInteger(3)
+                            }
+                        },
+                        ["example3"] = new OpenApiExample()
+                        {
+                            Value = new OpenApiObject()
+                            {
+                                ["x"] = new OpenApiInteger(4),
+                                ["y"] = new OpenApiInteger(40),
+                            }
+                        },
+                    }
+            };
+
+            // Act
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
+            var walker = new OpenApiWalker(validator);
+            walker.Walk(header);
+
+            errors = validator.Errors;
+            bool result = !errors.Any();
+
+            // Assert
+            result.Should().BeFalse();
+            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            {
+                RuleHelpers.DataTypeMismatchedErrorMessage,
+                RuleHelpers.DataTypeMismatchedErrorMessage,
+                RuleHelpers.DataTypeMismatchedErrorMessage,
+            });
+            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            {
+                // #enum/0 is not an error since the spec allows
+                // representing an object using a string.
+                "#/examples/example1/value/y",
+                "#/examples/example1/value/z",
+                "#/examples/example2/value"
+            });
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiMediaTypeValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiMediaTypeValidationTests.cs
@@ -15,59 +15,15 @@ using Xunit;
 
 namespace Microsoft.OpenApi.Validations.Tests
 {
-    public class OpenApiParameterValidationTests
+    public class OpenApiMediaTypeValidationTests
     {
-        [Fact]
-        public void ValidateFieldIsRequiredInParameter()
-        {
-            // Arrange
-            string nameError = String.Format(SRResource.Validation_FieldIsRequired, "name", "parameter");
-            string inError = String.Format(SRResource.Validation_FieldIsRequired, "in", "parameter");
-            var parameter = new OpenApiParameter();
-
-            // Act
-            var errors = parameter.Validate(ValidationRuleSet.GetDefaultRuleSet());
-
-            // Assert
-            errors.Should().NotBeEmpty();
-            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
-            {
-                nameError,
-                inError
-            });
-        }
-
-        [Fact]
-        public void ValidateRequiredIsTrueWhenInIsPathInParameter()
-        {
-            // Arrange
-            var parameter = new OpenApiParameter()
-            {
-                Name = "name",
-                In = ParameterLocation.Path
-            };
-
-            // Act
-            var errors = parameter.Validate(ValidationRuleSet.GetDefaultRuleSet());
-
-            // Assert
-            errors.Should().NotBeEmpty();
-            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
-            {
-                "\"required\" must be true when parameter location is \"path\""
-            });
-        }
-
         [Fact]
         public void ValidateExampleShouldNotHaveDataTypeMismatchForSimpleSchema()
         {
             // Arrange
             IEnumerable<OpenApiError> errors;
-            var parameter = new OpenApiParameter()
+            var mediaType = new OpenApiMediaType()
             {
-                Name = "parameter1",
-                In = ParameterLocation.Path,
-                Required = true,
                 Example = new OpenApiInteger(55),
                 Schema = new OpenApiSchema()
                 {
@@ -78,7 +34,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             // Act
             var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
             var walker = new OpenApiWalker(validator);
-            walker.Walk(parameter);
+            walker.Walk(mediaType);
 
             errors = validator.Errors;
             bool result = !errors.Any();
@@ -101,11 +57,8 @@ namespace Microsoft.OpenApi.Validations.Tests
             // Arrange
             IEnumerable<OpenApiError> errors;
 
-            var parameter = new OpenApiParameter()
+            var mediaType = new OpenApiMediaType()
             {
-                Name = "parameter1",
-                In = ParameterLocation.Path,
-                Required = true,
                 Schema = new OpenApiSchema()
                 {
                     Type = "object",
@@ -151,7 +104,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             // Act
             var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
             var walker = new OpenApiWalker(validator);
-            walker.Walk(parameter);
+            walker.Walk(mediaType);
 
             errors = validator.Errors;
             bool result = !errors.Any();

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiSchemaValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiSchemaValidationTests.cs
@@ -1,0 +1,236 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
+using Microsoft.OpenApi.Services;
+using Microsoft.OpenApi.Validations.Rules;
+using Xunit;
+
+namespace Microsoft.OpenApi.Validations.Tests
+{
+    [Collection("DefaultSettings")]
+    public class OpenApiSchemaValidationTests
+    {
+        [Fact]
+        public void ValidateDefaultShouldNotHaveDataTypeForSimpleSchemaMismatch()
+        {
+            // Arrange
+            IEnumerable<OpenApiError> errors;
+            var schema = new OpenApiSchema()
+            {
+                Default = new OpenApiInteger(55),
+                Type = "string",
+            };
+
+            // Act
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
+            var walker = new OpenApiWalker(validator);
+            walker.Walk(schema);
+
+            errors = validator.Errors;
+            bool result = !errors.Any();
+
+            // Assert
+            result.Should().BeFalse();
+            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            {
+                OpenApiSchemaRules.DataTypeMismatchedErrorMessage
+            });
+            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            {
+                "#/default",
+            });
+        }
+
+        [Fact]
+        public void ValidateExampleAndDefaultShouldNotHaveDataTypeForSimpleSchemaMismatch()
+        {
+            // Arrange
+            IEnumerable<OpenApiError> errors;
+            var schema = new OpenApiSchema()
+            {
+                Example = new OpenApiLong(55),
+                Default = new OpenApiPassword("1234"),
+                Type = "string",
+            };
+
+            // Act
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
+            var walker = new OpenApiWalker(validator);
+            walker.Walk(schema);
+
+            errors = validator.Errors;
+            bool result = !errors.Any();
+
+            // Assert
+            result.Should().BeFalse();
+            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            {
+                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
+                OpenApiSchemaRules.DataTypeMismatchedErrorMessage
+            });
+            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            {
+                "#/default",
+                "#/example",
+            });
+        }
+
+        [Fact]
+        public void ValidateEnumShouldNotHaveDataTypeForSimpleSchemaMismatch()
+        {
+            // Arrange
+            IEnumerable<OpenApiError> errors;
+            var schema = new OpenApiSchema()
+            {
+                Enum =
+                {
+                    new OpenApiString("1"),
+                    new OpenApiObject()
+                    {
+                        ["x"] = new OpenApiInteger(2),
+                        ["y"] = new OpenApiString("20"),
+                        ["z"] = new OpenApiString("200")
+                    },
+                    new OpenApiArray()
+                    {
+                        new OpenApiInteger(3)
+                    },
+                    new OpenApiObject()
+                    {
+                        ["x"] = new OpenApiInteger(4),
+                        ["y"] = new OpenApiInteger(40),
+                    },
+                },
+                Type = "object",
+                AdditionalProperties = new OpenApiSchema()
+                {
+                    Type = "integer",
+                }
+            };
+
+            // Act
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
+            var walker = new OpenApiWalker(validator);
+            walker.Walk(schema);
+
+            errors = validator.Errors;
+            bool result = !errors.Any();
+
+            // Assert
+            result.Should().BeFalse();
+            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            {
+                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
+                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
+                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
+                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
+            });
+            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            {
+                "#/enum/0",
+                "#/enum/1/y",
+                "#/enum/1/z",
+                "#/enum/2"
+            });
+        }
+
+        [Fact]
+        public void ValidateDefaultShouldNotHaveDataTypeForComplexSchemaMismatch()
+        {
+            // Arrange
+            IEnumerable<OpenApiError> errors;
+            var schema = new OpenApiSchema()
+            {
+                Type = "object",
+                Properties =
+                {
+                    ["property1"] = new OpenApiSchema()
+                    {
+                        Type = "array",
+                        Items = new OpenApiSchema()
+                        {
+                            Type = "integer",
+                            Format = "int64"
+                        }
+                    },
+                    ["property2"] = new OpenApiSchema()
+                    {
+                        Type = "array",
+                        Items = new OpenApiSchema()
+                        {
+                            Type = "object",
+                            AdditionalProperties = new OpenApiSchema()
+                            {
+                                Type = "boolean"
+                            }
+                        }
+                    },
+                    ["property3"] = new OpenApiSchema()
+                    {
+                        Type = "string",
+                        Format = "password"
+                    },
+                    ["property4"] = new OpenApiSchema()
+                    {
+                        Type = "string"
+                    }
+                },
+                Default = new OpenApiObject()
+                {
+                    ["property1"] = new OpenApiArray()
+                    {
+                        new OpenApiInteger(12),
+                        new OpenApiLong(13),
+                        new OpenApiString("1"),
+                    },
+                    ["property2"] = new OpenApiArray()
+                    {
+                        new OpenApiInteger(2),
+                        new OpenApiObject()
+                        {
+                            ["x"] = new OpenApiBoolean(true),
+                            ["y"] = new OpenApiBoolean(false),
+                            ["z"] = new OpenApiString("1234"),
+                        }
+                    },
+                    ["property3"] = new OpenApiPassword("123"),
+                    ["property4"] = new OpenApiDateTime(DateTime.UtcNow)
+                }
+            };
+
+            // Act
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
+            var walker = new OpenApiWalker(validator);
+            walker.Walk(schema);
+
+            errors = validator.Errors;
+            bool result = !errors.Any();
+
+            // Assert
+            result.Should().BeFalse();
+            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            {
+                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
+                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
+                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
+                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
+                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
+            });
+            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            {
+                "#/default/property1/0",
+                "#/default/property1/2",
+                "#/default/property2/0",
+                "#/default/property2/1/z",
+                "#/default/property4",
+            });
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiSchemaValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiSchemaValidationTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.Properties;
 using Microsoft.OpenApi.Services;
 using Microsoft.OpenApi.Validations.Rules;
 using Xunit;
@@ -18,7 +17,7 @@ namespace Microsoft.OpenApi.Validations.Tests
     public class OpenApiSchemaValidationTests
     {
         [Fact]
-        public void ValidateDefaultShouldNotHaveDataTypeForSimpleSchemaMismatch()
+        public void ValidateDefaultShouldNotHaveDataTypeMismatchForSimpleSchema()
         {
             // Arrange
             IEnumerable<OpenApiError> errors;
@@ -40,7 +39,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             result.Should().BeFalse();
             errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
-                OpenApiSchemaRules.DataTypeMismatchedErrorMessage
+                RuleHelpers.DataTypeMismatchedErrorMessage
             });
             errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {
@@ -49,7 +48,7 @@ namespace Microsoft.OpenApi.Validations.Tests
         }
 
         [Fact]
-        public void ValidateExampleAndDefaultShouldNotHaveDataTypeForSimpleSchemaMismatch()
+        public void ValidateExampleAndDefaultShouldNotHaveDataTypeMismatchForSimpleSchema()
         {
             // Arrange
             IEnumerable<OpenApiError> errors;
@@ -72,8 +71,8 @@ namespace Microsoft.OpenApi.Validations.Tests
             result.Should().BeFalse();
             errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
-                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
-                OpenApiSchemaRules.DataTypeMismatchedErrorMessage
+                RuleHelpers.DataTypeMismatchedErrorMessage,
+                RuleHelpers.DataTypeMismatchedErrorMessage
             });
             errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {
@@ -83,7 +82,7 @@ namespace Microsoft.OpenApi.Validations.Tests
         }
 
         [Fact]
-        public void ValidateEnumShouldNotHaveDataTypeForSimpleSchemaMismatch()
+        public void ValidateEnumShouldNotHaveDataTypeMismatchForSimpleSchema()
         {
             // Arrange
             IEnumerable<OpenApiError> errors;
@@ -127,14 +126,14 @@ namespace Microsoft.OpenApi.Validations.Tests
             result.Should().BeFalse();
             errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
-                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
-                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
-                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
-                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
+                RuleHelpers.DataTypeMismatchedErrorMessage,
+                RuleHelpers.DataTypeMismatchedErrorMessage,
+                RuleHelpers.DataTypeMismatchedErrorMessage,
             });
             errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {
-                "#/enum/0",
+                // #enum/0 is not an error since the spec allows
+                // representing an object using a string.
                 "#/enum/1/y",
                 "#/enum/1/z",
                 "#/enum/2"
@@ -142,7 +141,7 @@ namespace Microsoft.OpenApi.Validations.Tests
         }
 
         [Fact]
-        public void ValidateDefaultShouldNotHaveDataTypeForComplexSchemaMismatch()
+        public void ValidateDefaultShouldNotHaveDataTypeMismatchForComplexSchema()
         {
             // Arrange
             IEnumerable<OpenApiError> errors;
@@ -217,11 +216,11 @@ namespace Microsoft.OpenApi.Validations.Tests
             result.Should().BeFalse();
             errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
-                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
-                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
-                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
-                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
-                OpenApiSchemaRules.DataTypeMismatchedErrorMessage,
+                RuleHelpers.DataTypeMismatchedErrorMessage,
+                RuleHelpers.DataTypeMismatchedErrorMessage,
+                RuleHelpers.DataTypeMismatchedErrorMessage,
+                RuleHelpers.DataTypeMismatchedErrorMessage,
+                RuleHelpers.DataTypeMismatchedErrorMessage,
             });
             errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {

--- a/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.NotEmpty(rules);
 
             // Update the number if you add new default rule(s).
-            Assert.Equal(17, rules.Count);
+            Assert.Equal(19, rules.Count);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.NotEmpty(rules);
 
             // Update the number if you add new default rule(s).
-            Assert.Equal(19, rules.Count);
+            Assert.Equal(20, rules.Count);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.NotEmpty(rules);
 
             // Update the number if you add new default rule(s).
-            Assert.Equal(16, rules.Count);
+            Assert.Equal(17, rules.Count);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
@@ -95,16 +95,16 @@ namespace Microsoft.OpenApi.Tests.Walkers
 
             locator.Locations.ShouldBeEquivalentTo(new List<string> {
                 "#/servers",
-                "#/tags",
                 "#/paths",
                 "#/paths/~1test",
                 "#/paths/~1test/get",
-                "#/paths/~1test/get/tags",
                 "#/paths/~1test/get/responses",
                 "#/paths/~1test/get/responses/200",
                 "#/paths/~1test/get/responses/200/content",
                 "#/paths/~1test/get/responses/200/content/application~1json",
                 "#/paths/~1test/get/responses/200/content/application~1json/schema",
+                "#/paths/~1test/get/tags",
+                "#/tags",
 
             });
 


### PR DESCRIPTION
Fix #306

- Parse IOpenApiAny with respect to `type` and `format` This handles parsing `default`, `enum`, `example`, and `examples` in both V2 and V3.

- Validation rules added to validate whether there is a mismatch between the given type and the data itself.

- The code is quite involved given that the schema type/format information may not reside at the same level as the Any itself (e.g. the Any deep down in `examples` field in media type needs information form `schema` field).