### PR TITLE
Supporting all header fields inside components/headers

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiHeaderDeserializer.cs
@@ -34,6 +34,12 @@ namespace Microsoft.OpenApi.Readers.V3
                 }
             },
             {
+                "allowEmptyValue", (o, n) =>
+                {
+                    o.AllowEmptyValue = bool.Parse(n.GetScalarValue());
+                }
+            },
+            {
                 "allowReserved", (o, n) =>
                 {
                     o.AllowReserved = bool.Parse(n.GetScalarValue());
@@ -46,11 +52,29 @@ namespace Microsoft.OpenApi.Readers.V3
                 }
             },
             {
+                "explode", (o, n) =>
+                {
+                    o.Explode = bool.Parse(n.GetScalarValue());
+                }
+            },
+            {
                 "schema", (o, n) =>
                 {
                     o.Schema = LoadSchema(n);
                 }
-            }
+            },
+            {
+                "examples", (o, n) =>
+                {
+                    o.Examples = n.CreateMap(LoadExample);
+                }
+            },
+            {
+                "example", (o, n) =>
+                {
+                    o.Example = n.CreateAny();
+                }
+            },
         };
 
         private static readonly PatternFieldMap<OpenApiHeader> _headerPatternFields = new PatternFieldMap<OpenApiHeader>

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -112,6 +112,9 @@
       <EmbeddedResource Include="V3Tests\Samples\OpenApiDocument\minimalDocument.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiDocument\apiWithFullHeaderComponent.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
       <EmbeddedResource Include="V3Tests\Samples\OpenApiDocument\petStore.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -1204,5 +1204,15 @@ paths: {}",
                 Assert.Same(securityRequirement.Keys.First(), openApiDoc.Components.SecuritySchemes.First().Value);
             }
         }
+
+        [Fact]
+        public void HeaderParameterShouldAllowExample()
+        {
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "apiWithFullHeaderComponent.yaml")))
+            {
+                var openApiDoc = new OpenApiStreamReader().Read(stream, out var diagnostic);
+                Assert.Equal(0, diagnostic.Errors.Count);
+            }
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using FluentAssertions;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Validations;
 using Microsoft.OpenApi.Validations.Rules;
@@ -1211,7 +1212,68 @@ paths: {}",
             using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "apiWithFullHeaderComponent.yaml")))
             {
                 var openApiDoc = new OpenApiStreamReader().Read(stream, out var diagnostic);
-                Assert.Equal(0, diagnostic.Errors.Count);
+
+                var exampleHeader = openApiDoc.Components?.Headers?["example-header"];
+                Assert.NotNull(exampleHeader);
+                exampleHeader.ShouldBeEquivalentTo(
+                    new OpenApiHeader()
+                    {
+                        Description = "Test header with example",
+                        Required = true,
+                        Deprecated = true,
+                        AllowEmptyValue = true,
+                        AllowReserved = true,
+                        Style = ParameterStyle.Simple,
+                        Explode = true,
+                        Example = new OpenApiString("99391c7e-ad88-49ec-a2ad-99ddcb1f7721"),
+                        Schema = new OpenApiSchema()
+                        {
+                            Type = "string",
+                            Format = "uuid"
+                        },
+                        Reference = new OpenApiReference()
+                        {
+                            Type = ReferenceType.Header,
+                            Id = "example-header"
+                        }
+                    });
+
+                var examplesHeader = openApiDoc.Components?.Headers?["examples-header"];
+                Assert.NotNull(examplesHeader);
+                examplesHeader.ShouldBeEquivalentTo(
+                    new OpenApiHeader()
+                    {
+                        Description = "Test header with example",
+                        Required = true,
+                        Deprecated = true,
+                        AllowEmptyValue = true,
+                        AllowReserved = true,
+                        Style = ParameterStyle.Simple,
+                        Explode = true,
+                        Examples = new Dictionary<string, OpenApiExample>()
+                        {
+                            { "uuid1", new OpenApiExample()
+                                {
+                                    Value = new OpenApiString("99391c7e-ad88-49ec-a2ad-99ddcb1f7721")
+                                }
+                            },
+                            { "uuid2", new OpenApiExample()
+                                {
+                                    Value = new OpenApiString("99391c7e-ad88-49ec-a2ad-99ddcb1f7721")
+                                }
+                            }
+                        },
+                        Schema = new OpenApiSchema()
+                        {
+                            Type = "string",
+                            Format = "uuid"
+                        },
+                        Reference = new OpenApiReference()
+                        {
+                            Type = ReferenceType.Header,
+                            Id = "examples-header"
+                        }
+                    });
             }
         }
     }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiDocument/apiWithFullHeaderComponent.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiDocument/apiWithFullHeaderComponent.yaml
@@ -2,24 +2,16 @@ openapi: '3.0.0'
 info:
   version: '1.0.0'
   title: Header components
-paths:
-  /:
-    get:
-      responses:
-        '200':
-          description: sample response
-          headers:
-            $ref: "#/components/headers/X-Request-ID"
 components:
   headers:
     example-header:
       description: Test header with example
       required: true
-      deprecated: false
-      allowEmptyValue: false
+      deprecated: true
+      allowEmptyValue: true
       allowReserved: true
       style: simple
-      explode: false
+      explode: true
       example: "99391c7e-ad88-49ec-a2ad-99ddcb1f7721"
       schema:
         type: string
@@ -27,14 +19,16 @@ components:
     examples-header:
       description: Test header with example
       required: true
-      deprecated: false
-      allowEmptyValue: false
+      deprecated: true
+      allowEmptyValue: true
       allowReserved: true
       style: simple
-      explode: false
+      explode: true
       examples:
-        uuid1: "99391c7e-ad88-49ec-a2ad-99ddcb1f7721"
-        uuid2: "99391c7e-ad88-49ec-a2ad-99ddcb1f7721"
+        uuid1: 
+            value: "99391c7e-ad88-49ec-a2ad-99ddcb1f7721"
+        uuid2:
+            value: "99391c7e-ad88-49ec-a2ad-99ddcb1f7721"
       schema:
         type: string
         format: uuid

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiDocument/apiWithFullHeaderComponent.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiDocument/apiWithFullHeaderComponent.yaml
@@ -1,0 +1,40 @@
+openapi: '3.0.0'
+info:
+  version: '1.0.0'
+  title: Header components
+paths:
+  /:
+    get:
+      responses:
+        '200':
+          description: sample response
+          headers:
+            $ref: "#/components/headers/X-Request-ID"
+components:
+  headers:
+    example-header:
+      description: Test header with example
+      required: true
+      deprecated: false
+      allowEmptyValue: false
+      allowReserved: true
+      style: simple
+      explode: false
+      example: "99391c7e-ad88-49ec-a2ad-99ddcb1f7721"
+      schema:
+        type: string
+        format: uuid
+    examples-header:
+      description: Test header with example
+      required: true
+      deprecated: false
+      allowEmptyValue: false
+      allowReserved: true
+      style: simple
+      explode: false
+      examples:
+        uuid1: "99391c7e-ad88-49ec-a2ad-99ddcb1f7721"
+        uuid2: "99391c7e-ad88-49ec-a2ad-99ddcb1f7721"
+      schema:
+        type: string
+        format: uuid


### PR DESCRIPTION
Specification says HeaderObject is a ParameterObject with some minor differences: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#headerObject

components/headers at the same time is defined as Map[string, Header Object \| Reference Object]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#componentsObject

which leads me to believe that components/headers should support full set of properties allowed for ParameterObject with exception of "name" and "in"


