### PR TITLE
Cause scalar string with colon to be quoted #380

### DIFF
--- a/src/Microsoft.OpenApi/Writers/SpecialCharacterStringExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/SpecialCharacterStringExtensions.cs
@@ -42,8 +42,7 @@ namespace Microsoft.OpenApi.Writers
         // http://www.yaml.org/spec/1.2/spec.html#style/flow/plain
         private static readonly string[] _yamlPlainStringForbiddenCombinations =
         {
-            //": ",
-            ":",  // Even though colons can be allowed, this change prevents unquoted trailing colon which causes a problem
+            ": ",
             " #",
 
             // These are technically forbidden only inside flow collections, but
@@ -53,6 +52,13 @@ namespace Microsoft.OpenApi.Writers
             "{",
             "}",
             ","
+        };
+
+        // Plain style strings cannot end with these characters.
+        // http://www.yaml.org/spec/1.2/spec.html#style/flow/plain
+        private static readonly string[] _yamlPlainStringForbiddenTerminals =
+        {
+            ":"
         };
 
         // Double-quoted strings are needed for these non-printable control characters.
@@ -171,6 +177,7 @@ namespace Microsoft.OpenApi.Writers
             // http://www.yaml.org/spec/1.2/spec.html#style/flow/plain
             if (_yamlPlainStringForbiddenCombinations.Any(fc => input.Contains(fc)) ||
                 _yamlIndicators.Any(i => input.StartsWith(i.ToString())) ||
+                _yamlPlainStringForbiddenTerminals.Any(i => input.EndsWith(i.ToString())) ||
                 input.Trim() != input)
             {
                 // Escape single quotes with two single quotes.

--- a/src/Microsoft.OpenApi/Writers/SpecialCharacterStringExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/SpecialCharacterStringExtensions.cs
@@ -42,7 +42,8 @@ namespace Microsoft.OpenApi.Writers
         // http://www.yaml.org/spec/1.2/spec.html#style/flow/plain
         private static readonly string[] _yamlPlainStringForbiddenCombinations =
         {
-            ": ",
+            //": ",
+            ":",  // Even though colons can be allowed, this change prevents unquoted trailing colon which causes a problem
             " #",
 
             // These are technically forbidden only inside flow collections, but

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterSpecialCharacterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterSpecialCharacterTests.cs
@@ -60,6 +60,7 @@ namespace Microsoft.OpenApi.Tests.Writers
         [InlineData("true", " 'true'")]
         [InlineData("trailingspace ", " 'trailingspace '")]
         [InlineData("     trailingspace", " '     trailingspace'")]
+        [InlineData("terminal:", " 'terminal:'")]
         public void WriteStringWithSpecialCharactersAsYamlWorks(string input, string expected)
         {
             // Arrange


### PR DESCRIPTION
A trailing colon in a string causes the YAML parser to think the scaler is a map key.  This change ensures scalars with colons are quoted.  Arguably, we could allow colons in the middle of strings as long as they are not followed by a space but, this change should be sufficient.  Fixes #380 