### PR TITLE
write the binary to base64string and read it as byte[]

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
@@ -195,13 +195,17 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
             if (type == "string" && format == "byte")
             {
-                if ( byte.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var byteValue))
+                if (byte.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var byteValue))
                 {
                     return new OpenApiByte(byteValue);
                 }
             }
 
-            // TODO: Parse byte array to OpenApiBinary type.
+            // binary
+            if (type == "string" && format == "binary")
+            {
+                return new OpenApiBinary(Convert.FromBase64String(value));
+            }
 
             if (type == "string" && format == "date")
             {

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterAnyExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterAnyExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Exceptions;
@@ -170,7 +171,14 @@ namespace Microsoft.OpenApi.Writers
 
                 case PrimitiveType.Binary:
                     var binaryValue = (OpenApiBinary)primitive;
-                    writer.WriteValue(binaryValue.Value);
+                    if (binaryValue == null)
+                    {
+                        writer.WriteNull();
+                    }
+                    else
+                    {
+                        writer.WriteValue(Convert.ToBase64String(binaryValue.Value));
+                    }
                     break;
 
                 case PrimitiveType.Boolean:

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiExampleTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiExampleTests.cs
@@ -29,7 +29,8 @@ namespace Microsoft.OpenApi.Tests.Models
                             new OpenApiObject
                             {
                                 ["href"] = new OpenApiString("http://example.com/1"),
-                                ["rel"] = new OpenApiString("sampleRel1")
+                                ["rel"] = new OpenApiString("sampleRel1"),
+                                ["binary"] = new OpenApiBinary(new byte[] { 1, 2, 3 })
                             }
                         }
                     },
@@ -116,7 +117,8 @@ namespace Microsoft.OpenApi.Tests.Models
         ""links"": [
           {
             ""href"": ""http://example.com/1"",
-            ""rel"": ""sampleRel1""
+            ""rel"": ""sampleRel1"",
+            ""binary"": ""AQID""
           }
         ]
       },


### PR DESCRIPTION
This PR trys to fix the issue at #386 .

Before this change, the library can't write the "byte[]" types.