### PR TITLE
Change OpenApiByte & OpenApiBinary

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Models;
@@ -195,16 +196,23 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
             if (type == "string" && format == "byte")
             {
-                if (byte.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var byteValue))
+                try
                 {
-                    return new OpenApiByte(byteValue);
+                    return new OpenApiByte(Convert.FromBase64String(value));
                 }
+                catch(Exception)
+                { }
             }
 
             // binary
             if (type == "string" && format == "binary")
             {
-                return new OpenApiBinary(Convert.FromBase64String(value));
+                try
+                {
+                    return new OpenApiBinary(Encoding.UTF8.GetBytes(value));
+                }
+                catch(Exception)
+                { }
             }
 
             if (type == "string" && format == "date")

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
@@ -200,7 +200,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 {
                     return new OpenApiByte(Convert.FromBase64String(value));
                 }
-                catch(Exception)
+                catch(FormatException)
                 { }
             }
 
@@ -211,7 +211,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 {
                     return new OpenApiBinary(Encoding.UTF8.GetBytes(value));
                 }
-                catch(Exception)
+                catch(EncoderFallbackException)
                 { }
             }
 

--- a/src/Microsoft.OpenApi/Any/OpenApiByte.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiByte.cs
@@ -6,12 +6,20 @@ namespace Microsoft.OpenApi.Any
     /// <summary>
     /// Open API Byte
     /// </summary>
-    public class OpenApiByte : OpenApiPrimitive<byte>
+    public class OpenApiByte : OpenApiPrimitive<byte[]>
     {
         /// <summary>
         /// Initializes the <see cref="OpenApiByte"/> class.
         /// </summary>
         public OpenApiByte(byte value)
+            : this(new byte[] { value })
+        {
+        }
+
+        /// <summary>
+        /// Initializes the <see cref="OpenApiByte"/> class.
+        /// </summary>
+        public OpenApiByte(byte[] value)
             : base(value)
         {
         }

--- a/src/Microsoft.OpenApi/Any/OpenApiPrimitive.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiPrimitive.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
+using System.Text;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Properties;
 using Microsoft.OpenApi.Writers;
@@ -73,12 +75,28 @@ namespace Microsoft.OpenApi.Any
 
                 case PrimitiveType.Byte:
                     var byteValue = (OpenApiByte)(IOpenApiPrimitive)this;
-                    writer.WriteValue(byteValue.Value);
+                    if (byteValue.Value == null)
+                    {
+                        writer.WriteNull();
+                    }
+                    else
+                    {
+                        writer.WriteValue(Convert.ToBase64String(byteValue.Value));
+                    }
+
                     break;
 
                 case PrimitiveType.Binary:
                     var binaryValue = (OpenApiBinary)(IOpenApiPrimitive)this;
-                    writer.WriteValue(binaryValue.Value);
+                    if (binaryValue.Value == null)
+                    {
+                        writer.WriteNull();
+                    }
+                    else
+                    {
+                        writer.WriteValue(Encoding.UTF8.GetString(binaryValue.Value));
+                    }
+
                     break;
 
                 case PrimitiveType.Boolean:

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterAnyExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterAnyExtensions.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System;
 using System.Collections.Generic;
-using Microsoft.OpenApi.Interfaces;
-using Microsoft.OpenApi.Exceptions;
-using Microsoft.OpenApi.Properties;
 using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Interfaces;
 
 namespace Microsoft.OpenApi.Writers
 {
@@ -137,76 +134,8 @@ namespace Microsoft.OpenApi.Writers
                 throw Error.ArgumentNull(nameof(primitive));
             }
 
-            switch (primitive.PrimitiveType)
-            {
-                case PrimitiveType.Integer:
-                    var intValue = (OpenApiInteger)primitive;
-                    writer.WriteValue(intValue.Value);
-                    break;
-
-                case PrimitiveType.Long:
-                    var longValue = (OpenApiLong)primitive;
-                    writer.WriteValue(longValue.Value);
-                    break;
-
-                case PrimitiveType.Float:
-                    var floatValue = (OpenApiFloat)primitive;
-                    writer.WriteValue(floatValue.Value);
-                    break;
-
-                case PrimitiveType.Double:
-                    var doubleValue = (OpenApiDouble)primitive;
-                    writer.WriteValue(doubleValue.Value);
-                    break;
-
-                case PrimitiveType.String:
-                    var stringValue = (OpenApiString)primitive;
-                    writer.WriteValue(stringValue.Value);
-                    break;
-
-                case PrimitiveType.Byte:
-                    var byteValue = (OpenApiByte)primitive;
-                    writer.WriteValue(byteValue.Value);
-                    break;
-
-                case PrimitiveType.Binary:
-                    var binaryValue = (OpenApiBinary)primitive;
-                    if (binaryValue == null)
-                    {
-                        writer.WriteNull();
-                    }
-                    else
-                    {
-                        writer.WriteValue(Convert.ToBase64String(binaryValue.Value));
-                    }
-                    break;
-
-                case PrimitiveType.Boolean:
-                    var boolValue = (OpenApiBoolean)primitive;
-                    writer.WriteValue(boolValue.Value);
-                    break;
-
-                case PrimitiveType.Date:
-                    var dateValue = (OpenApiDate)primitive;
-                    writer.WriteValue(dateValue.Value);
-                    break;
-
-                case PrimitiveType.DateTime:
-                    var dateTimeValue = (OpenApiDateTime)primitive;
-                    writer.WriteValue(dateTimeValue.Value);
-                    break;
-
-                case PrimitiveType.Password:
-                    var passwordValue = (OpenApiPassword)primitive;
-                    writer.WriteValue(passwordValue.Value);
-                    break;
-
-                default:
-                    throw new OpenApiWriterException(
-                        string.Format(
-                            SRResource.PrimitiveTypeNotSupported,
-                            primitive.PrimitiveType));
-            }
+            // The Spec version is meaning for the Any type, so it's ok to use the latest one.
+            primitive.Write(writer, OpenApiSpecVersion.OpenApi3_0);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiExampleTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiExampleTests.cs
@@ -31,7 +31,8 @@ namespace Microsoft.OpenApi.Tests.Models
                             {
                                 ["href"] = new OpenApiString("http://example.com/1"),
                                 ["rel"] = new OpenApiString("sampleRel1"),
-                                ["binary"] = new OpenApiBinary(new byte[] { 1, 2, 3 })
+                                ["bytes"] = new OpenApiByte(new byte[] { 1, 2, 3 }),
+                                ["binary"] = new OpenApiBinary(new byte[] { 41, 42, 43 })
                             }
                         }
                     },
@@ -119,7 +120,8 @@ namespace Microsoft.OpenApi.Tests.Models
           {
             ""href"": ""http://example.com/1"",
             ""rel"": ""sampleRel1"",
-            ""binary"": ""AQID""
+            ""bytes"": ""AQID"",
+            ""binary"": "")*+""
           }
         ]
       },

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiExampleTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiExampleTests.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.IO;
+using System.Text;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
@@ -32,7 +33,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["href"] = new OpenApiString("http://example.com/1"),
                                 ["rel"] = new OpenApiString("sampleRel1"),
                                 ["bytes"] = new OpenApiByte(new byte[] { 1, 2, 3 }),
-                                ["binary"] = new OpenApiBinary(new byte[] { 41, 42, 43 })
+                                ["binary"] = new OpenApiBinary(Encoding.UTF8.GetBytes("Ñ😻😑♮Í☛oƞ♑😲☇éǋžŁ♻😟¥a´Ī♃ƠąøƩ"))
                             }
                         }
                     },
@@ -121,7 +122,7 @@ namespace Microsoft.OpenApi.Tests.Models
             ""href"": ""http://example.com/1"",
             ""rel"": ""sampleRel1"",
             ""bytes"": ""AQID"",
-            ""binary"": "")*+""
+            ""binary"": ""Ñ😻😑♮Í☛oƞ♑😲☇éǋžŁ♻😟¥a´Ī♃ƠąøƩ""
           }
         ]
       },


### PR DESCRIPTION
1. Change OpenApiByte
2. Change OpenApiBinary
3. Chang the OpenApiByte & OpenApiBinary serialization/desalinization.

Below are the discussions:

@darrelmiller 
Admittedly, the schema is unnecessary, but there are examples in the spec that show this.  In this scenario the format: binary is used to indicate that there is no special serialization that is performed on the bytes.  They are raw.  If you try and present them as a string, they might not create printable text.

This is not a problem in 90% of cases because for the definition of an API you don’t need to include any data.  The spec says the parameter contains binary data and tooling knows not to do any processing on it.  That’s obviously potentially tricky if it is in a URL parameter! However, for us, the only place it causes a problem is in examples.   In examples it is important that the user chooses example data that can be serialized into printable strings.  Or not include a sample for binary data as it is somewhat redundant.

This brings me back to my suggestion that for examples of binary data, if they are present, we should just assume that they can successfully be rendered as UTF8 strings and that they will roundtrip.  If it doesn’t work, then the user should choose an example of binary data that can be stored in UTF-8 because that’s a limitation of the OpenAPI spec.

This will ensure that round tripping works just fine.  However, if someone manually creates an OpenAPI document via the DOM and assigns an arbitrary set of bytes that cannot be represented as UTF-8 characters then it will not round trip.  Ironically, this is good because it will discourage people from using format “binary”.  If we “fix” this bug to make it serialize properly then we will hide the problem and people will expect other OpenAPI implementations to process the issue properly.  But we don’t control how other implementations will interpret binary.

