### PR TITLE
Fix to properly assign schemas to content of all media types of all r…

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiOperationDeserializer.cs
@@ -136,6 +136,9 @@ namespace Microsoft.OpenApi.Readers.V2
                 ProcessProduces(node.CheckMapNode("responses"), response, node.Context);
             }
 
+            // Reset so that it's not picked up later
+            node.Context.SetTempStorage(TempStorageKeys.OperationProduces, null);
+
             return operation;
         }
 

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.OpenApi.Readers.V2
                 response.Content = new Dictionary<string, OpenApiMediaType>();
             }
 
-            if (produces != null && produces.Count > 0)
+            if (produces != null)
             {
                 foreach (var produce in produces)
                 {

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -13,6 +13,9 @@
         <AssemblyOriginatorKeyFile>..\..\src\Microsoft.OpenApi.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
     <ItemGroup>
+      <None Remove="V2Tests\Samples\multipleProduces.json" />
+    </ItemGroup>
+    <ItemGroup>
       <EmbeddedResource Include="OpenApiReaderTests\Samples\unsupported.v1.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
@@ -96,6 +99,9 @@
       </EmbeddedResource>
       <EmbeddedResource Include="V2Tests\Samples\OpenApiSecurityScheme\oauth2PasswordSecurityScheme.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V2Tests\Samples\multipleProduces.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </EmbeddedResource>
       <EmbeddedResource Include="V2Tests\Samples\twoResponses.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -13,9 +13,6 @@
         <AssemblyOriginatorKeyFile>..\..\src\Microsoft.OpenApi.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
     <ItemGroup>
-      <None Remove="V2Tests\Samples\multipleProduces.json" />
-    </ItemGroup>
-    <ItemGroup>
       <EmbeddedResource Include="OpenApiReaderTests\Samples\unsupported.v1.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
@@ -159,25 +158,12 @@ paths: {}",
                 Assert.NotNull(doc.Paths["/items"]);
                 Assert.Equal(3, doc.Paths["/items"].Operations.Count);
 
-                foreach (var operation in doc.Paths["/items"].Operations)
+                var successSchema = new OpenApiSchema()
                 {
-                    Assert.Equal(2, operation.Value.Responses.Count);
-
-                    var okResponse = operation.Value.Responses["200"];
-                    okResponse.ShouldBeEquivalentTo(
-                        new OpenApiResponse()
-                        {
-                            Description = "An OK response",
-                            Content =
-                            {
-                                ["application/json"] = new OpenApiMediaType()
-                                {
-                                    Schema = new OpenApiSchema()
-                                    {
-                                        Type = "array",
-                                        Items = new OpenApiSchema()
-                                        {
-                                            Properties = new Dictionary<string, OpenApiSchema>()
+                    Type = "array",
+                    Items = new OpenApiSchema()
+                    {
+                        Properties = new Dictionary<string, OpenApiSchema>()
                                             {
                                                 { "id", new OpenApiSchema()
                                                     {
@@ -186,29 +172,16 @@ paths: {}",
                                                     }
                                                 }
                                             },
-                                            Reference = new OpenApiReference()
-                                            {
-                                                Type = ReferenceType.Schema,
-                                                Id = "Item"
-                                            }
-                                        }
-                                    },
-                                }
-                            }
-                        });
-
-                    var errorResponse = operation.Value.Responses["default"];
-                    errorResponse.ShouldBeEquivalentTo(
-                        new OpenApiResponse()
+                        Reference = new OpenApiReference()
                         {
-                            Description = "An error response",
-                            Content =
-                            {
-                                ["application/json"] = new OpenApiMediaType()
-                                {
-                                    Schema = new OpenApiSchema()
-                                    {
-                                        Properties = new Dictionary<string, OpenApiSchema>()
+                            Type = ReferenceType.Schema,
+                            Id = "Item"
+                        }
+                    }
+                };
+                var errorSchema = new OpenApiSchema()
+                {
+                    Properties = new Dictionary<string, OpenApiSchema>()
                                         {
                                             { "code", new OpenApiSchema()
                                                 {
@@ -227,12 +200,48 @@ paths: {}",
                                                 }
                                             }
                                         },
-                                        Reference = new OpenApiReference()
-                                        {
-                                            Type = ReferenceType.Schema,
-                                            Id = "Error"
-                                        }
-                                    },
+                    Reference = new OpenApiReference()
+                    {
+                        Type = ReferenceType.Schema,
+                        Id = "Error"
+                    }
+                };
+                foreach (var operation in doc.Paths["/items"].Operations)
+                {
+                    Assert.Equal(2, operation.Value.Responses.Count);
+
+                    var okResponse = operation.Value.Responses["200"];
+                    okResponse.ShouldBeEquivalentTo(
+                        new OpenApiResponse()
+                        {
+                            Description = "An OK response",
+                            Content =
+                            {
+                                ["application/json"] = new OpenApiMediaType()
+                                {
+                                    Schema = successSchema,
+                                },
+                                ["application/xml"] = new OpenApiMediaType()
+                                {
+                                    Schema = successSchema,
+                                }
+                            }
+                        });
+
+                    var errorResponse = operation.Value.Responses["default"];
+                    errorResponse.ShouldBeEquivalentTo(
+                        new OpenApiResponse()
+                        {
+                            Description = "An error response",
+                            Content =
+                            {
+                                ["application/json"] = new OpenApiMediaType()
+                                {
+                                    Schema = errorSchema,
+                                },
+                                ["application/xml"] = new OpenApiMediaType()
+                                {
+                                    Schema = errorSchema,
                                 }
                             }
                         });

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
@@ -236,6 +237,31 @@ paths: {}",
                             }
                         });
                 }
+            }
+        }
+
+        [Fact]
+        public void ShouldAssignSchemaToAllResponses()
+        {
+            OpenApiDocument document;
+            OpenApiDiagnostic diagnostic;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "multipleProduces.json")))
+            {
+                document = new OpenApiStreamReader().Read(stream, out diagnostic);
+            }
+
+            Assert.Equal(OpenApiSpecVersion.OpenApi2_0, diagnostic.SpecificationVersion);
+
+            var responses = document.Paths["/items"].Operations[OperationType.Get].Responses;
+            foreach (var content in responses.Values.Select(r => r.Content))
+            {
+                var json = content["application/json"];
+                Assert.NotNull(json);
+                Assert.NotNull(json.Schema);
+
+                var xml = content["application/xml"];
+                Assert.NotNull(xml);
+                Assert.NotNull(xml.Schema);
             }
         }
     }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
@@ -179,6 +179,7 @@ paths: {}",
                         }
                     }
                 };
+
                 var errorSchema = new OpenApiSchema()
                 {
                     Properties = new Dictionary<string, OpenApiSchema>()
@@ -206,6 +207,7 @@ paths: {}",
                         Id = "Error"
                     }
                 };
+
                 foreach (var operation in doc.Paths["/items"].Operations)
                 {
                     Assert.Equal(2, operation.Value.Responses.Count);
@@ -215,17 +217,7 @@ paths: {}",
                         new OpenApiResponse()
                         {
                             Description = "An OK response",
-                            Content =
-                            {
-                                ["application/json"] = new OpenApiMediaType()
-                                {
-                                    Schema = successSchema,
-                                },
-                                ["application/xml"] = new OpenApiMediaType()
-                                {
-                                    Schema = successSchema,
-                                }
-                            }
+                            Content = GetMediaTypes(successSchema, operation.Key != OperationType.Post)
                         });
 
                     var errorResponse = operation.Value.Responses["default"];
@@ -233,18 +225,21 @@ paths: {}",
                         new OpenApiResponse()
                         {
                             Description = "An error response",
-                            Content =
-                            {
-                                ["application/json"] = new OpenApiMediaType()
-                                {
-                                    Schema = errorSchema,
-                                },
-                                ["application/xml"] = new OpenApiMediaType()
-                                {
-                                    Schema = errorSchema,
-                                }
-                            }
+                            Content = GetMediaTypes(errorSchema, operation.Key != OperationType.Post)
                         });
+                }
+
+                IDictionary<string, OpenApiMediaType> GetMediaTypes(OpenApiSchema schema, bool includeXml)
+                {
+                    var mediaTypes = new Dictionary<string, OpenApiMediaType>
+                    {
+                        ["application/json"] = new OpenApiMediaType() { Schema = schema }
+                    };
+                    if (includeXml)
+                    {
+                        mediaTypes["application/xml"] = new OpenApiMediaType() { Schema = schema };
+                    }
+                    return mediaTypes;
                 }
             }
         }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/multipleProduces.json
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/multipleProduces.json
@@ -1,0 +1,62 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Multiple produces",
+        "version": "1.0.0"
+    },
+    "schemes": [
+        "https"
+    ],
+    "basePath": "/",
+    "paths": {
+        "/items": {
+            "get": {
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "An OK response",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Item"
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "An error response",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Item": {
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Item identifier."
+                }
+            }
+        },
+        "Error": {
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "fields": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/twoResponses.json
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/twoResponses.json
@@ -78,8 +78,7 @@
         }
     },
     "produces": [
-        "application/json",
-        "application/xml"
+        "application/json"
     ],
     "definitions": {
         "Item": {

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/twoResponses.json
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/twoResponses.json
@@ -12,7 +12,8 @@
         "/items": {
             "get": {
                 "produces": [
-                    "application/json"
+                    "application/json",
+                    "application/xml"
                 ],
                 "responses": {
                     "200": {
@@ -70,13 +71,15 @@
                     }
                 },
                 "produces": [
-                    "application/json"
+                    "application/json",
+                    "application/xml"
                 ]
             }
         }
     },
     "produces": [
-        "application/json"
+        "application/json",
+        "application/xml"
     ],
     "definitions": {
         "Item": {


### PR DESCRIPTION
It is an error to clean temp schema storage after processing single "produces" item since it's per response. Thus moving it outside by cleaning it only if there are any "produces" items to accomodate for scenario when "produces" is specified after "paths"