### PR TITLE
Allow null as a valid data when schema.nullable is set to true

### DIFF
--- a/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
@@ -114,11 +114,6 @@ namespace Microsoft.OpenApi.Validations.Rules
                     return;
                 }
 
-                if (value is OpenApiNull)
-                {
-                    return;
-                }
-
                 // If value is not a string and also not an array, there is a data mismatch.
                 if (!(value is OpenApiArray))
                 {

--- a/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
@@ -40,9 +40,9 @@ namespace Microsoft.OpenApi.Validations.Rules
         }
 
         public static void ValidateDataTypeMismatch(
-            IValidationContext context, 
-            string ruleName, 
-            IOpenApiAny value, 
+            IValidationContext context,
+            string ruleName,
+            IOpenApiAny value,
             OpenApiSchema schema)
         {
             if (schema == null)
@@ -52,6 +52,17 @@ namespace Microsoft.OpenApi.Validations.Rules
 
             var type = schema.Type;
             var format = schema.Format;
+            var nullable = schema.Nullable;
+
+            // Before checking the type, check first if the schema allows null.
+            // If so and the data given is also null, this is allowed for any type.
+            if (nullable)
+            {
+                if (value is OpenApiNull)
+                {
+                    return;
+                }
+            }
 
             if (type == "object")
             {
@@ -99,6 +110,11 @@ namespace Microsoft.OpenApi.Validations.Rules
                 // To represent examples of media types that cannot naturally be represented in JSON or YAML,
                 // a string value can contain the example with escaping where necessary
                 if (value is OpenApiString)
+                {
+                    return;
+                }
+
+                if (value is OpenApiNull)
                 {
                     return;
                 }


### PR DESCRIPTION
Fix #394 

Allow OpenApiNull as the data when schema specifies `nullable` as true

Note that this applies to all data types, even arrays, objects, and strings. Per JSON schema, objects, arrays, strings, etc. are separate from the null types. If the schema wants to allow the objects, arrays, etc. to be nullable, the nullable boolean must be specifically set to true. (In JSON schema, this is done by using type : ["array", "null"], which is not allowed in OpenAPI spec).

### Reference:

#### JSON Schema
At its core, JSON Schema defines the following basic types:

string
Numeric types
object
array
boolean
null

#### OpenAPI Nullable

Primitive data types in the OAS are based on the types supported by the JSON Schema Specification Wright Draft 00. Note that integer as a type is also supported and is defined as a JSON number without a fraction or exponent part. null is not supported as a type (see nullable for an alternative solution). Models are defined using the Schema Object, which is an extended subset of JSON Schema Specification Wright Draft 00.