### PR TITLE
Serialize explode value properly on parameters with style "form"

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
@@ -177,7 +177,7 @@ namespace Microsoft.OpenApi.Models
             writer.WriteProperty(OpenApiConstants.Style, Style?.GetDisplayName());
 
             // explode
-            writer.WriteProperty(OpenApiConstants.Explode, Explode, false);
+            writer.WriteProperty(OpenApiConstants.Explode, Explode, Style.HasValue && Style.Value == ParameterStyle.Form);
 
             // allowReserved
             writer.WriteProperty(OpenApiConstants.AllowReserved, AllowReserved, false);

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using FluentAssertions;
+using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Writers;
@@ -56,6 +57,50 @@ namespace Microsoft.OpenApi.Tests.Models
                     Description = "description3"
                 }
             }
+        };
+
+        public static OpenApiParameter ParameterWithFormStyleAndExplodeFalse = new OpenApiParameter
+        {
+            Name = "name1",
+            In = ParameterLocation.Query,
+            Description = "description1",
+            Style = ParameterStyle.Form,
+            Explode = false,
+            Schema = new OpenApiSchema
+            {
+                Type = "array",
+                Items = new OpenApiSchema
+                {
+                    Enum = new List<IOpenApiAny>
+                    {
+                        new OpenApiString("value1"),
+                        new OpenApiString("value2")
+                    }
+                }
+            }
+
+        };
+
+        public static OpenApiParameter ParameterWithFormStyleAndExplodeTrue = new OpenApiParameter
+        {
+            Name = "name1",
+            In = ParameterLocation.Query,
+            Description = "description1",
+            Style = ParameterStyle.Form,
+            Explode = true,
+            Schema = new OpenApiSchema
+            {
+                Type = "array",
+                Items = new OpenApiSchema
+                {
+                    Enum = new List<IOpenApiAny>
+                    {
+                        new OpenApiString("value1"),
+                        new OpenApiString("value2")
+                    }
+                }
+            }
+
         };
 
         public static OpenApiParameter AdvancedHeaderParameterWithSchemaReference = new OpenApiParameter
@@ -301,6 +346,75 @@ namespace Microsoft.OpenApi.Tests.Models
 
             // Act
             AdvancedHeaderParameterWithSchemaTypeObject.SerializeAsV2(writer);
+            writer.Flush();
+            var actual = outputStringWriter.GetStringBuilder().ToString();
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeParameterWithFormStyleAndExplodeFalseWorks()
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiJsonWriter(outputStringWriter);
+            var expected =
+                @"{
+  ""name"": ""name1"",
+  ""in"": ""query"",
+  ""description"": ""description1"",
+  ""style"": ""form"",
+  ""explode"": false,
+  ""schema"": {
+    ""type"": ""array"",
+    ""items"": {
+      ""enum"": [
+        ""value1"",
+        ""value2""
+      ]
+    }
+  }
+}";
+
+            // Act
+            ParameterWithFormStyleAndExplodeFalse.SerializeAsV3WithoutReference(writer);
+            writer.Flush();
+            var actual = outputStringWriter.GetStringBuilder().ToString();
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeParameterWithFormStyleAndExplodeTrueWorks()
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiJsonWriter(outputStringWriter);
+            var expected =
+                @"{
+  ""name"": ""name1"",
+  ""in"": ""query"",
+  ""description"": ""description1"",
+  ""style"": ""form"",
+  ""schema"": {
+    ""type"": ""array"",
+    ""items"": {
+      ""enum"": [
+        ""value1"",
+        ""value2""
+      ]
+    }
+  }
+}";
+
+            // Act
+            ParameterWithFormStyleAndExplodeTrue.SerializeAsV3WithoutReference(writer);
             writer.Flush();
             var actual = outputStringWriter.GetStringBuilder().ToString();
 


### PR DESCRIPTION
When a parameter has the style set to "form" and explode set to false,
the v3 serializer will not write out the value for explode. Swagger UI
then defaults the explode value to true, since it is not specified and
that is the correct default value when the style is set to "form". The
OpenAPI spec for this is right around here:

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields-10

I'll be glad to make any changes required to get his accepted.