### PR TITLE
Use context specific storage for param parsing

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/TempStorageKeys.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/TempStorageKeys.cs
@@ -15,5 +15,6 @@ namespace Microsoft.OpenApi.Readers.V2
         public const string OperationConsumes = "operationConsumes";
         public const string GlobalConsumes = "globalConsumes";
         public const string GlobalProduces = "globalProduces";
+        public const string ParameterIsBodyOrFormData = "parameterIsBodyOrFormData";
     }
 }


### PR DESCRIPTION
Change from a static variable to temp storage scoped to the parse
context to fix thread-safety issue in v2 parameter parsing.

Fixes #416 