### PR TITLE
Collapsed components that are references

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ParseNodes/MapNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/MapNode.cs
@@ -100,11 +100,15 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                      {
                          return null;  // Body Parameters shouldn't be converted to Parameters
                      }
-                     entry.value.Reference = new OpenApiReference()
+                     // If the component isn't a reference to another component, then point it to itself.
+                     if (entry.value.Reference == null)
                      {
-                         Type = referenceType,
-                         Id = entry.key
-                     };
+                         entry.value.Reference = new OpenApiReference()
+                         {
+                             Type = referenceType,
+                             Id = entry.key
+                         };
+                     }
                      return entry;
                  }
                  );

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -13,6 +13,9 @@
         <AssemblyOriginatorKeyFile>..\..\src\Microsoft.OpenApi.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
     <ItemGroup>
+      <None Remove="V2Tests\Samples\ComponentRootReference.json" />
+    </ItemGroup>
+    <ItemGroup>
       <EmbeddedResource Include="OpenApiReaderTests\Samples\unsupported.v1.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
@@ -24,6 +27,9 @@
       </EmbeddedResource>
       <EmbeddedResource Include="V2Tests\Samples\basic.v3.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V2Tests\Samples\ComponentRootReference.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </EmbeddedResource>
       <EmbeddedResource Include="V2Tests\Samples\minimal.v2.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
@@ -316,5 +316,24 @@ paths: {}",
                 xml.Schema.ShouldBeEquivalentTo(targetSchema);
             }
         }
+
+
+        [Fact]
+        public void ShouldAllowComponentsThatJustContainAReference()
+        {
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "ComponentRootReference.json")))
+            {
+                OpenApiStreamReader reader = new OpenApiStreamReader();
+                OpenApiDocument doc = reader.Read(stream, out OpenApiDiagnostic diags);
+                OpenApiSchema schema1 = doc.Components.Schemas["AllPets"];
+                Assert.False(schema1.UnresolvedReference);
+                OpenApiSchema schema2 = (OpenApiSchema)doc.ResolveReference(schema1.Reference);
+                if (schema2.UnresolvedReference && schema1.Reference.Id == schema2.Reference.Id)
+                {
+                    // detected a cycle - this code gets triggered
+                    Assert.True(false, "A cycle should not be detected");
+                }
+            }
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/ComponentRootReference.json
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/ComponentRootReference.json
@@ -1,0 +1,178 @@
+{
+	"openapi": "3.0.0",
+	"info": {
+		"version": "1.0.0",
+		"title": "Swagger Petstore",
+		"license": {
+			"name": "MIT"
+		}
+	},
+	"servers": [
+		{
+			"url": "http://petstore.swagger.io/v1"
+		}
+	],
+	"paths": {
+		"/pets": {
+			"get": {
+				"summary": "List all pets",
+				"operationId": "listPets",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "limit",
+						"in": "query",
+						"description": "How many items to return at one time (max 100)",
+						"required": false,
+						"schema": {
+							"type": "integer",
+							"format": "int32"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "A paged array of pets",
+						"headers": {
+							"x-next": {
+								"description": "A link to the next page of responses",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AllPets"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "unexpected error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Error"
+								}
+							}
+						}
+					}
+				}
+			},
+			"post": {
+				"summary": "Create a pet",
+				"operationId": "createPets",
+				"tags": [
+					"pets"
+				],
+				"responses": {
+					"201": {
+						"description": "Null response"
+					},
+					"default": {
+						"description": "unexpected error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Error"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/pets/{petId}": {
+			"get": {
+				"summary": "Info for a specific pet",
+				"operationId": "showPetById",
+				"tags": [
+					"pets"
+				],
+				"parameters": [
+					{
+						"name": "petId",
+						"in": "path",
+						"required": true,
+						"description": "The id of the pet to retrieve",
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Expected response to a valid request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Pets"
+								}
+							}
+						}
+					},
+					"default": {
+						"description": "unexpected error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Error"
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	},
+	"components": {
+		"schemas": {
+			"Pet": {
+				"required": [
+					"id",
+					"name"
+				],
+				"properties": {
+					"id": {
+						"type": "integer",
+						"format": "int64"
+					},
+					"name": {
+						"type": "string"
+					},
+					"tag": {
+						"type": "string"
+					}
+				}
+			},
+			"Pets": {
+				"type": "array",
+				"items": {
+					"$ref": "#/components/schemas/Pet"
+				}
+			},
+			"AllPets": {
+				"$ref": "#/components/schemas/Pets"
+			},
+			"Error": {
+				"required": [
+					"code",
+					"message"
+				],
+				"properties": {
+					"code": {
+						"type": "integer",
+						"format": "int32"
+					},
+					"message": {
+						"type": "string"
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Attempt to fix #415 
This is only partial fix.  It does ensure that the object model is valid however, due to the way references are resolved we lose the fact that in the original document the reference was to AllPets as it gets collapsed down to Pets.  More investigation is required.
