### PR TITLE
Make lib async

### DIFF
--- a/src/Microsoft.OpenApi/Any/OpenApiArray.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiArray.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.OpenApi.Writers;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Microsoft.OpenApi.Any
 {
@@ -32,6 +33,23 @@ namespace Microsoft.OpenApi.Any
 
             writer.WriteEndArray();
 
+        }
+
+        /// <summary>
+        /// Write out contents of OpenApiArray to passed writer
+        /// </summary>
+        /// <param name="writer">Instance of JSON or YAML writer.</param>
+        /// <param name="specVersion">Version of the OpenAPI specification that that will be output.</param>
+        public async Task WriteAsync(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
+        {
+            await writer.WriteStartArrayAsync();
+
+            foreach (var item in this)
+            {
+                await writer.WriteAnyAsync(item);
+            }
+
+            await writer.WriteEndArrayAsync();
         }
     }
 }

--- a/src/Microsoft.OpenApi/Any/OpenApiNull.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiNull.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Writers;
 
 namespace Microsoft.OpenApi.Any
@@ -23,6 +24,16 @@ namespace Microsoft.OpenApi.Any
         public void Write(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
         {
             writer.WriteAny(this);
+        }
+
+        /// <summary>
+        /// Write out null representation
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="specVersion">Version of the OpenAPI specification that that will be output.</param>
+        public async Task WriteAsync(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
+        {
+            await writer.WriteAnyAsync(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Any/OpenApiObject.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiObject.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Writers;
 
 namespace Microsoft.OpenApi.Any
@@ -32,6 +33,25 @@ namespace Microsoft.OpenApi.Any
             }
 
             writer.WriteEndObject();
+
+        }
+        
+        /// <summary>
+        /// Serialize OpenApiObject to writer
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="specVersion">Version of the OpenAPI specification that that will be output.</param>
+        public async Task WriteAsync(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
+        {
+            await writer.WriteStartObjectAsync();
+
+            foreach (var item in this)
+            {
+                await writer.WritePropertyNameAsync(item.Key);
+                await writer.WriteAnyAsync(item.Value);
+            }
+
+            await writer.WriteEndObjectAsync();
 
         }
     }

--- a/src/Microsoft.OpenApi/Any/OpenApiPrimitive.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiPrimitive.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Properties;
 using Microsoft.OpenApi.Writers;
@@ -117,6 +118,95 @@ namespace Microsoft.OpenApi.Any
                 case PrimitiveType.Password:
                     var passwordValue = (OpenApiPassword)(IOpenApiPrimitive)this;
                     writer.WriteValue(passwordValue.Value);
+                    break;
+
+                default:
+                    throw new OpenApiWriterException(
+                        string.Format(
+                            SRResource.PrimitiveTypeNotSupported,
+                            this.PrimitiveType));
+            }
+
+        }
+        
+        /// <summary>
+        /// Write out content of primitive element
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="specVersion"></param>
+        public async Task WriteAsync(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
+        {
+            switch (this.PrimitiveType)
+            {
+                case PrimitiveType.Integer:
+                    var intValue = (OpenApiInteger)(IOpenApiPrimitive)this;
+                    await writer.WriteValueAsync(intValue.Value);
+                    break;
+
+                case PrimitiveType.Long:
+                    var longValue = (OpenApiLong)(IOpenApiPrimitive)this;
+                    await writer.WriteValueAsync(longValue.Value);
+                    break;
+
+                case PrimitiveType.Float:
+                    var floatValue = (OpenApiFloat)(IOpenApiPrimitive)this;
+                    await writer.WriteValueAsync(floatValue.Value);
+                    break;
+
+                case PrimitiveType.Double:
+                    var doubleValue = (OpenApiDouble)(IOpenApiPrimitive)this;
+                    await writer.WriteValueAsync(doubleValue.Value);
+                    break;
+
+                case PrimitiveType.String:
+                    var stringValue = (OpenApiString)(IOpenApiPrimitive)this;
+                    await writer.WriteValueAsync(stringValue.Value);
+                    break;
+
+                case PrimitiveType.Byte:
+                    var byteValue = (OpenApiByte)(IOpenApiPrimitive)this;
+                    if (byteValue.Value == null)
+                    {
+                        await writer.WriteNullAsync();
+                    }
+                    else
+                    {
+                        await writer.WriteValueAsync(Convert.ToBase64String(byteValue.Value));
+                    }
+
+                    break;
+
+                case PrimitiveType.Binary:
+                    var binaryValue = (OpenApiBinary)(IOpenApiPrimitive)this;
+                    if (binaryValue.Value == null)
+                    {
+                        await writer.WriteNullAsync();
+                    }
+                    else
+                    {
+                        await writer.WriteValueAsync(Encoding.UTF8.GetString(binaryValue.Value));
+                    }
+
+                    break;
+
+                case PrimitiveType.Boolean:
+                    var boolValue = (OpenApiBoolean)(IOpenApiPrimitive)this;
+                    await writer.WriteValueAsync(boolValue.Value);
+                    break;
+
+                case PrimitiveType.Date:
+                    var dateValue = (OpenApiDate)(IOpenApiPrimitive)this;
+                    await writer.WriteValueAsync(dateValue.Value);
+                    break;
+
+                case PrimitiveType.DateTime:
+                    var dateTimeValue = (OpenApiDateTime)(IOpenApiPrimitive)this;
+                    await writer.WriteValueAsync(dateTimeValue.Value);
+                    break;
+
+                case PrimitiveType.Password:
+                    var passwordValue = (OpenApiPassword)(IOpenApiPrimitive)this;
+                    await writer.WriteValueAsync(passwordValue.Value);
                     break;
 
                 default:

--- a/src/Microsoft.OpenApi/Extensions/OpenApiSerializableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiSerializableExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Properties;
@@ -27,6 +28,19 @@ namespace Microsoft.OpenApi.Extensions
         {
             element.Serialize(stream, specVersion, OpenApiFormat.Json);
         }
+        
+        /// <summary>
+        /// Serialize the <see cref="IOpenApiSerializable"/> to the Open API document (JSON) using the given stream and specification version.
+        /// </summary>
+        /// <typeparam name="T">the <see cref="IOpenApiSerializable"/></typeparam>
+        /// <param name="element">The Open API element.</param>
+        /// <param name="stream">The output stream.</param>
+        /// <param name="specVersion">The Open API specification version.</param>
+        public static async Task SerializeAsJsonAsync<T>(this T element, Stream stream, OpenApiSpecVersion specVersion)
+            where T : IOpenApiSerializable
+        {
+            await element.SerializeAsync(stream, specVersion, OpenApiFormat.Json);
+        }
 
         /// <summary>
         /// Serializes the <see cref="IOpenApiSerializable"/> to the Open API document (YAML) using the given stream and specification version.
@@ -39,6 +53,19 @@ namespace Microsoft.OpenApi.Extensions
             where T : IOpenApiSerializable
         {
             element.Serialize(stream, specVersion, OpenApiFormat.Yaml);
+        }
+        
+        /// <summary>
+        /// Serializes the <see cref="IOpenApiSerializable"/> to the Open API document (YAML) using the given stream and specification version.
+        /// </summary>
+        /// <typeparam name="T">the <see cref="IOpenApiSerializable"/></typeparam>
+        /// <param name="element">The Open API element.</param>
+        /// <param name="stream">The output stream.</param>
+        /// <param name="specVersion">The Open API specification version.</param>
+        public static async Task SerializeAsYamlAsync<T>(this T element, Stream stream, OpenApiSpecVersion specVersion)
+            where T : IOpenApiSerializable
+        {
+            await element.SerializeAsync(stream, specVersion, OpenApiFormat.Yaml);
         }
 
         /// <summary>
@@ -78,6 +105,44 @@ namespace Microsoft.OpenApi.Extensions
 
             element.Serialize(writer, specVersion);
         }
+        
+        /// <summary>
+        /// Serializes the <see cref="IOpenApiSerializable"/> to the Open API document using
+        /// the given stream, specification version and the format.
+        /// </summary>
+        /// <typeparam name="T">the <see cref="IOpenApiSerializable"/></typeparam>
+        /// <param name="element">The Open API element.</param>
+        /// <param name="stream">The given stream.</param>
+        /// <param name="specVersion">The Open API specification version.</param>
+        /// <param name="format">The output format (JSON or YAML).</param>
+        public static async Task SerializeAsync<T>(
+            this T element,
+            Stream stream,
+            OpenApiSpecVersion specVersion,
+            OpenApiFormat format)
+            where T : IOpenApiSerializable
+        {
+            if (stream == null)
+            {
+                throw Error.ArgumentNull(nameof(stream));
+            }
+
+            IOpenApiWriter writer;
+            var streamWriter = new FormattingStreamWriter(stream, CultureInfo.InvariantCulture);
+            switch (format)
+            {
+                case OpenApiFormat.Json:
+                    writer = new OpenApiJsonWriter(streamWriter);
+                    break;
+                case OpenApiFormat.Yaml:
+                    writer = new OpenApiYamlWriter(streamWriter);
+                    break;
+                default:
+                    throw new OpenApiException(string.Format(SRResource.OpenApiFormatNotSupported, format));
+            }
+
+            await element.SerializeAsync(writer, specVersion);
+        }
 
         /// <summary>
         /// Serializes the <see cref="IOpenApiSerializable"/> to Open API document using the given specification version and writer.
@@ -115,6 +180,43 @@ namespace Microsoft.OpenApi.Extensions
 
             writer.Flush();
         }
+        
+        /// <summary>
+        /// Serializes the <see cref="IOpenApiSerializable"/> to Open API document using the given specification version and writer.
+        /// </summary>
+        /// <typeparam name="T">the <see cref="IOpenApiSerializable"/></typeparam>
+        /// <param name="element">The Open API element.</param>
+        /// <param name="writer">The output writer.</param>
+        /// <param name="specVersion">Version of the specification the output should conform to</param>
+        public static async Task SerializeAsync<T>(this T element, IOpenApiWriter writer, OpenApiSpecVersion specVersion)
+            where T : IOpenApiSerializable
+        {
+            if (element == null)
+            {
+                throw Error.ArgumentNull(nameof(element));
+            }
+
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            switch (specVersion)
+            {
+                case OpenApiSpecVersion.OpenApi3_0:
+                    await element.SerializeAsV3Async(writer);
+                    break;
+
+                case OpenApiSpecVersion.OpenApi2_0:
+                    await element.SerializeAsV2(writer);
+                    break;
+
+                default:
+                    throw new OpenApiException(string.Format(SRResource.OpenApiSpecVersionNotSupported, specVersion));
+            }
+
+            await writer.FlushAsync();
+        }
 
         /// <summary>
         /// Serializes the <see cref="IOpenApiSerializable"/> to the Open API document as a string in JSON format.
@@ -129,6 +231,20 @@ namespace Microsoft.OpenApi.Extensions
         {
             return element.Serialize(specVersion, OpenApiFormat.Json);
         }
+        
+        /// <summary>
+        /// Serializes the <see cref="IOpenApiSerializable"/> to the Open API document as a string in JSON format.
+        /// </summary>
+        /// <typeparam name="T">the <see cref="IOpenApiSerializable"/></typeparam>
+        /// <param name="element">The Open API element.</param>
+        /// <param name="specVersion">The Open API specification version.</param>
+        public static async Task<string> SerializeAsJsonAsync<T>(
+            this T element,
+            OpenApiSpecVersion specVersion)
+            where T : IOpenApiSerializable
+        {
+            return await element.SerializeAsync(specVersion, OpenApiFormat.Json);
+        }
 
         /// <summary>
         /// Serializes the <see cref="IOpenApiSerializable"/> to the Open API document as a string in YAML format.
@@ -142,6 +258,20 @@ namespace Microsoft.OpenApi.Extensions
             where T : IOpenApiSerializable
         {
             return element.Serialize(specVersion, OpenApiFormat.Yaml);
+        }
+        
+        /// <summary>
+        /// Serializes the <see cref="IOpenApiSerializable"/> to the Open API document as a string in YAML format.
+        /// </summary>
+        /// <typeparam name="T">the <see cref="IOpenApiSerializable"/></typeparam>
+        /// <param name="element">The Open API element.</param>
+        /// <param name="specVersion">The Open API specification version.</param>
+        public static async Task<string> SerializeAsYamlAsync<T>(
+            this T element,
+            OpenApiSpecVersion specVersion)
+            where T : IOpenApiSerializable
+        {
+            return await element.SerializeAsync(specVersion, OpenApiFormat.Yaml);
         }
 
         /// <summary>
@@ -170,6 +300,36 @@ namespace Microsoft.OpenApi.Extensions
                 using (var streamReader = new StreamReader(stream))
                 {
                     return streamReader.ReadToEnd();
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Serializes the <see cref="IOpenApiSerializable"/> to the Open API document as a string in the given format.
+        /// </summary>
+        /// <typeparam name="T">the <see cref="IOpenApiSerializable"/></typeparam>
+        /// <param name="element">The Open API element.</param>
+        /// <param name="specVersion">The Open API specification version.</param>
+        /// <param name="format">Open API document format.</param>
+        public static async Task<string> SerializeAsync<T>(
+            this T element,
+            OpenApiSpecVersion specVersion,
+            OpenApiFormat format)
+            where T : IOpenApiSerializable
+        {
+            if (element == null)
+            {
+                throw Error.ArgumentNull(nameof(element));
+            }
+
+            using (var stream = new MemoryStream())
+            {
+                await element.SerializeAsync(stream, specVersion, format);
+                stream.Position = 0;
+
+                using (var streamReader = new StreamReader(stream))
+                {
+                    return await streamReader.ReadToEndAsync();
                 }
             }
         }

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiExtension.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiExtension.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Writers;
 
 namespace Microsoft.OpenApi.Interfaces
@@ -16,5 +17,12 @@ namespace Microsoft.OpenApi.Interfaces
         /// <param name="writer"></param>
         /// <param name="specVersion">Version of the OpenAPI specification that that will be output.</param>
         void Write(IOpenApiWriter writer, OpenApiSpecVersion specVersion);
+        
+        /// <summary>
+        /// Write out contents of custom extension
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="specVersion">Version of the OpenAPI specification that that will be output.</param>
+        Task WriteAsync(IOpenApiWriter writer, OpenApiSpecVersion specVersion);
     }
 }

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiSerializable.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiSerializable.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Writers;
 
 namespace Microsoft.OpenApi.Interfaces
@@ -21,5 +22,17 @@ namespace Microsoft.OpenApi.Interfaces
         /// </summary>
         /// <param name="writer">The writer.</param>
         void SerializeAsV2(IOpenApiWriter writer);
+
+        /// <summary>
+        /// Serialize Open API element to v3.0.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        Task SerializeAsV3Async(IOpenApiWriter writer);
+
+        /// <summary>
+        /// Serialize Open API element to v2.0.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        Task SerializeAsV2Async(IOpenApiWriter writer);
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Expressions;
 using Microsoft.OpenApi.Interfaces;
@@ -78,11 +79,29 @@ namespace Microsoft.OpenApi.Models
             
             SerializeAsV3WithoutReference(writer);
         }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiCallback"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            if (Reference != null)
+            {
+                await Reference.SerializeAsV3Async(writer);
+                return;
+            }
+            
+            await SerializeAsV3WithoutReferenceAsync(writer);
+        }
 
         /// <summary>
         /// Serialize to OpenAPI V3 document without using reference.
         /// </summary>
-
         public void SerializeAsV3WithoutReference(IOpenApiWriter writer)
         {
             writer.WriteStartObject();
@@ -105,6 +124,36 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             // Callback object does not exist in V2.
+        }
+
+       
+        
+        /// <summary>
+        /// Serialize to OpenAPI V3 document without using reference.
+        /// </summary>
+        public async Task SerializeAsV3WithoutReferenceAsync(IOpenApiWriter writer)
+        {
+            await writer.WriteStartObjectAsync();
+
+            // path items
+            foreach (var item in PathItems)
+            {
+                await writer.WriteRequiredObjectAsync(item.Key.Expression, item.Value, (w, p) => p.SerializeAsV3(w));
+            }
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
+
+        /// <summary>
+        /// Serialize <see cref="OpenApiCallback"/> to Open Api v2.0
+        /// </summary>
+        public Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            // Callback object does not exist in V2.
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -250,11 +251,204 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
+        /// Serialize <see cref="OpenApiComponents"/> to Open Api v3.0.
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // Serialize each referenceable object as full object without reference if the reference in the object points to itself.
+            // If the reference exists but points to other objects, the object is serialized to just that reference.
+
+            // schemas
+            await writer.WriteOptionalMapAsync(
+                OpenApiConstants.Schemas,
+                Schemas,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Schema &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
+
+            // responses
+            writer.WriteOptionalMap(
+                OpenApiConstants.Responses,
+                Responses,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Response &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
+
+            // parameters
+            writer.WriteOptionalMap(
+                OpenApiConstants.Parameters,
+                Parameters,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Parameter &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
+
+            // examples
+            writer.WriteOptionalMap(
+                OpenApiConstants.Examples,
+                Examples,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Example &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
+
+            // requestBodies
+            writer.WriteOptionalMap(
+                OpenApiConstants.RequestBodies,
+                RequestBodies,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.RequestBody &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
+
+            // headers
+            writer.WriteOptionalMap(
+                OpenApiConstants.Headers,
+                Headers,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Header &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
+
+            // securitySchemes
+            writer.WriteOptionalMap(
+                OpenApiConstants.SecuritySchemes,
+                SecuritySchemes,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.SecurityScheme &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
+
+            // links
+            writer.WriteOptionalMap(
+                OpenApiConstants.Links,
+                Links,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Link &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
+
+            // callbacks
+            writer.WriteOptionalMap(
+                OpenApiConstants.Callbacks,
+                Callbacks,
+                (w, key, component) =>
+                {
+                    if (component.Reference != null &&
+                        component.Reference.Type == ReferenceType.Callback &&
+                        component.Reference.Id == key)
+                    {
+                        component.SerializeAsV3WithoutReference(w);
+                    }
+                    else
+                    {
+                        component.SerializeAsV3(w);
+                    }
+                });
+
+            // extensions
+            writer.WriteExtensions(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            writer.WriteEndObject();
+        }
+
+
+        /// <summary>
         /// Serialize <see cref="OpenApiComponents"/> to Open Api v2.0.
         /// </summary>
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             // Components object does not exist in V2.
+        }
+
+        /// <summary>
+        /// Serialize <see cref="OpenApiComponents"/> to Open Api v2.0.
+        /// </summary>
+        public Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            // Components object does not exist in V2.
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiContact.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiContact.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -42,6 +43,14 @@ namespace Microsoft.OpenApi.Models
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi3_0);
         }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiContact"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            await WriteInternalAsync(writer, OpenApiSpecVersion.OpenApi3_0);
+        }
 
         /// <summary>
         /// Serialize <see cref="OpenApiContact"/> to Open Api v2.0
@@ -49,6 +58,14 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi2_0);
+        }
+
+        /// <summary>
+        /// Serialize <see cref="OpenApiContact"/> to Open Api v2.0
+        /// </summary>
+        public async Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            await WriteInternalAsync(writer, OpenApiSpecVersion.OpenApi2_0);
         }
 
         private void WriteInternal(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
@@ -73,6 +90,30 @@ namespace Microsoft.OpenApi.Models
             writer.WriteExtensions(Extensions, specVersion);
 
             writer.WriteEndObject();
+        }
+        
+        private async Task WriteInternalAsync(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // name
+            await writer.WritePropertyAsync(OpenApiConstants.Name, Name);
+
+            // url
+            await writer.WritePropertyAsync(OpenApiConstants.Url, Url?.OriginalString);
+
+            // email
+            await writer.WritePropertyAsync(OpenApiConstants.Email, Email);
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, specVersion);
+
+            await writer.WriteEndObjectAsync();
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiDiscriminator.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDiscriminator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
 
@@ -41,6 +42,35 @@ namespace Microsoft.OpenApi.Models
             writer.WriteOptionalMap(OpenApiConstants.Mapping, Mapping, (w, s) => w.WriteValue(s));
 
             writer.WriteEndObject();
+        }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiDiscriminator"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // propertyName
+            await writer.WritePropertyAsync(OpenApiConstants.PropertyName, PropertyName);
+
+            // mapping
+            await writer.WriteOptionalMapAsync(OpenApiConstants.Mapping, Mapping, (w, s) => w.WriteValue(s));
+
+            await writer.WriteEndObjectAsync();
+        }
+
+        /// <summary>
+        /// Serialize <see cref="OpenApiDiscriminator"/> to Open Api v2.0
+        /// </summary>
+        public Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiEncoding.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiEncoding.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
@@ -87,11 +88,52 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
+        /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v3.0.
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull("writer");
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // contentType
+            await writer.WritePropertyAsync(OpenApiConstants.ContentType, ContentType);
+
+            // headers
+            await writer.WriteOptionalMapAsync(OpenApiConstants.Headers, Headers, async (w, h) => await h.SerializeAsV3Async(w));
+
+            // style
+            await writer.WritePropertyAsync(OpenApiConstants.Style, Style?.GetDisplayName());
+
+            // explode
+            await writer.WritePropertyAsync(OpenApiConstants.Explode, Explode, false);
+
+            // allowReserved
+            await writer.WritePropertyAsync(OpenApiConstants.AllowReserved, AllowReserved, false);
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
+        
+        /// <summary>
         /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v2.0.
         /// </summary>
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             // nothing here
+        }
+
+        /// <summary>
+        /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v2.0.
+        /// </summary>
+        public Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiExample.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExample.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -74,6 +75,25 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
+        /// Serialize <see cref="OpenApiExample"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            if (Reference != null)
+            {
+                await Reference.SerializeAsV3Async(writer);
+                return;
+            }
+
+            await SerializeAsV3WithoutReferenceAsync(writer);
+        }
+
+        /// <summary>
         /// Serialize to OpenAPI V3 document without using reference.
         /// </summary>
         public void SerializeAsV3WithoutReference(IOpenApiWriter writer)
@@ -99,6 +119,32 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
+        /// Serialize to OpenAPI V3 document without using reference.
+        /// </summary>
+        public async Task SerializeAsV3WithoutReferenceAsync(IOpenApiWriter writer)
+        {
+            await writer.WriteStartObjectAsync();
+
+            // summary
+            await writer.WritePropertyAsync(OpenApiConstants.Summary, Summary);
+
+            // description
+            await writer.WritePropertyAsync(OpenApiConstants.Description, Description);
+
+            // value
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Value, Value, (w, v) => w.WriteAny(v));
+
+            // externalValue
+            await writer.WritePropertyAsync(OpenApiConstants.ExternalValue, ExternalValue);
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
+
+
+        /// <summary>
         /// Serialize <see cref="OpenApiExample"/> to Open Api v2.0
         /// </summary>
         public void SerializeAsV2(IOpenApiWriter writer)
@@ -106,6 +152,15 @@ namespace Microsoft.OpenApi.Models
             // Example object of this form does not exist in V2.
             // V2 Example object requires knowledge of media type and exists only
             // in Response object, so it will be serialized as a part of the Response object.
+        }
+
+
+        /// <summary>
+        /// Serialize <see cref="OpenApiExample"/> to Open Api v2.0
+        /// </summary>
+        public Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -43,6 +44,28 @@ namespace Microsoft.OpenApi.Models
 
             writer.WriteEndObject();
         }
+        
+        /// <summary>
+        /// Serialize to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            foreach (var item in this)
+            {
+                await writer.WriteRequiredObjectAsync(item.Key, item.Value, async (w, p) => await p.SerializeAsV3Async(w));
+            }
+
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
 
         /// <summary>
         /// Serialize to Open Api v2.0
@@ -64,6 +87,28 @@ namespace Microsoft.OpenApi.Models
             writer.WriteExtensions(Extensions, OpenApiSpecVersion.OpenApi2_0);
 
             writer.WriteEndObject();
+        }
+        
+        /// <summary>
+        /// Serialize to Open Api v2.0
+        /// </summary>
+        public async Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            foreach (var item in this)
+            {
+                await writer.WriteRequiredObjectAsync(item.Key, item.Value, async (w, p) => await p.SerializeAsV2Async(w));
+            }
+
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi2_0);
+
+            await writer.WriteEndObjectAsync();
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiExternalDocs.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExternalDocs.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -38,11 +39,27 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
+        /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v3.0.
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            await WriteInternalAsync(writer, OpenApiSpecVersion.OpenApi3_0);
+        }
+        
+        /// <summary>
         /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v2.0.
         /// </summary>
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi2_0);
+        }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v2.0.
+        /// </summary>
+        public async Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            await WriteInternalAsync(writer, OpenApiSpecVersion.OpenApi2_0);
         }
 
         private void WriteInternal(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
@@ -64,6 +81,27 @@ namespace Microsoft.OpenApi.Models
             writer.WriteExtensions(Extensions, specVersion);
 
             writer.WriteEndObject();
+        }
+
+        private async Task WriteInternalAsync(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // description
+            await writer.WritePropertyAsync(OpenApiConstants.Description, Description);
+
+            // url
+            await writer.WritePropertyAsync(OpenApiConstants.Url, Url?.OriginalString);
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, specVersion);
+
+            await writer.WriteEndObjectAsync();
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
@@ -104,6 +105,25 @@ namespace Microsoft.OpenApi.Models
 
             SerializeAsV3WithoutReference(writer);
         }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiHeader"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            if (Reference != null)
+            {
+                await Reference.SerializeAsV3Async(writer);
+                return;
+            }
+
+            await SerializeAsV3WithoutReferenceAsync(writer);
+        }
 
         /// <summary>
         /// Serialize to OpenAPI V3 document without using reference.
@@ -150,6 +170,52 @@ namespace Microsoft.OpenApi.Models
 
             writer.WriteEndObject();
         }
+        
+        /// <summary>
+        /// Serialize to OpenAPI V3 document without using reference.
+        /// </summary>
+        public async Task SerializeAsV3WithoutReferenceAsync(IOpenApiWriter writer)
+        {
+            await writer.WriteStartObjectAsync();
+
+            // description
+            await writer.WritePropertyAsync(OpenApiConstants.Description, Description);
+
+            // required
+            await writer.WritePropertyAsync(OpenApiConstants.Required, Required, false);
+
+            // deprecated
+            await writer.WritePropertyAsync(OpenApiConstants.Deprecated, Deprecated, false);
+
+            // allowEmptyValue
+            await writer.WritePropertyAsync(OpenApiConstants.AllowEmptyValue, AllowEmptyValue, false);
+
+            // style
+            await writer.WritePropertyAsync(OpenApiConstants.Style, Style?.GetDisplayName());
+
+            // explode
+            await writer.WritePropertyAsync(OpenApiConstants.Explode, Explode, false);
+
+            // allowReserved
+            await writer.WritePropertyAsync(OpenApiConstants.AllowReserved, AllowReserved, false);
+
+            // schema
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Schema, Schema, (w, s) => s.SerializeAsV3(w));
+
+            // example
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Example, Example, (w, s) => w.WriteAny(s));
+
+            // examples
+            await writer.WriteOptionalMapAsync(OpenApiConstants.Examples, Examples, (w, e) => e.SerializeAsV3(w));
+
+            // content
+            await writer.WriteOptionalMapAsync(OpenApiConstants.Content, Content, (w, c) => c.SerializeAsV3(w));
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
 
         /// <summary>
         /// Serialize <see cref="OpenApiHeader"/> to Open Api v2.0
@@ -168,6 +234,25 @@ namespace Microsoft.OpenApi.Models
             }
 
             SerializeAsV2WithoutReference(writer);
+        }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiHeader"/> to Open Api v2.0
+        /// </summary>
+        public async Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            if (Reference != null)
+            {
+                await Reference.SerializeAsV2Async(writer);
+                return;
+            }
+
+            await SerializeAsV2WithoutReferenceAsync(writer);
         }
 
         /// <summary>
@@ -208,6 +293,46 @@ namespace Microsoft.OpenApi.Models
             writer.WriteExtensions(Extensions, OpenApiSpecVersion.OpenApi2_0);
 
             writer.WriteEndObject();
+        }
+        
+        /// <summary>
+        /// Serialize to OpenAPI V2 document without using reference.
+        /// </summary>
+        public async Task SerializeAsV2WithoutReferenceAsync(IOpenApiWriter writer)
+        {
+            await writer.WriteStartObjectAsync();
+
+            // description
+            await writer.WritePropertyAsync(OpenApiConstants.Description, Description);
+
+            // required
+            await writer.WritePropertyAsync(OpenApiConstants.Required, Required, false);
+
+            // deprecated
+            await writer.WritePropertyAsync(OpenApiConstants.Deprecated, Deprecated, false);
+
+            // allowEmptyValue
+            await writer.WritePropertyAsync(OpenApiConstants.AllowEmptyValue, AllowEmptyValue, false);
+
+            // style
+            await writer.WritePropertyAsync(OpenApiConstants.Style, Style?.GetDisplayName());
+
+            // explode
+            await writer.WritePropertyAsync(OpenApiConstants.Explode, Explode, false);
+
+            // allowReserved
+            await writer.WritePropertyAsync(OpenApiConstants.AllowReserved, AllowReserved, false);
+
+            // schema
+            await Schema?.WriteAsItemsPropertiesAsync(writer);
+
+            // example
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Example, Example, (w, s) => w.WriteAny(s));
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi2_0);
+
+            await writer.WriteEndObjectAsync();
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiInfo.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiInfo.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -84,6 +85,42 @@ namespace Microsoft.OpenApi.Models
 
             writer.WriteEndObject();
         }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiInfo"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // title
+            await writer.WritePropertyAsync(OpenApiConstants.Title, Title);
+
+            // description
+            await writer.WritePropertyAsync(OpenApiConstants.Description, Description);
+
+            // termsOfService
+            await writer.WritePropertyAsync(OpenApiConstants.TermsOfService, TermsOfService?.OriginalString);
+
+            // contact object
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Contact, Contact, async (w, c) => await c.SerializeAsV3Async(w));
+
+            // license object
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.License, License, async (w, l) => await l.SerializeAsV3Async(w));
+
+            // version
+            await writer.WritePropertyAsync(OpenApiConstants.Version, Version);
+
+            // specification extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
 
         /// <summary>
         /// Serialize <see cref="OpenApiInfo"/> to Open Api v2.0
@@ -119,6 +156,42 @@ namespace Microsoft.OpenApi.Models
             writer.WriteExtensions(Extensions, OpenApiSpecVersion.OpenApi2_0);
 
             writer.WriteEndObject();
+        }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiInfo"/> to Open Api v2.0
+        /// </summary>
+        public async Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // title
+            await writer.WritePropertyAsync(OpenApiConstants.Title, Title);
+
+            // description
+            await writer.WritePropertyAsync(OpenApiConstants.Description, Description);
+
+            // termsOfService
+            await writer.WritePropertyAsync(OpenApiConstants.TermsOfService, TermsOfService?.OriginalString);
+
+            // contact object
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Contact, Contact, async (w, c) => await c.SerializeAsV2Async(w));
+
+            // license object
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.License, License, async (w, l) => await l.SerializeAsV2Async(w));
+
+            // version
+            await writer.WritePropertyAsync(OpenApiConstants.Version, Version);
+
+            // specification extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi2_0);
+
+            await writer.WriteEndObjectAsync();
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -36,6 +37,14 @@ namespace Microsoft.OpenApi.Models
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi3_0);
         }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiLicense"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            await WriteInternalAsync(writer, OpenApiSpecVersion.OpenApi3_0);
+        }
 
         /// <summary>
         /// Serialize <see cref="OpenApiLicense"/> to Open Api v2.0
@@ -43,6 +52,14 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi2_0);
+        }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiLicense"/> to Open Api v2.0
+        /// </summary>
+        public async Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            await WriteInternalAsync(writer, OpenApiSpecVersion.OpenApi2_0);
         }
 
         private void WriteInternal(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
@@ -64,6 +81,27 @@ namespace Microsoft.OpenApi.Models
             writer.WriteExtensions(Extensions, specVersion);
 
             writer.WriteEndObject();
+        }
+        
+        private async Task WriteInternalAsync(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // name
+            await writer.WritePropertyAsync(OpenApiConstants.Name, Name);
+
+            // url
+            await writer.WritePropertyAsync(OpenApiConstants.Url, Url?.OriginalString);
+
+            // specification extensions
+            await writer.WriteExtensionsAsync(Extensions, specVersion);
+
+            await writer.WriteEndObjectAsync();
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -74,11 +75,49 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
+        /// Serialize <see cref="OpenApiMediaType"/> to Open Api v3.0.
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // schema
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Schema, Schema, async (w, s) => await s.SerializeAsV3Async(w));
+
+            // example
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Example, Example, async (w, e) => await w.WriteAnyAsync(e));
+
+            // examples
+            await writer.WriteOptionalMapAsync(OpenApiConstants.Examples, Examples, async (w, e) => await e.SerializeAsV3Async(w));
+
+            // encoding
+            await writer.WriteOptionalMapAsync(OpenApiConstants.Encoding, Encoding, async (w, e) => await e.SerializeAsV3Async(w));
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
+
+        /// <summary>
         /// Serialize <see cref="OpenApiMediaType"/> to Open Api v2.0.
         /// </summary>
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             // Media type does not exist in V2.
+        }
+
+        /// <summary>
+        /// Serialize <see cref="OpenApiMediaType"/> to Open Api v2.0.
+        /// </summary>
+        public Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiOAuthFlow.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOAuthFlow.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -72,11 +73,50 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
+        /// Serialize <see cref="OpenApiOAuthFlow"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // authorizationUrl
+            await writer.WritePropertyAsync(OpenApiConstants.AuthorizationUrl, AuthorizationUrl?.ToString());
+
+            // tokenUrl
+            await writer.WritePropertyAsync(OpenApiConstants.TokenUrl, TokenUrl?.ToString());
+
+            // refreshUrl
+            await writer.WritePropertyAsync(OpenApiConstants.RefreshUrl, RefreshUrl?.ToString());
+
+            // scopes
+            await writer.WriteRequiredMapAsync(OpenApiConstants.Scopes, Scopes, async (w, s) => await w.WriteValueAsync(s));
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
+
+
+        /// <summary>
         /// Serialize <see cref="OpenApiOAuthFlow"/> to Open Api v2.0
         /// </summary>
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             // OAuthFlow object does not exist in V2.
+        }
+
+        /// <summary>
+        /// Serialize <see cref="OpenApiOAuthFlow"/> to Open Api v2.0
+        /// </summary>
+        public Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiOAuthFlows.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOAuthFlows.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -75,11 +76,55 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
+        /// Serialize <see cref="OpenApiOAuthFlows"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // implicit
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Implicit, Implicit, async (w, o) => await o.SerializeAsV3Async(w));
+
+            // password
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Password, Password, async (w, o) => await o.SerializeAsV3Async(w));
+
+            // clientCredentials
+            await writer.WriteOptionalObjectAsync(
+                OpenApiConstants.ClientCredentials,
+                ClientCredentials,
+                async (w, o) => await o.SerializeAsV3Async(w));
+
+            // authorizationCode
+            await writer .WriteOptionalObjectAsync(
+                OpenApiConstants.AuthorizationCode,
+                AuthorizationCode,
+                async (w, o) => await o.SerializeAsV3Async(w));
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
+
+        /// <summary>
         /// Serialize <see cref="OpenApiOAuthFlows"/> to Open Api v2.0
         /// </summary>
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             // OAuthFlows object does not exist in V2.
+        }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiOAuthFlows"/> to Open Api v2.0
+        /// </summary>
+        public Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiReference.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiReference.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -138,6 +139,38 @@ namespace Microsoft.OpenApi.Models
 
             writer.WriteEndObject();
         }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiReference"/> to Open Api v3.0.
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            if (Type == ReferenceType.Tag)
+            {
+                // Write the string value only
+                await writer.WriteValueAsync(ReferenceV3);
+                return;
+            }
+
+            if (Type == ReferenceType.SecurityScheme)
+            {
+                // Write the string as property name
+                await writer.WritePropertyNameAsync(ReferenceV3);
+                return;
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // $ref
+            await writer.WritePropertyAsync(OpenApiConstants.DollarRef, ReferenceV3);
+
+            await writer.WriteEndObjectAsync();
+        }
 
         /// <summary>
         /// Serialize <see cref="OpenApiReference"/> to Open Api v2.0.
@@ -169,6 +202,38 @@ namespace Microsoft.OpenApi.Models
             writer.WriteProperty(OpenApiConstants.DollarRef, ReferenceV2);
 
             writer.WriteEndObject();
+        }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiReference"/> to Open Api v2.0.
+        /// </summary>
+        public async Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            if (Type == ReferenceType.Tag)
+            {
+                // Write the string value only
+                await writer.WriteValueAsync(ReferenceV2);
+                return;
+            }
+
+            if (Type == ReferenceType.SecurityScheme)
+            {
+                // Write the string as property name
+                await writer.WritePropertyNameAsync(ReferenceV2);
+                return;
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // $ref
+            await writer.WritePropertyAsync(OpenApiConstants.DollarRef, ReferenceV2);
+
+            await writer.WriteEndObjectAsync();
         }
 
         private string GetExternalReference()

--- a/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -63,6 +64,25 @@ namespace Microsoft.OpenApi.Models
 
             SerializeAsV3WithoutReference(writer);
         }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiRequestBody"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            if (Reference != null)
+            {
+                await Reference.SerializeAsV3Async(writer);
+                return;
+            }
+
+            await SerializeAsV3WithoutReferenceAsync(writer);
+        }
 
         /// <summary>
         /// Serialize to OpenAPI V3 document without using reference.
@@ -85,6 +105,28 @@ namespace Microsoft.OpenApi.Models
 
             writer.WriteEndObject();
         }
+        
+        /// <summary>
+        /// Serialize to OpenAPI V3 document without using reference.
+        /// </summary>
+        public async Task SerializeAsV3WithoutReferenceAsync(IOpenApiWriter writer)
+        {
+            await writer.WriteStartObjectAsync();
+
+            // description
+            await writer.WritePropertyAsync(OpenApiConstants.Description, Description);
+
+            // content
+            await writer.WriteRequiredMapAsync(OpenApiConstants.Content, Content, async (w, c) => await c.SerializeAsV3Async(w));
+
+            // required
+            await writer.WritePropertyAsync(OpenApiConstants.Required, Required, false);
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
 
         /// <summary>
         /// Serialize <see cref="OpenApiRequestBody"/> to Open Api v2.0
@@ -92,6 +134,15 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             // RequestBody object does not exist in V2.
+        }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiRequestBody"/> to Open Api v2.0
+        /// </summary>
+        public Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            // RequestBody object does not exist in V2.
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -261,6 +262,25 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
+        /// Serialize <see cref="OpenApiSchema"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            if (Reference != null)
+            {
+                await Reference.SerializeAsV3Async(writer);
+                return;
+            }
+
+            await SerializeAsV3WithoutReferenceAsync(writer);
+        }
+
+        /// <summary>
         /// Serialize to OpenAPI V3 document without using reference.
         /// </summary>
         public void SerializeAsV3WithoutReference(IOpenApiWriter writer)
@@ -389,6 +409,143 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
+        /// Serialize to OpenAPI V3 document without using reference.
+        /// </summary>
+        public async Task SerializeAsV3WithoutReferenceAsync(IOpenApiWriter writer)
+        {
+            await writer.WriteStartObjectAsync();
+
+            // title
+            await writer.WritePropertyAsync(OpenApiConstants.Title, Title);
+
+            // multipleOf
+            await writer.WritePropertyAsync(OpenApiConstants.MultipleOf, MultipleOf);
+
+            // maximum
+            await writer.WritePropertyAsync(OpenApiConstants.Maximum, Maximum);
+
+            // exclusiveMaximum
+            await writer.WritePropertyAsync(OpenApiConstants.ExclusiveMaximum, ExclusiveMaximum);
+
+            // minimum
+            await writer.WritePropertyAsync(OpenApiConstants.Minimum, Minimum);
+
+            // exclusiveMinimum
+            await writer.WritePropertyAsync(OpenApiConstants.ExclusiveMinimum, ExclusiveMinimum);
+
+            // maxLength
+            await writer.WritePropertyAsync(OpenApiConstants.MaxLength, MaxLength);
+
+            // minLength
+            await writer.WritePropertyAsync(OpenApiConstants.MinLength, MinLength);
+
+            // pattern
+            await writer.WritePropertyAsync(OpenApiConstants.Pattern, Pattern);
+
+            // maxItems
+            await writer.WritePropertyAsync(OpenApiConstants.MaxItems, MaxItems);
+
+            // minItems
+            await writer.WritePropertyAsync(OpenApiConstants.MinItems, MinItems);
+
+            // uniqueItems
+            await writer.WritePropertyAsync(OpenApiConstants.UniqueItems, UniqueItems);
+
+            // maxProperties
+            await writer.WritePropertyAsync(OpenApiConstants.MaxProperties, MaxProperties);
+
+            // minProperties
+            await writer.WritePropertyAsync(OpenApiConstants.MinProperties, MinProperties);
+
+            // required
+            await writer.WriteOptionalCollectionAsync(OpenApiConstants.Required, Required, async (w, s) => await w.WriteValueAsync(s));
+
+            // enum
+            await writer.WriteOptionalCollectionAsync(OpenApiConstants.Enum, Enum, async (nodeWriter, s) => await nodeWriter.WriteAnyAsync(s));
+
+            // type
+            await writer.WritePropertyAsync(OpenApiConstants.Type, Type);
+
+            // allOf
+            await writer.WriteOptionalCollectionAsync(OpenApiConstants.AllOf, AllOf, async (w, s) => await s.SerializeAsV3Async(w));
+
+            // anyOf
+            await writer.WriteOptionalCollectionAsync(OpenApiConstants.AnyOf, AnyOf, async (w, s) => await s.SerializeAsV3Async(w));
+
+            // oneOf
+            await writer.WriteOptionalCollectionAsync(OpenApiConstants.OneOf, OneOf, async (w, s) => await s.SerializeAsV3Async(w));
+
+            // not
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Not, Not, async (w, s) => await s.SerializeAsV3Async(w));
+
+            // items
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Items, Items, async (w, s) => await s.SerializeAsV3Async(w));
+
+            // properties
+            await writer.WriteOptionalMapAsync(OpenApiConstants.Properties, Properties, async (w, s) => await s.SerializeAsV3Async(w));
+
+            // additionalProperties
+            if (AdditionalPropertiesAllowed)
+            {
+                await writer.WriteOptionalObjectAsync(
+                    OpenApiConstants.AdditionalProperties,
+                    AdditionalProperties,
+                    async (w, s) => await s.SerializeAsV3Async(w));
+            }
+            else
+            {
+                await writer.WritePropertyAsync(OpenApiConstants.AdditionalProperties, AdditionalPropertiesAllowed);
+            }
+
+            // description
+            await writer.WritePropertyAsync(OpenApiConstants.Description, Description);
+
+            // format
+            await writer.WritePropertyAsync(OpenApiConstants.Format, Format);
+
+            // default
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Default, Default, async (w, d) => await w.WriteAnyAsync(d));
+
+            // nullable
+            await writer.WritePropertyAsync(OpenApiConstants.Nullable, Nullable, false);
+
+            // discriminator
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Discriminator, Discriminator, async (w, s) => await s.SerializeAsV3Async(w));
+
+            // readOnly
+            await writer.WritePropertyAsync(OpenApiConstants.ReadOnly, ReadOnly, false);
+
+            // writeOnly
+            await writer.WritePropertyAsync(OpenApiConstants.WriteOnly, WriteOnly, false);
+
+            // xml
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Xml, Xml, async (w, s) => await s.SerializeAsV2Async(w));
+
+            // externalDocs
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.ExternalDocs, ExternalDocs, async (w, s) => await s.SerializeAsV3Async(w));
+
+            // example
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Example, Example, async (w, e) => await w.WriteAnyAsync(e));
+
+            // deprecated
+            await writer.WritePropertyAsync(OpenApiConstants.Deprecated, Deprecated, false);
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
+
+        /// <summary>
+        /// Serialize <see cref="OpenApiSchema"/> to Open Api v2.0
+        /// </summary>
+        public async Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            await SerializeAsV2Async(writer: writer, parentRequiredProperties: new HashSet<string>(), propertyName: null);
+        }
+
+
+        /// <summary>
         /// Serialize <see cref="OpenApiSchema"/> to Open Api v2.0
         /// </summary>
         public void SerializeAsV2(IOpenApiWriter writer)
@@ -402,6 +559,17 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV2WithoutReference(IOpenApiWriter writer)
         {
             SerializeAsV2WithoutReference(
+                writer: writer,
+                parentRequiredProperties: new HashSet<string>(),
+                propertyName: null);
+        }
+        
+        /// <summary>
+        /// Serialize to OpenAPI V2 document without using reference.
+        /// </summary>
+        public async Task SerializeAsV2WithoutReferenceAsync(IOpenApiWriter writer)
+        {
+            await SerializeAsV2WithoutReferenceAsync(
                 writer: writer,
                 parentRequiredProperties: new HashSet<string>(),
                 propertyName: null);
@@ -439,6 +607,37 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
+        /// Serialize <see cref="OpenApiSchema"/> to Open Api v2.0 and handles not marking the provided property 
+        /// as readonly if its included in the provided list of required properties of parent schema.
+        /// </summary>
+        /// <param name="writer">The open api writer.</param>
+        /// <param name="parentRequiredProperties">The list of required properties in parent schema.</param>
+        /// <param name="propertyName">The property name that will be serialized.</param>
+        internal async Task SerializeAsV2Async(
+            IOpenApiWriter writer,
+            ISet<string> parentRequiredProperties,
+            string propertyName)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            if (Reference != null)
+            {
+                await Reference.SerializeAsV2Async(writer);
+                return;
+            }
+
+            if (parentRequiredProperties == null)
+            {
+                parentRequiredProperties = new HashSet<string>();
+            }
+
+            await SerializeAsV2WithoutReferenceAsync(writer, parentRequiredProperties, propertyName);
+        }
+
+        /// <summary>
         /// Serialize to OpenAPI V2 document without using reference and handles not marking the provided property 
         /// as readonly if its included in the provided list of required properties of parent schema.
         /// </summary>
@@ -453,6 +652,23 @@ namespace Microsoft.OpenApi.Models
             writer.WriteStartObject();
             WriteAsSchemaProperties(writer, parentRequiredProperties, propertyName);
             writer.WriteEndObject();
+        }
+
+        /// <summary>
+        /// Serialize to OpenAPI V2 document without using reference and handles not marking the provided property 
+        /// as readonly if its included in the provided list of required properties of parent schema.
+        /// </summary>
+        /// <param name="writer">The open api writer.</param>
+        /// <param name="parentRequiredProperties">The list of required properties in parent schema.</param>
+        /// <param name="propertyName">The property name that will be serialized.</param>
+        internal async Task SerializeAsV2WithoutReferenceAsync(
+            IOpenApiWriter writer,
+            ISet<string> parentRequiredProperties,
+            string propertyName)
+        {
+            await writer.WriteStartObjectAsync();
+            await WriteAsSchemaPropertiesAsync(writer, parentRequiredProperties, propertyName);
+            await writer.WriteEndObjectAsync();
         }
 
         internal void WriteAsItemsProperties(IOpenApiWriter writer)
@@ -518,6 +734,71 @@ namespace Microsoft.OpenApi.Models
             // extensions
             writer.WriteExtensions(Extensions, OpenApiSpecVersion.OpenApi2_0);
         }
+
+        internal async Task WriteAsItemsPropertiesAsync(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            // type
+            await writer.WritePropertyAsync(OpenApiConstants.Type, Type);
+
+            // format
+            await writer.WritePropertyAsync(OpenApiConstants.Format, Format);
+
+            // items
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Items, Items, async (w, s) => await s.SerializeAsV2Async(w));
+
+            // collectionFormat
+            // We need information from style in parameter to populate this.
+            // The best effort we can make is to pull this information from the first parameter
+            // that leverages this schema. However, that in itself may not be as simple
+            // as the schema directly under parameter might be referencing one in the Components,
+            // so we will need to do a full scan of the object before we can write the value for
+            // this property. This is not supported yet, so we will skip this property at the moment.
+
+            // default
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Default, Default, async (w, d) => await w.WriteAnyAsync(d));
+
+            // maximum
+            await writer.WritePropertyAsync(OpenApiConstants.Maximum, Maximum);
+
+            // exclusiveMaximum
+            await writer.WritePropertyAsync(OpenApiConstants.ExclusiveMaximum, ExclusiveMaximum);
+
+            // minimum
+            await writer.WritePropertyAsync(OpenApiConstants.Minimum, Minimum);
+
+            // exclusiveMinimum
+            await writer.WritePropertyAsync(OpenApiConstants.ExclusiveMinimum, ExclusiveMinimum);
+
+            // maxLength
+            await writer.WritePropertyAsync(OpenApiConstants.MaxLength, MaxLength);
+
+            // minLength
+            await writer.WritePropertyAsync(OpenApiConstants.MinLength, MinLength);
+
+            // pattern
+            await writer.WritePropertyAsync(OpenApiConstants.Pattern, Pattern);
+
+            // maxItems
+            await writer.WritePropertyAsync(OpenApiConstants.MaxItems, MaxItems);
+
+            // minItems
+            await writer.WritePropertyAsync(OpenApiConstants.MinItems, MinItems);
+
+            // enum
+            await writer.WriteOptionalCollectionAsync(OpenApiConstants.Enum, Enum, async (w, s) => await w.WriteAnyAsync(s));
+
+            // multipleOf
+            await writer.WritePropertyAsync(OpenApiConstants.MultipleOf, MultipleOf);
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi2_0);
+        }
+
 
         internal void WriteAsSchemaProperties(
             IOpenApiWriter writer,
@@ -627,6 +908,116 @@ namespace Microsoft.OpenApi.Models
 
             // extensions
             writer.WriteExtensions(Extensions, OpenApiSpecVersion.OpenApi2_0);
+        }
+
+        internal async Task WriteAsSchemaPropertiesAsync(
+            IOpenApiWriter writer,
+            ISet<string> parentRequiredProperties,
+            string propertyName)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            // format
+            await writer.WritePropertyAsync(OpenApiConstants.Format, Format);
+
+            // title
+            await writer.WritePropertyAsync(OpenApiConstants.Title, Title);
+
+            // description
+            await writer.WritePropertyAsync(OpenApiConstants.Description, Description);
+
+            // default
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Default, Default, async (w, d) => await w.WriteAnyAsync(d));
+
+            // multipleOf
+            await writer.WritePropertyAsync(OpenApiConstants.MultipleOf, MultipleOf);
+
+            // maximum
+            await writer.WritePropertyAsync(OpenApiConstants.Maximum, Maximum);
+
+            // exclusiveMaximum
+            await writer.WritePropertyAsync(OpenApiConstants.ExclusiveMaximum, ExclusiveMaximum);
+
+            // minimum
+            await writer.WritePropertyAsync(OpenApiConstants.Minimum, Minimum);
+
+            // exclusiveMinimum
+            await writer.WritePropertyAsync(OpenApiConstants.ExclusiveMinimum, ExclusiveMinimum);
+
+            // maxLength
+            await writer.WritePropertyAsync(OpenApiConstants.MaxLength, MaxLength);
+
+            // minLength
+            await writer.WritePropertyAsync(OpenApiConstants.MinLength, MinLength);
+
+            // pattern
+            await writer.WritePropertyAsync(OpenApiConstants.Pattern, Pattern);
+
+            // maxItems
+            await writer.WritePropertyAsync(OpenApiConstants.MaxItems, MaxItems);
+
+            // minItems
+            await writer.WritePropertyAsync(OpenApiConstants.MinItems, MinItems);
+
+            // uniqueItems
+            await writer.WritePropertyAsync(OpenApiConstants.UniqueItems, UniqueItems);
+
+            // maxProperties
+            await writer.WritePropertyAsync(OpenApiConstants.MaxProperties, MaxProperties);
+
+            // minProperties
+            await writer.WritePropertyAsync(OpenApiConstants.MinProperties, MinProperties);
+
+            // required
+            await writer.WriteOptionalCollectionAsync(OpenApiConstants.Required, Required, async (w, s) => await w.WriteValueAsync(s));
+
+            // enum
+            await writer.WriteOptionalCollectionAsync(OpenApiConstants.Enum, Enum, async (w, s) => await w.WriteAnyAsync(s));
+
+            // type
+            await writer.WritePropertyAsync(OpenApiConstants.Type, Type);
+
+            // items
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Items, Items, async (w, s) => await s.SerializeAsV2Async(w));
+
+            // allOf
+            await writer.WriteOptionalCollectionAsync(OpenApiConstants.AllOf, AllOf, async (w, s) => await s.SerializeAsV2Async(w));
+
+            // properties
+            await writer.WriteOptionalMapAsync(OpenApiConstants.Properties, Properties, async (w, key, s) =>
+                await s.SerializeAsV2Async(w, Required, key));
+
+            // additionalProperties
+            await writer.WriteOptionalObjectAsync(
+                OpenApiConstants.AdditionalProperties,
+                AdditionalProperties,
+                async (w, s) => await s.SerializeAsV2Async(w));
+
+            // discriminator
+            await writer.WritePropertyAsync(OpenApiConstants.Discriminator, Discriminator?.PropertyName);
+
+            // readOnly
+            // In V2 schema if a property is part of required properties of parent schema,
+            // it cannot be marked as readonly.
+            if (!parentRequiredProperties.Contains(propertyName))
+            {
+                await writer.WritePropertyAsync(name: OpenApiConstants.ReadOnly, value: ReadOnly, defaultValue: false);
+            }
+
+            // xml
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Xml, Xml, async (w, s) => await s.SerializeAsV2Async(w));
+
+            // externalDocs
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.ExternalDocs, ExternalDocs, async (w, s) => await s.SerializeAsV2Async(w));
+
+            // example
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.Example, Example, async (w, e) => await w.WriteAnyAsync(e));
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi2_0);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiSecurityRequirement.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSecurityRequirement.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
 
@@ -67,6 +68,46 @@ namespace Microsoft.OpenApi.Models
 
             writer.WriteEndObject();
         }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiSecurityRequirement"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            foreach (var securitySchemeAndScopesValuePair in this)
+            {
+                var securityScheme = securitySchemeAndScopesValuePair.Key;
+                var scopes = securitySchemeAndScopesValuePair.Value;
+
+                if (securityScheme.Reference == null)
+                {
+                    // Reaching this point means the reference to a specific OpenApiSecurityScheme fails.
+                    // We are not able to serialize this SecurityScheme/Scopes key value pair since we do not know what
+                    // string to output.
+                    continue;
+                }
+
+                await securityScheme.SerializeAsV3Async(writer);
+
+                await writer.WriteStartArrayAsync();
+
+                foreach (var scope in scopes)
+                {
+                    await writer.WriteValueAsync(scope);
+                }
+
+                await writer.WriteEndArrayAsync();
+            }
+
+            await writer.WriteEndObjectAsync();
+        }
 
         /// <summary>
         /// Serialize <see cref="OpenApiSecurityRequirement"/> to Open Api v2.0
@@ -106,6 +147,46 @@ namespace Microsoft.OpenApi.Models
             }
 
             writer.WriteEndObject();
+        }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiSecurityRequirement"/> to Open Api v2.0
+        /// </summary>
+        public async Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            foreach (var securitySchemeAndScopesValuePair in this)
+            {
+                var securityScheme = securitySchemeAndScopesValuePair.Key;
+                var scopes = securitySchemeAndScopesValuePair.Value;
+
+                if (securityScheme.Reference == null)
+                {
+                    // Reaching this point means the reference to a specific OpenApiSecurityScheme fails.
+                    // We are not able to serialize this SecurityScheme/Scopes key value pair since we do not know what
+                    // string to output.
+                    continue;
+                }
+
+                await securityScheme.SerializeAsV2Async(writer);
+
+                await writer.WriteStartArrayAsync();
+
+                foreach (var scope in scopes)
+                {
+                    await writer.WriteValueAsync(scope);
+                }
+
+                await writer.WriteEndArrayAsync();
+            }
+
+            await writer.WriteEndObjectAsync();
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiServer.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiServer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -64,11 +65,47 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
+        /// Serialize <see cref="OpenApiServer"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // url
+            await writer.WritePropertyAsync(OpenApiConstants.Url, Url);
+
+            // description
+            await writer.WritePropertyAsync(OpenApiConstants.Description, Description);
+
+            // variables
+            await writer.WriteOptionalMapAsync(OpenApiConstants.Variables, Variables, async (w, v) => await v.SerializeAsV3Async(w));
+
+            // specification extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
+
+        /// <summary>
         /// Serialize <see cref="OpenApiServer"/> to Open Api v2.0
         /// </summary>
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             // Server object does not exist in V2.
+        }
+
+
+        /// <summary>
+        /// Serialize <see cref="OpenApiServer"/> to Open Api v2.0
+        /// </summary>
+        public Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiServerVariable.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiServerVariable.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -60,6 +61,33 @@ namespace Microsoft.OpenApi.Models
 
             writer.WriteEndObject();
         }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiServerVariable"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // default
+            await writer.WritePropertyAsync(OpenApiConstants.Default, Default);
+
+            // description
+            await writer.WritePropertyAsync(OpenApiConstants.Description, Description);
+
+            // enums
+            await writer.WriteOptionalCollectionAsync(OpenApiConstants.Enum, Enum, async (w, s) => await w.WriteValueAsync(s));
+
+            // specification extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
 
         /// <summary>
         /// Serialize <see cref="OpenApiServerVariable"/> to Open Api v2.0
@@ -67,6 +95,15 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             // ServerVariable does not exist in V2.
+        }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiServerVariable"/> to Open Api v2.0
+        /// </summary>
+        public Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            // ServerVariable does not exist in V2.
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiTag.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiTag.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -61,6 +62,25 @@ namespace Microsoft.OpenApi.Models
 
             writer.WriteValue(Name);
         }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiTag"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            if (Reference != null)
+            {
+                await Reference.SerializeAsV3Async(writer);
+                return;
+            }
+
+            await writer.WriteValueAsync(Name);
+        }
 
         /// <summary>
         /// Serialize to OpenAPI V3 document without using reference.
@@ -83,6 +103,28 @@ namespace Microsoft.OpenApi.Models
 
             writer.WriteEndObject();
         }
+        
+        /// <summary>
+        /// Serialize to OpenAPI V3 document without using reference.
+        /// </summary>
+        public async Task SerializeAsV3WithoutReferenceAsync(IOpenApiWriter writer)
+        {
+            await writer.WriteStartObjectAsync();
+
+            // name
+            await writer.WritePropertyAsync(OpenApiConstants.Name, Name);
+
+            // description
+            await writer.WritePropertyAsync(OpenApiConstants.Description, Description);
+
+            // external docs
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.ExternalDocs, ExternalDocs, async (w, e) => await e.SerializeAsV3Async(w));
+
+            // extensions.
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi3_0);
+
+            await writer.WriteEndObjectAsync();
+        }
 
         /// <summary>
         /// Serialize <see cref="OpenApiTag"/> to Open Api v2.0
@@ -101,6 +143,25 @@ namespace Microsoft.OpenApi.Models
             }
 
             writer.WriteValue(Name);
+        }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiTag"/> to Open Api v2.0
+        /// </summary>
+        public async Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            if (Reference != null)
+            {
+                await Reference.SerializeAsV2Async(writer);
+                return;
+            }
+
+            await writer.WriteValueAsync(Name);
         }
 
         /// <summary>
@@ -123,6 +184,28 @@ namespace Microsoft.OpenApi.Models
             writer.WriteExtensions(Extensions, OpenApiSpecVersion.OpenApi2_0);
 
             writer.WriteEndObject();
+        }
+        
+        /// <summary>
+        /// Serialize to OpenAPI V2 document without using reference.
+        /// </summary>
+        public async Task SerializeAsV2WithoutReferenceAsync(IOpenApiWriter writer)
+        {
+            await writer.WriteStartObjectAsync();
+
+            // name
+            await writer.WritePropertyAsync(OpenApiConstants.Name, Name);
+
+            // description
+            await writer.WritePropertyAsync(OpenApiConstants.Description, Description);
+
+            // external docs
+            await writer.WriteOptionalObjectAsync(OpenApiConstants.ExternalDocs, ExternalDocs, async (w, e) => await e.SerializeAsV2Async(w));
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, OpenApiSpecVersion.OpenApi2_0);
+
+            await writer.WriteEndObjectAsync();
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiXml.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiXml.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -53,6 +54,15 @@ namespace Microsoft.OpenApi.Models
         {
             Write(writer, OpenApiSpecVersion.OpenApi3_0);
         }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiXml"/> to Open Api v3.0
+        /// </summary>
+        public async Task SerializeAsV3Async(IOpenApiWriter writer)
+        {
+            await WriteAsync(writer, OpenApiSpecVersion.OpenApi3_0);
+
+        }
 
         /// <summary>
         /// Serialize <see cref="OpenApiXml"/> to Open Api v2.0
@@ -60,6 +70,14 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             Write(writer, OpenApiSpecVersion.OpenApi2_0);
+        }
+
+        /// <summary>
+        /// Serialize <see cref="OpenApiXml"/> to Open Api v2.0
+        /// </summary>
+        public async Task SerializeAsV2Async(IOpenApiWriter writer)
+        {
+            await WriteAsync(writer, OpenApiSpecVersion.OpenApi2_0);
         }
 
         private void Write(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
@@ -90,6 +108,36 @@ namespace Microsoft.OpenApi.Models
             writer.WriteExtensions(Extensions, specVersion);
 
             writer.WriteEndObject();
+        }
+        
+        private async Task WriteAsync(IOpenApiWriter writer, OpenApiSpecVersion specVersion)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            await writer.WriteStartObjectAsync();
+
+            // name
+            await writer.WritePropertyAsync(OpenApiConstants.Name, Name);
+
+            // namespace
+            await writer.WritePropertyAsync(OpenApiConstants.Namespace, Namespace?.AbsoluteUri);
+
+            // prefix
+            await writer.WritePropertyAsync(OpenApiConstants.Prefix, Prefix);
+
+            // attribute
+            await writer.WritePropertyAsync(OpenApiConstants.Attribute, Attribute, false);
+
+            // wrapped
+            await writer.WritePropertyAsync(OpenApiConstants.Wrapped, Wrapped, false);
+
+            // extensions
+            await writer.WriteExtensionsAsync(Extensions, specVersion);
+
+            await writer.WriteEndObjectAsync();
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/RuntimeExpressionAnyWrapper.cs
+++ b/src/Microsoft.OpenApi/Models/RuntimeExpressionAnyWrapper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Expressions;
 using Microsoft.OpenApi.Interfaces;
@@ -65,6 +66,26 @@ namespace Microsoft.OpenApi.Models
             else if (_expression != null)
             {
                 writer.WriteValue(_expression.Expression);
+            }
+        }
+        
+        /// <summary>
+        /// Write <see cref="RuntimeExpressionAnyWrapper"/>
+        /// </summary>
+        public async Task WriteValueAsync(IOpenApiWriter writer)
+        {
+            if (writer == null)
+            {
+                throw Error.ArgumentNull(nameof(writer));
+            }
+
+            if (_any != null)
+            {
+                await writer.WriteAnyAsync(_any);
+            }
+            else if (_expression != null)
+            {
+                await writer.WriteValueAsync(_expression.Expression);
             }
         }
     }

--- a/src/Microsoft.OpenApi/Writers/IOpenApiWriter.cs
+++ b/src/Microsoft.OpenApi/Writers/IOpenApiWriter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Threading.Tasks;
+
 namespace Microsoft.OpenApi.Writers
 {
     /// <summary>
@@ -72,5 +74,70 @@ namespace Microsoft.OpenApi.Writers
         /// Flush the writer.
         /// </summary>
         void Flush();
+        
+        /// <summary>
+        /// Write the start object.
+        /// </summary>
+        Task WriteStartObjectAsync();
+
+        /// <summary>
+        /// Write the end object.
+        /// </summary>
+        Task WriteEndObjectAsync();
+
+        /// <summary>
+        /// Write the start array.
+        /// </summary>
+        Task WriteStartArrayAsync();
+
+        /// <summary>
+        /// Write the end array.
+        /// </summary>
+        Task WriteEndArrayAsync();
+
+        /// <summary>
+        /// Write the property name.
+        /// </summary>
+        Task WritePropertyNameAsync(string name);
+
+        /// <summary>
+        /// Write the string value.
+        /// </summary>
+        Task WriteValueAsync(string value);
+
+        /// <summary>
+        /// Write the decimal value.
+        /// </summary>
+        Task WriteValueAsync(decimal value);
+
+        /// <summary>
+        /// Write the int value.
+        /// </summary>
+        Task WriteValueAsync(int value);
+
+        /// <summary>
+        /// Write the boolean value.
+        /// </summary>
+        Task WriteValueAsync(bool value);
+
+        /// <summary>
+        /// Write the null value.
+        /// </summary>
+        Task WriteNullAsync();
+
+        /// <summary>
+        /// Write the raw content value.
+        /// </summary>
+        Task WriteRawAsync(string value);
+
+        /// <summary>
+        /// Write the object value.
+        /// </summary>
+        Task WriteValueAsync(object value);
+
+        /// <summary>
+        /// Flush the writer.
+        /// </summary>
+        Task FlushAsync();
     }
 }

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Properties;
 
@@ -58,9 +59,19 @@ namespace Microsoft.OpenApi.Writers
         public abstract void WriteStartObject();
 
         /// <summary>
+        /// Write start object.
+        /// </summary>
+        public abstract Task WriteStartObjectAsync();
+
+        /// <summary>
         /// Write end object.
         /// </summary>
         public abstract void WriteEndObject();
+
+        /// <summary>
+        /// Write end object.
+        /// </summary>
+        public abstract Task WriteEndObjectAsync();
 
         /// <summary>
         /// Write start array.
@@ -68,9 +79,19 @@ namespace Microsoft.OpenApi.Writers
         public abstract void WriteStartArray();
 
         /// <summary>
+        /// Write start array.
+        /// </summary>
+        public abstract Task WriteStartArrayAsync();
+
+        /// <summary>
         /// Write end array.
         /// </summary>
         public abstract void WriteEndArray();
+
+        /// <summary>
+        /// Write end array.
+        /// </summary>
+        public abstract Task WriteEndArrayAsync();
 
         /// <summary>
         /// Write the start property.
@@ -78,9 +99,19 @@ namespace Microsoft.OpenApi.Writers
         public abstract void WritePropertyName(string name);
 
         /// <summary>
+        /// Write the start property.
+        /// </summary>
+        public abstract Task WritePropertyNameAsync(string name);
+
+        /// <summary>
         /// Writes a separator of a value if it's needed for the next value to be written.
         /// </summary>
         protected abstract void WriteValueSeparator();
+
+        /// <summary>
+        /// Writes a separator of a value if it's needed for the next value to be written.
+        /// </summary>
+        protected abstract Task WriteValueSeparatorAsync();
 
         /// <summary>
         /// Write null value.
@@ -88,9 +119,19 @@ namespace Microsoft.OpenApi.Writers
         public abstract void WriteNull();
 
         /// <summary>
+        /// Write null value.
+        /// </summary>
+        public abstract Task WriteNullAsync();
+
+        /// <summary>
         /// Write content raw value.
         /// </summary>
         public abstract void WriteRaw(string value);
+
+        /// <summary>
+        /// Write content raw value.
+        /// </summary>
+        public abstract Task WriteRawAsync(string value);
 
         /// <summary>
         /// Flush the writer.
@@ -101,11 +142,161 @@ namespace Microsoft.OpenApi.Writers
         }
 
         /// <summary>
+        /// Flush the writer.
+        /// </summary>
+        public async Task FlushAsync()
+        {
+            await Writer.FlushAsync();
+        }
+        
+        /// <summary>
+        /// Write decimal value.
+        /// </summary>
+        /// <param name="value">The decimal value.</param>
+        public virtual async Task WriteValueAsync(decimal value)
+        {
+            await WriteValueSeparatorAsync();
+            await Writer.WriteAsync(value.ToString());
+        }
+
+        /// <summary>
+        /// Write integer value.
+        /// </summary>
+        /// <param name="value">The integer value.</param>
+        public virtual async Task WriteValueAsync(int value)
+        {
+            await WriteValueSeparatorAsync();
+            await Writer.WriteAsync(value.ToString());
+        }
+
+        /// <summary>
+        /// Write boolean value.
+        /// </summary>
+        /// <param name="value">The boolean value.</param>
+        public virtual async Task WriteValueAsync(bool value)
+        {
+            await WriteValueSeparatorAsync();
+            await Writer.WriteAsync(value.ToString());
+        }
+
+        /// <summary>
+        /// Write float value.
+        /// </summary>
+        /// <param name="value">The float value.</param>
+        public virtual async Task WriteValueAsync(float value)
+        {
+            await WriteValueSeparatorAsync();
+            await Writer.WriteAsync(value.ToString());
+        }
+
+        /// <summary>
+        /// Write long value.
+        /// </summary>
+        /// <param name="value">The long value.</param>
+        public virtual async Task WriteValueAsync(long value)
+        {
+            await WriteValueSeparatorAsync();
+            await Writer.WriteAsync(value.ToString());
+        }
+        
+        /// <summary>
+        /// Write double value.
+        /// </summary>
+        /// <param name="value">The double value.</param>
+        public virtual async Task WriteValueAsync(double value)
+        {
+            await WriteValueSeparatorAsync();
+            await Writer.WriteAsync(value.ToString());
+        }
+        
+        /// <summary>
+        /// Write DateTime value.
+        /// </summary>
+        /// <param name="value">The DateTime value.</param>
+        public virtual async Task WriteValueAsync(DateTime value)
+        {
+            await this.WriteValueAsync(value.ToString("o"));
+        }
+        
+        /// <summary>
+        /// Write DateTimeOffset value.
+        /// </summary>
+        /// <param name="value">The DateTimeOffset value.</param>
+        public virtual async Task WriteValueAsync(DateTimeOffset value)
+        {
+            await this.WriteValueAsync(value.ToString("o"));
+        }
+
+        /// <summary>
+        /// Write object value.
+        /// </summary>
+        /// <param name="value">The object value.</param>
+        public virtual async Task WriteValueAsync(object value)
+        {
+            if (value == null)
+            {
+                await WriteNullAsync();
+                return;
+            }
+
+            var type = value.GetType();
+
+            if (type == typeof(string))
+            {
+                await WriteValueAsync((string) (value));
+            }
+            else if (type == typeof(int) || type == typeof(int?))
+            {
+                await WriteValueAsync((int) value);
+            }
+            else if (type == typeof(long) || type == typeof(long?))
+            {
+                await WriteValueAsync((long) value);
+            }
+            else if (type == typeof(bool) || type == typeof(bool?))
+            {
+                await WriteValueAsync((bool) value);
+            }
+            else if (type == typeof(float) || type == typeof(float?))
+            {
+                await WriteValueAsync((float) value);
+            }
+            else if (type == typeof(double) || type == typeof(double?))
+            {
+                await WriteValueAsync((double) value);
+            }
+            else if (type == typeof(decimal) || type == typeof(decimal?))
+            {
+                await WriteValueAsync((decimal) value);
+            }
+            else if (type == typeof(DateTime) || type == typeof(DateTime?))
+            {
+                await WriteValueAsync((DateTime) value);
+            }
+            else if (type == typeof(DateTimeOffset) || type == typeof(DateTimeOffset?))
+            {
+                await WriteValueAsync((DateTimeOffset) value);
+            }
+            else
+            {
+                throw new OpenApiWriterException(string.Format(SRResource.OpenApiUnsupportedValueType, type.FullName));
+            }
+        }
+
+
+        /// <summary>
         /// Write string value.
         /// </summary>
         /// <param name="value">The string value.</param>
         public abstract void WriteValue(string value);
-        
+
+        /// <summary>
+        /// Write string value.
+        /// </summary>
+        /// <param name="value">The string value.</param>
+        public abstract Task WriteValueAsync(string value);
+
+
         /// <summary>
         /// Write float value.
         /// </summary>
@@ -200,39 +391,39 @@ namespace Microsoft.OpenApi.Writers
 
             if (type == typeof(string))
             {
-                WriteValue((string)(value));
+                WriteValue((string) (value));
             }
             else if (type == typeof(int) || type == typeof(int?))
             {
-                WriteValue((int)value);
+                WriteValue((int) value);
             }
             else if (type == typeof(long) || type == typeof(long?))
             {
-                WriteValue((long)value);
+                WriteValue((long) value);
             }
             else if (type == typeof(bool) || type == typeof(bool?))
             {
-                WriteValue((bool)value);
+                WriteValue((bool) value);
             }
             else if (type == typeof(float) || type == typeof(float?))
             {
-                WriteValue((float)value);
+                WriteValue((float) value);
             }
             else if (type == typeof(double) || type == typeof(double?))
             {
-                WriteValue((double)value);
+                WriteValue((double) value);
             }
             else if (type == typeof(decimal) || type == typeof(decimal?))
             {
-                WriteValue((decimal)value);
+                WriteValue((decimal) value);
             }
-            else if ( type == typeof(DateTime) || type == typeof(DateTime?) )
+            else if (type == typeof(DateTime) || type == typeof(DateTime?))
             {
-                WriteValue((DateTime)value);
+                WriteValue((DateTime) value);
             }
             else if (type == typeof(DateTimeOffset) || type == typeof(DateTimeOffset?))
             {
-                WriteValue((DateTimeOffset)value);
+                WriteValue((DateTimeOffset) value);
             }
             else
             {
@@ -276,6 +467,17 @@ namespace Microsoft.OpenApi.Writers
             for (var i = 0; i < (BaseIndentation + _indentLevel - 1); i++)
             {
                 Writer.Write(IndentationString);
+            }
+        }
+
+        /// <summary>
+        /// Write the indentation.
+        /// </summary>
+        public virtual async Task WriteIndentationAsync()
+        {
+            for (var i = 0; i < (BaseIndentation + _indentLevel - 1); i++)
+            {
+                await Writer.WriteAsync(IndentationString);
             }
         }
 

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.OpenApi.Interfaces;
 
 namespace Microsoft.OpenApi.Writers
@@ -33,6 +34,24 @@ namespace Microsoft.OpenApi.Writers
         }
 
         /// <summary>
+        /// Write a string property.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="value">The property value.</param>
+        public static async Task WritePropertyAsync(this IOpenApiWriter writer, string name, string value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            CheckArguments(writer, name);
+            await writer.WritePropertyNameAsync(name);
+            await writer.WriteValueAsync(value);
+        }
+
+        /// <summary>
         /// Write a boolean property.
         /// </summary>
         /// <param name="writer">The writer.</param>
@@ -49,6 +68,25 @@ namespace Microsoft.OpenApi.Writers
             CheckArguments(writer, name);
             writer.WritePropertyName(name);
             writer.WriteValue(value);
+        }
+
+        /// <summary>
+        /// Write a boolean property.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="value">The property value.</param>
+        /// <param name="defaultValue">The default boolean value.</param>
+        public static async Task WritePropertyAsync(this IOpenApiWriter writer, string name, bool value, bool defaultValue = false)
+        {
+            if (value == defaultValue)
+            {
+                return;
+            }
+
+            CheckArguments(writer, name);
+            await writer.WritePropertyNameAsync(name);
+            await writer.WriteValueAsync(value);
         }
 
         /// <summary>
@@ -75,6 +113,29 @@ namespace Microsoft.OpenApi.Writers
         }
 
         /// <summary>
+        /// Write a boolean property.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="value">The property value.</param>
+        /// <param name="defaultValue">The default boolean value.</param>
+        public static async Task WritePropertyAsync(
+            this IOpenApiWriter writer,
+            string name,
+            bool? value,
+            bool defaultValue = false)
+        {
+            if (value == null || value.Value == defaultValue)
+            {
+                return;
+            }
+
+            CheckArguments(writer, name);
+            await writer.WritePropertyNameAsync(name);
+            await writer.WriteValueAsync(value.Value);
+        }
+
+        /// <summary>
         /// Write a primitive property.
         /// </summary>
         /// <param name="writer">The writer.</param>
@@ -92,6 +153,23 @@ namespace Microsoft.OpenApi.Writers
         }
 
         /// <summary>
+        /// Write a primitive property.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="value">The property value.</param>
+        public static async Task WritePropertyAsync<T>(this IOpenApiWriter writer, string name, T? value)
+            where T : struct
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            await writer.WritePropertyAsync(name, value.Value);
+        }
+
+        /// <summary>
         /// Write a string/number property.
         /// </summary>
         /// <param name="writer">The writer.</param>
@@ -103,6 +181,20 @@ namespace Microsoft.OpenApi.Writers
             CheckArguments(writer, name);
             writer.WritePropertyName(name);
             writer.WriteValue(value);
+        }
+
+        /// <summary>
+        /// Write a string/number property.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="value">The property value.</param>
+        public static async Task WritePropertyAsync<T>(this IOpenApiWriter writer, string name, T value)
+            where T : struct
+        {
+            CheckArguments(writer, name);
+            await writer.WritePropertyNameAsync(name);
+            await writer.WriteValueAsync(value);
         }
 
         /// <summary>
@@ -129,6 +221,33 @@ namespace Microsoft.OpenApi.Writers
                 }
 
                 writer.WriteRequiredObject(name, value, action);
+            }
+        }
+
+        /// <summary>
+        /// Write the optional Open API object/element.
+        /// </summary>
+        /// <typeparam name="T">The Open API element type. <see cref="IOpenApiElement"/></typeparam>
+        /// <param name="writer">The Open API writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="value">The property value.</param>
+        /// <param name="action">The proprety value writer action.</param>
+        public static async Task WriteOptionalObjectAsync<T>(
+            this IOpenApiWriter writer,
+            string name,
+            T value,
+            Action<IOpenApiWriter, T> action)
+            where T : IOpenApiElement
+        {
+            if (value != null)
+            {
+                var values = value as IEnumerable;
+                if (values != null && !values.GetEnumerator().MoveNext())
+                {
+                    return; // Don't render optional empty collections
+                }
+
+                await writer.WriteRequiredObjectAsync(name, value, action);
             }
         }
 
@@ -162,6 +281,35 @@ namespace Microsoft.OpenApi.Writers
         }
 
         /// <summary>
+        /// Write the required Open API object/element.
+        /// </summary>
+        /// <typeparam name="T">The Open API element type. <see cref="IOpenApiElement"/></typeparam>
+        /// <param name="writer">The Open API writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="value">The property value.</param>
+        /// <param name="action">The proprety value writer action.</param>
+        public static async Task WriteRequiredObjectAsync<T>(
+            this IOpenApiWriter writer,
+            string name,
+            T value,
+            Action<IOpenApiWriter, T> action)
+            where T : IOpenApiElement
+        {
+            CheckArguments(writer, name, action);
+
+            await writer.WritePropertyNameAsync(name);
+            if (value != null)
+            {
+                action(writer, value);
+            }
+            else
+            {
+                await writer.WriteStartObjectAsync();
+                await writer.WriteEndObjectAsync();
+            }
+        }
+
+        /// <summary>
         /// Write the optional of collection string.
         /// </summary>
         /// <param name="writer">The Open API writer.</param>
@@ -177,6 +325,25 @@ namespace Microsoft.OpenApi.Writers
             if (elements != null && elements.Any())
             {
                 writer.WriteCollectionInternal(name, elements, action);
+            }
+        }
+
+        /// <summary>
+        /// Write the optional of collection string.
+        /// </summary>
+        /// <param name="writer">The Open API writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="elements">The collection values.</param>
+        /// <param name="action">The collection string writer action.</param>
+        public static async Task WriteOptionalCollectionAsync(
+            this IOpenApiWriter writer,
+            string name,
+            IEnumerable<string> elements,
+            Action<IOpenApiWriter, string> action)
+        {
+            if (elements != null && elements.Any())
+            {
+                await writer.WriteCollectionInternalAsync(name, elements, action);
             }
         }
 
@@ -202,6 +369,27 @@ namespace Microsoft.OpenApi.Writers
         }
 
         /// <summary>
+        /// Write the optional Open API object/element collection.
+        /// </summary>
+        /// <typeparam name="T">The Open API element type. <see cref="IOpenApiElement"/></typeparam>
+        /// <param name="writer">The Open API writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="elements">The collection values.</param>
+        /// <param name="action">The collection element writer action.</param>
+        public static async Task WriteOptionalCollectionAsync<T>(
+            this IOpenApiWriter writer,
+            string name,
+            IEnumerable<T> elements,
+            Action<IOpenApiWriter, T> action)
+            where T : IOpenApiElement
+        {
+            if (elements != null && elements.Any())
+            {
+                await writer.WriteCollectionInternalAsync(name, elements, action);
+            }
+        }
+
+        /// <summary>
         /// Write the required Open API object/element collection.
         /// </summary>
         /// <typeparam name="T">The Open API element type. <see cref="IOpenApiElement"/></typeparam>
@@ -217,6 +405,24 @@ namespace Microsoft.OpenApi.Writers
             where T : IOpenApiElement
         {
             writer.WriteCollectionInternal(name, elements, action);
+        }
+
+        /// <summary>
+        /// Write the required Open API object/element collection.
+        /// </summary>
+        /// <typeparam name="T">The Open API element type. <see cref="IOpenApiElement"/></typeparam>
+        /// <param name="writer">The Open API writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="elements">The collection values.</param>
+        /// <param name="action">The collection element writer action.</param>
+        public static async Task WriteRequiredCollectionAsync<T>(
+            this IOpenApiWriter writer,
+            string name,
+            IEnumerable<T> elements,
+            Action<IOpenApiWriter, T> action)
+            where T : IOpenApiElement
+        {
+            await writer.WriteCollectionInternalAsync(name, elements, action);
         }
 
         /// <summary>
@@ -238,6 +444,26 @@ namespace Microsoft.OpenApi.Writers
             }
         }
 
+
+        /// <summary>
+        /// Write the optional Open API element map (string to string mapping).
+        /// </summary>
+        /// <param name="writer">The Open API writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="elements">The map values.</param>
+        /// <param name="action">The map element writer action.</param>
+        public static async Task WriteOptionalMapAsync(
+            this IOpenApiWriter writer,
+            string name,
+            IDictionary<string, string> elements,
+            Action<IOpenApiWriter, string> action)
+        {
+            if (elements != null && elements.Any())
+            {
+                await writer.WriteMapInternalAsync(name, elements, action);
+            }
+        }
+
         /// <summary>
         /// Write the required Open API element map (string to string mapping).
         /// </summary>
@@ -252,6 +478,22 @@ namespace Microsoft.OpenApi.Writers
             Action<IOpenApiWriter, string> action)
         {
             writer.WriteMapInternal(name, elements, action);
+        }
+
+        /// <summary>
+        /// Write the required Open API element map (string to string mapping).
+        /// </summary>
+        /// <param name="writer">The Open API writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="elements">The map values.</param>
+        /// <param name="action">The map element writer action.</param>
+        public static async Task WriteRequiredMapAsync(
+            this IOpenApiWriter writer,
+            string name,
+            IDictionary<string, string> elements,
+            Action<IOpenApiWriter, string> action)
+        {
+            await writer.WriteMapInternalAsync(name, elements, action);
         }
 
         /// <summary>
@@ -272,6 +514,27 @@ namespace Microsoft.OpenApi.Writers
             if (elements != null && elements.Any())
             {
                 writer.WriteMapInternal(name, elements, action);
+            }
+        }
+        
+        /// <summary>
+        /// Write the optional Open API element map.
+        /// </summary>
+        /// <typeparam name="T">The Open API element type. <see cref="IOpenApiElement"/></typeparam>
+        /// <param name="writer">The Open API writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="elements">The map values.</param>
+        /// <param name="action">The map element writer action with writer and value as input.</param>
+        public static async Task WriteOptionalMapAsync<T>(
+            this IOpenApiWriter writer,
+            string name,
+            IDictionary<string, T> elements,
+            Action<IOpenApiWriter, T> action)
+            where T : IOpenApiElement
+        {
+            if (elements != null && elements.Any())
+            {
+                await writer.WriteMapInternalAsync(name, elements, action);
             }
         }
 
@@ -295,7 +558,28 @@ namespace Microsoft.OpenApi.Writers
                 writer.WriteMapInternal(name, elements, action);
             }
         }
-
+        
+        /// <summary>
+        /// Write the optional Open API element map.
+        /// </summary>
+        /// <typeparam name="T">The Open API element type. <see cref="IOpenApiElement"/></typeparam>
+        /// <param name="writer">The Open API writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="elements">The map values.</param>
+        /// <param name="action">The map element writer action with writer, key, and value as input.</param>
+        public static async Task WriteOptionalMapAsync<T>(
+            this IOpenApiWriter writer,
+            string name,
+            IDictionary<string, T> elements,
+            Action<IOpenApiWriter, string, T> action)
+            where T : IOpenApiElement
+        {
+            if (elements != null && elements.Any())
+            {
+                await writer.WriteMapInternalAsync(name, elements, action);
+            }
+        }
+        
         /// <summary>
         /// Write the required Open API element map.
         /// </summary>
@@ -312,6 +596,24 @@ namespace Microsoft.OpenApi.Writers
             where T : IOpenApiElement
         {
             writer.WriteMapInternal(name, elements, action);
+        }
+        
+        /// <summary>
+        /// Write the required Open API element map.
+        /// </summary>
+        /// <typeparam name="T">The Open API element type. <see cref="IOpenApiElement"/></typeparam>
+        /// <param name="writer">The Open API writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="elements">The map values.</param>
+        /// <param name="action">The map element writer action.</param>
+        public static async Task WriteRequiredMapAsync<T>(
+            this IOpenApiWriter writer,
+            string name,
+            IDictionary<string, T> elements,
+            Action<IOpenApiWriter, T> action)
+            where T : IOpenApiElement
+        {
+            await writer.WriteMapInternalAsync(name, elements, action);
         }
 
         private static void WriteCollectionInternal<T>(
@@ -341,6 +643,34 @@ namespace Microsoft.OpenApi.Writers
 
             writer.WriteEndArray();
         }
+        
+        private static async Task WriteCollectionInternalAsync<T>(
+            this IOpenApiWriter writer,
+            string name,
+            IEnumerable<T> elements,
+            Action<IOpenApiWriter, T> action)
+        {
+            CheckArguments(writer, name, action);
+
+            await writer.WritePropertyNameAsync(name);
+            await writer.WriteStartArrayAsync();
+            if (elements != null)
+            {
+                foreach (var item in elements)
+                {
+                    if (item != null)
+                    {
+                        action(writer, item);
+                    }
+                    else
+                    {
+                        await writer.WriteNullAsync();
+                    }
+                }
+            }
+
+            await writer.WriteEndArrayAsync();
+        }
 
         private static void WriteMapInternal<T>(
             this IOpenApiWriter writer,
@@ -349,6 +679,15 @@ namespace Microsoft.OpenApi.Writers
             Action<IOpenApiWriter, T> action)
         {
             WriteMapInternal(writer, name, elements, (w, k, s) => action(w, s));
+        }
+        
+        private static async Task WriteMapInternalAsync<T>(
+            this IOpenApiWriter writer,
+            string name,
+            IDictionary<string, T> elements,
+            Action<IOpenApiWriter, T> action)
+        {
+            await WriteMapInternalAsync(writer, name, elements, (w, k, s) => action(w, s));
         }
 
         private static void WriteMapInternal<T>(
@@ -379,6 +718,36 @@ namespace Microsoft.OpenApi.Writers
             }
 
             writer.WriteEndObject();
+        }
+        
+        private static async Task WriteMapInternalAsync<T>(
+            this IOpenApiWriter writer,
+            string name,
+            IDictionary<string, T> elements,
+            Action<IOpenApiWriter, string, T> action)
+        {
+            CheckArguments(writer, name, action);
+
+            await writer.WritePropertyNameAsync(name);
+            await writer.WriteStartObjectAsync();
+
+            if (elements != null)
+            {
+                foreach (var item in elements)
+                {
+                    await writer.WritePropertyNameAsync(item.Key);
+                    if (item.Value != null)
+                    {
+                        action(writer, item.Key, item.Value);
+                    }
+                    else
+                    {
+                        await writer.WriteNullAsync();
+                    }
+                }
+            }
+
+            await writer.WriteEndObjectAsync();
         }
 
         private static void CheckArguments<T>(IOpenApiWriter writer, string name, Action<IOpenApiWriter, T> action)

--- a/src/Microsoft.OpenApi/Writers/OpenApiYamlWriter.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiYamlWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Microsoft.OpenApi.Writers
 {
@@ -150,6 +151,25 @@ namespace Microsoft.OpenApi.Writers
         }
 
         /// <summary>
+        /// Write null value.
+        /// </summary>
+        public override async Task WriteNullAsync()
+        {
+            // YAML allows null value to be represented by either nothing or the word null.
+            // We will write nothing here.
+            await WriteValueSeparatorAsync();
+        }
+
+        /// <summary>
+        /// Writes the content raw value.
+        /// </summary>
+        public override async Task WriteRawAsync(string value)
+        {
+            await WriteValueSeparatorAsync();
+            await Writer.WriteAsync(value);
+        }
+
+        /// <summary>
         /// Write string value.
         /// </summary>
         /// <param name="value">The string value.</param>
@@ -160,6 +180,30 @@ namespace Microsoft.OpenApi.Writers
             value = value.GetYamlCompatibleString();
 
             Writer.Write(value);
+        }
+
+        /// <summary>
+        /// Write value separator.
+        /// </summary>
+        protected override async Task WriteValueSeparatorAsync()
+        {
+            if (IsArrayScope())
+            {
+                // If array is the outermost scope and this is the first item, there is no need to insert a newline.
+                if (!IsTopLevelScope() || CurrentScope().ObjectCount != 0)
+                {
+                    await Writer.WriteLineAsync();
+                }
+
+                await WriteIndentationAsync();
+                await Writer.WriteAsync(WriterConstants.PrefixOfArrayItem);
+
+                CurrentScope().ObjectCount++;
+            }
+            else
+            {
+                await Writer.WriteAsync(" ");
+            }
         }
 
         /// <summary>
@@ -203,6 +247,144 @@ namespace Microsoft.OpenApi.Writers
         {
             WriteValueSeparator();
             Writer.Write(value);
+        }
+
+        /// <summary>
+        /// Write YAML start object.
+        /// </summary>
+        public override async Task WriteStartObjectAsync()
+        {
+            var previousScope = CurrentScope();
+
+            var currentScope = StartScope(ScopeType.Object);
+
+            if (previousScope != null && previousScope.Type == ScopeType.Array)
+            {
+                currentScope.IsInArray = true;
+
+                await Writer.WriteLineAsync();
+
+                await WriteIndentationAsync();
+
+                await Writer.WriteAsync(WriterConstants.PrefixOfArrayItem);
+            }
+
+            IncreaseIndentation();
+        }
+
+        /// <summary>
+        /// Write YAML end object.
+        /// </summary>
+        public override async Task WriteEndObjectAsync()
+        {
+            var previousScope = EndScope(ScopeType.Object);
+            DecreaseIndentation();
+
+            var currentScope = CurrentScope();
+
+            // If the object is empty, indicate it by writing { }
+            if (previousScope.ObjectCount == 0)
+            {
+                // If we are in an object, write a white space preceding the braces.
+                if (currentScope != null && currentScope.Type == ScopeType.Object)
+                {
+                    await Writer.WriteAsync(" ");
+                }
+
+                await Writer.WriteAsync(WriterConstants.EmptyObject);
+            }
+        }
+
+        /// <summary>
+        /// Write YAML start array.
+        /// </summary>
+        public override async Task WriteStartArrayAsync()
+        {
+            var previousScope = CurrentScope();
+
+            var currentScope = StartScope(ScopeType.Array);
+
+            if (previousScope != null && previousScope.Type == ScopeType.Array)
+            {
+                currentScope.IsInArray = true;
+
+                await Writer.WriteLineAsync();
+
+                await WriteIndentationAsync();
+
+                await Writer.WriteAsync(WriterConstants.PrefixOfArrayItem);
+            }
+
+            IncreaseIndentation();
+        }
+
+        /// <summary>
+        /// Write YAML end array.
+        /// </summary>
+        public override async Task WriteEndArrayAsync()
+        {
+            var previousScope = EndScope(ScopeType.Array);
+            DecreaseIndentation();
+
+            var currentScope = CurrentScope();
+
+            // If the array is empty, indicate it by writing [ ]
+            if (previousScope.ObjectCount == 0)
+            {
+                // If we are in an object, write a white space preceding the braces.
+                if (currentScope != null && currentScope.Type == ScopeType.Object)
+                {
+                    await Writer.WriteAsync(" ");
+                }
+
+                await Writer.WriteAsync(WriterConstants.EmptyArray);
+            }
+        }
+
+        /// <summary>
+        /// Write the property name and the delimiter.
+        /// </summary>
+        public override async Task WritePropertyNameAsync(string name)
+        {
+            VerifyCanWritePropertyName(name);
+
+            var currentScope = CurrentScope();
+
+            // If this is NOT the first property in the object, always start a new line and add indentation.
+            if (currentScope.ObjectCount != 0)
+            {
+                await Writer.WriteLineAsync();
+                await WriteIndentationAsync();
+            }
+            // Only add newline and indentation when this object is not in the top level scope and not in an array.
+            // The top level scope should have no indentation and it is already in its own line.
+            // The first property of an object inside array can go after the array prefix (-) directly.
+            else if (!IsTopLevelScope() && !currentScope.IsInArray)
+            {
+                await Writer.WriteLineAsync();
+                await WriteIndentationAsync();
+            }
+
+            name = name.GetYamlCompatibleString();
+
+            await Writer.WriteAsync(name);
+            await Writer.WriteAsync(":");
+
+            currentScope.ObjectCount++;
+            
+        }
+
+        /// <summary>
+        /// Write string value.
+        /// </summary>
+        /// <param name="value">The string value.</param>
+        public override async Task WriteValueAsync(string value)
+        {
+            await WriteValueSeparatorAsync();
+
+            value = value.GetYamlCompatibleString();
+
+            await Writer.WriteAsync(value);
         }
     }
 }


### PR DESCRIPTION
Fixes #421 

This adds async methods to the existing lib.  The methods are direct copies of there non async versions but call async versions which in the end call the async textwriter methods.

NOTE: Currently tests have not been updated to call the async methods. Let me know your thoughts here.