### PR TITLE
Bugfix #428 - Recursively denormalize references if entry point is 'serialize without references'

### DIFF
--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiComponentsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiComponentsTests.cs
@@ -81,6 +81,13 @@ namespace Microsoft.OpenApi.Tests.Models
                             {
                                 Type = ReferenceType.Schema,
                                 Id = "schema2"
+                            },
+                            Properties = new Dictionary<string, OpenApiSchema>
+                            {
+                                ["property2"] = new OpenApiSchema
+                                {
+                                    Type = "integer"
+                                }
                             }
                         }
                     },
@@ -99,7 +106,7 @@ namespace Microsoft.OpenApi.Tests.Models
                             Type = "integer"
                         }
                     }
-                },
+                }
             },
             SecuritySchemes = new Dictionary<string, OpenApiSecurityScheme>
             {
@@ -343,7 +350,11 @@ namespace Microsoft.OpenApi.Tests.Models
           ""type"": ""integer""
         },
         ""property3"": {
-          ""$ref"": ""#/components/schemas/schema2""
+          ""properties"": {
+            ""property2"": {
+              ""type"": ""integer""
+            }
+          }
         }
       }
     },
@@ -432,7 +443,9 @@ securitySchemes:
       property2:
         type: integer
       property3:
-        $ref: '#/components/schemas/schema2'
+        properties:
+          property2:
+            type: integer
   schema2:
     properties:
       property2:

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -617,6 +617,76 @@ namespace Microsoft.OpenApi.Tests.Models
         }
 
         [Fact]
+        public void SeralizeSchemaWCircularReferencesAsV3Throws()
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiJsonWriter(outputStringWriter);
+
+            var circularlyReferencedSchema1 = new OpenApiSchema
+            {
+                Title = "title1",
+                Type = "object",
+                Properties = new Dictionary<string, OpenApiSchema>()
+            };
+
+            var circularlyReferencedSchema2 = new OpenApiSchema
+            {
+                Title = "title2",
+                Type = "object",
+                Properties = new Dictionary<string, OpenApiSchema>
+                {
+                    ["property2"] = circularlyReferencedSchema1
+                }
+            };
+
+            circularlyReferencedSchema1.Properties["property1"] = circularlyReferencedSchema2;
+
+            // Act
+            Action action = () => circularlyReferencedSchema1.SerializeAsV3WithoutReference(writer);
+
+            // Assert
+            action
+                .ShouldThrow<NotSupportedException>()
+                .WithMessage("Serializing circular references in schemas is not yet supported");
+        }
+
+        [Fact]
+        public void SeralizeSchemaWCircularReferencesAsV2Throws()
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiJsonWriter(outputStringWriter);
+
+            var circularlyReferencedSchema1 = new OpenApiSchema
+            {
+                Title = "title1",
+                Type = "object",
+                Properties = new Dictionary<string, OpenApiSchema>()
+            };
+
+            var circularlyReferencedSchema2 = new OpenApiSchema
+            {
+                Title = "title2",
+                Type = "object",
+                Properties = new Dictionary<string, OpenApiSchema>
+                {
+                    ["property2"] = circularlyReferencedSchema1
+                }
+            };
+
+            circularlyReferencedSchema1.Properties["property1"] = circularlyReferencedSchema2;
+
+            // Act
+            Action action = () => circularlyReferencedSchema1.SerializeAsV2WithoutReference(writer);
+
+            // Assert
+            action
+                .ShouldThrow<NotSupportedException>()
+                .WithMessage("Serializing circular references in schemas is not yet supported");
+        }
+
+        [Fact]
         public void SerializeSchemaWRequiredPropertiesAsV2JsonWorks()
         {
             // Arrange

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -161,6 +161,30 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
+        public static OpenApiSchema NestedReferenceSchema = new OpenApiSchema
+        {
+            Title = "title1",
+            Type = "object",
+            Properties = new Dictionary<string, OpenApiSchema>
+            {
+                ["property1"] = new OpenApiSchema
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.Schema,
+                        Id = "schemaObject1"
+                    },
+                    Properties = new Dictionary<string, OpenApiSchema>
+                    {
+                        ["nestedProperty1"] = new OpenApiSchema
+                        {
+                            Type = "integer"
+                        }
+                    }
+                }
+            }
+        };
+
         public static OpenApiSchema AdvancedSchemaWithRequiredPropertiesObject = new OpenApiSchema
         {
             Title = "title1",
@@ -398,6 +422,101 @@ namespace Microsoft.OpenApi.Tests.Models
         }
 
         [Fact]
+        public void SerializeReferencedSchemaAsV2WithoutReferenceJsonWorks()
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiJsonWriter(outputStringWriter);
+
+            var expected = @"{
+  ""title"": ""title1"",
+  ""default"": 15,
+  ""multipleOf"": 3,
+  ""maximum"": 42,
+  ""minimum"": 10,
+  ""exclusiveMinimum"": true,
+  ""type"": ""integer"",
+  ""externalDocs"": {
+    ""url"": ""http://example.com/externalDocs""
+  }
+}";
+
+            // Act
+            ReferencedSchema.SerializeAsV2WithoutReference(writer);
+            writer.Flush();
+            var actual = outputStringWriter.GetStringBuilder().ToString();
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeNestedReferencedSchemaAsV3WithoutReferenceJsonWorks()
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiJsonWriter(outputStringWriter);
+
+            var expected = @"{
+  ""title"": ""title1"",
+  ""type"": ""object"",
+  ""properties"": {
+    ""property1"": {
+      ""properties"": {
+        ""nestedProperty1"": {
+          ""type"": ""integer""
+        }
+      }
+    }
+  }
+}";
+
+            // Act
+            NestedReferenceSchema.SerializeAsV3WithoutReference(writer);
+            writer.Flush();
+            var actual = outputStringWriter.GetStringBuilder().ToString();
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeNestedReferencedSchemaAsV2WithoutReferenceJsonWorks()
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiJsonWriter(outputStringWriter);
+
+            var expected = @"{
+  ""title"": ""title1"",
+  ""type"": ""object"",
+  ""properties"": {
+    ""property1"": {
+      ""properties"": {
+        ""nestedProperty1"": {
+          ""type"": ""integer""
+        }
+      }
+    }
+  }
+}";
+
+            // Act
+            NestedReferenceSchema.SerializeAsV2WithoutReference(writer);
+            writer.Flush();
+            var actual = outputStringWriter.GetStringBuilder().ToString();
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
         public void SerializeReferencedSchemaAsV3JsonWorks()
         {
             // Arrange
@@ -410,6 +529,84 @@ namespace Microsoft.OpenApi.Tests.Models
 
             // Act
             ReferencedSchema.SerializeAsV3(writer);
+            writer.Flush();
+            var actual = outputStringWriter.GetStringBuilder().ToString();
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeReferencedSchemaAsV2JsonWorks()
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiJsonWriter(outputStringWriter);
+
+            var expected = @"{
+  ""$ref"": ""#/definitions/schemaObject1""
+}";
+
+            // Act
+            ReferencedSchema.SerializeAsV2(writer);
+            writer.Flush();
+            var actual = outputStringWriter.GetStringBuilder().ToString();
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeNestedReferencedSchemaAsV3JsonWorks()
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiJsonWriter(outputStringWriter);
+
+            var expected = @"{
+  ""title"": ""title1"",
+  ""type"": ""object"",
+  ""properties"": {
+    ""property1"": {
+      ""$ref"": ""#/components/schemas/schemaObject1""
+    }
+  }
+}";
+
+            // Act
+            NestedReferenceSchema.SerializeAsV3(writer);
+            writer.Flush();
+            var actual = outputStringWriter.GetStringBuilder().ToString();
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeNestedReferencedSchemaAsV2JsonWorks()
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiJsonWriter(outputStringWriter);
+
+            var expected = @"{
+  ""title"": ""title1"",
+  ""type"": ""object"",
+  ""properties"": {
+    ""property1"": {
+      ""$ref"": ""#/definitions/schemaObject1""
+    }
+  }
+}";
+
+            // Act
+            NestedReferenceSchema.SerializeAsV2(writer);
             writer.Flush();
             var actual = outputStringWriter.GetStringBuilder().ToString();
 


### PR DESCRIPTION
Made some changes to the schema serialization, so that the intention of the caller is preserved. Specifically, whether or not they want reference schemas to be inlined. 

I broke some tests around OpenApiComponents, which is another example of the behaviour change, but I think the tests relied on the bug 😄 

More info in #428 