### PR TITLE
Explicitly specified string must stay a string

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
@@ -50,12 +50,24 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 return newObject;
             }
 
-            if (!(openApiAny is OpenApiString) || ((OpenApiString)openApiAny).IsExplicit())
+            if (!(openApiAny is OpenApiString))
             {
                 return openApiAny;
             }
 
             var value = ((OpenApiString)openApiAny).Value;
+
+            // For explicit strings only try to guess if it's a DateTimeOffset
+            if (((OpenApiString)openApiAny).IsExplicit())
+            {
+                if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTimeValue))
+                {
+                    return new OpenApiDateTime(dateTimeValue);
+                }
+
+                return openApiAny;
+            }
+
             if (value == null || value == "null")
             {
                 return new OpenApiNull();

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Readers.ParseNodes
@@ -15,86 +14,11 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
     {
         /// <summary>
         /// Converts the <see cref="OpenApiString"/>s in the given <see cref="IOpenApiAny"/>
-        /// into the most specific <see cref="IOpenApiPrimitive"/> type based on the value.
-        /// </summary>
-        public static IOpenApiAny GetSpecificOpenApiAny(IOpenApiAny openApiAny)
-        {
-            if (openApiAny is OpenApiArray openApiArray)
-            {
-                var newArray = new OpenApiArray();
-                foreach (var element in openApiArray)
-                {
-                    newArray.Add(GetSpecificOpenApiAny(element));
-                }
-
-                return newArray;
-            }
-
-            if (openApiAny is OpenApiObject openApiObject)
-            {
-                var newObject = new OpenApiObject();
-
-                foreach (var key in openApiObject.Keys.ToList())
-                {
-                    newObject[key] = GetSpecificOpenApiAny(openApiObject[key]);
-                }
-
-                return newObject;
-            }
-
-            if ( !(openApiAny is OpenApiString))
-            {
-                return openApiAny;
-            }
-
-            var value = ((OpenApiString)openApiAny).Value;
-
-            if (value == null || value == "null")
-            {
-                return new OpenApiNull();
-            }
-
-            if (value == "true")
-            {
-                return new OpenApiBoolean(true);
-            }
-
-            if (value == "false")
-            {
-                return new OpenApiBoolean(false);
-            }
-
-            if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
-            {
-                return new OpenApiInteger(intValue);
-            }
-
-            if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue))
-            {
-                return new OpenApiLong(longValue);
-            }
-
-            if (double.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var doubleValue))
-            {
-                return new OpenApiDouble(doubleValue);
-            }
-
-            if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTimeValue))
-            {
-                return new OpenApiDateTime(dateTimeValue);
-            }
-
-            // if we can't identify the type of value, return it as string.
-            return new OpenApiString(value);
-        }
-
-        /// <summary>
-        /// Converts the <see cref="OpenApiString"/>s in the given <see cref="IOpenApiAny"/>
         /// into the appropriate <see cref="IOpenApiPrimitive"/> type based on the given <see cref="OpenApiSchema"/>.
         /// For those strings that the schema does not specify the type for, convert them into
         /// the most specific type based on the value.
         /// </summary>
-        public static IOpenApiAny GetSpecificOpenApiAny(IOpenApiAny openApiAny, OpenApiSchema schema)
+        public static IOpenApiAny GetSpecificOpenApiAny(IOpenApiAny openApiAny, OpenApiSchema schema = null)
         {
             if (openApiAny is OpenApiArray openApiArray)
             {
@@ -113,9 +37,9 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
                 foreach (var key in openApiObject.Keys.ToList())
                 {
-                    if ( schema != null && schema.Properties != null && schema.Properties.ContainsKey(key) )
+                    if (schema?.Properties != null && schema.Properties.TryGetValue(key, out var property))
                     {
-                        newObject[key] = GetSpecificOpenApiAny(openApiObject[key], schema.Properties[key]);
+                        newObject[key] = GetSpecificOpenApiAny(openApiObject[key], property);
                     }
                     else
                     {
@@ -126,133 +50,162 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 return newObject;
             }
 
-            if (!(openApiAny is OpenApiString))
+            if (!(openApiAny is OpenApiString) || ((OpenApiString)openApiAny).IsExplicit())
             {
                 return openApiAny;
             }
 
-            if (schema?.Type == null)
-            {
-                return GetSpecificOpenApiAny(openApiAny);
-            }
-
-            var type = schema.Type;
-            var format = schema.Format;
-
             var value = ((OpenApiString)openApiAny).Value;
-
             if (value == null || value == "null")
             {
                 return new OpenApiNull();
             }
 
-            if (type == "integer" && format == "int32")
+            if (schema?.Type == null)
             {
+                if (value == "true")
+                {
+                    return new OpenApiBoolean(true);
+                }
+
+                if (value == "false")
+                {
+                    return new OpenApiBoolean(false);
+                }
+
                 if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
                 {
                     return new OpenApiInteger(intValue);
                 }
-            }
 
-            if (type == "integer" && format == "int64")
-            {
                 if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue))
                 {
                     return new OpenApiLong(longValue);
                 }
-            }
 
-            if (type == "integer")
-            {
-                if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
-                {
-                    return new OpenApiInteger(intValue);
-                }
-            }
-
-            if (type == "number" && format == "float")
-            {
-                if (float.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var floatValue))
-                {
-                    return new OpenApiFloat(floatValue);
-                }
-            }
-
-            if (type == "number" && format == "double" )
-            {
                 if (double.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var doubleValue))
                 {
                     return new OpenApiDouble(doubleValue);
                 }
-            }
 
-            if (type == "number")
-            {
-                if (double.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var doubleValue))
-                {
-                    return new OpenApiDouble(doubleValue);
-                }
-            }
-
-            if (type == "string" && format == "byte")
-            {
-                try
-                {
-                    return new OpenApiByte(Convert.FromBase64String(value));
-                }
-                catch(FormatException)
-                { }
-            }
-
-            // binary
-            if (type == "string" && format == "binary")
-            {
-                try
-                {
-                    return new OpenApiBinary(Encoding.UTF8.GetBytes(value));
-                }
-                catch(EncoderFallbackException)
-                { }
-            }
-
-            if (type == "string" && format == "date")
-            {
-                if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateValue))
-                {
-                    return new OpenApiDate(dateValue.Date);
-                }
-            }
-
-            if (type == "string" && format == "date-time")
-            {
                 if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTimeValue))
                 {
                     return new OpenApiDateTime(dateTimeValue);
                 }
             }
-
-            if (type == "string" && format == "password")
+            else
             {
-                return new OpenApiPassword(value);
-            }
+                var type = schema.Type;
+                var format = schema.Format;
 
-            if (type == "string")
-            {
-                return new OpenApiString(value);
-            }
-
-            if (type == "boolean")
-            {
-                if (bool.TryParse(value, out var booleanValue))
+                if (type == "integer" && format == "int32")
                 {
-                    return new OpenApiBoolean(booleanValue);
+                    if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
+                    {
+                        return new OpenApiInteger(intValue);
+                    }
+                }
+
+                if (type == "integer" && format == "int64")
+                {
+                    if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var longValue))
+                    {
+                        return new OpenApiLong(longValue);
+                    }
+                }
+
+                if (type == "integer")
+                {
+                    if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
+                    {
+                        return new OpenApiInteger(intValue);
+                    }
+                }
+
+                if (type == "number" && format == "float")
+                {
+                    if (float.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var floatValue))
+                    {
+                        return new OpenApiFloat(floatValue);
+                    }
+                }
+
+                if (type == "number" && format == "double")
+                {
+                    if (double.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var doubleValue))
+                    {
+                        return new OpenApiDouble(doubleValue);
+                    }
+                }
+
+                if (type == "number")
+                {
+                    if (double.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var doubleValue))
+                    {
+                        return new OpenApiDouble(doubleValue);
+                    }
+                }
+
+                if (type == "string" && format == "byte")
+                {
+                    try
+                    {
+                        return new OpenApiByte(Convert.FromBase64String(value));
+                    }
+                    catch (FormatException)
+                    { }
+                }
+
+                // binary
+                if (type == "string" && format == "binary")
+                {
+                    try
+                    {
+                        return new OpenApiBinary(Encoding.UTF8.GetBytes(value));
+                    }
+                    catch (EncoderFallbackException)
+                    { }
+                }
+
+                if (type == "string" && format == "date")
+                {
+                    if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateValue))
+                    {
+                        return new OpenApiDate(dateValue.Date);
+                    }
+                }
+
+                if (type == "string" && format == "date-time")
+                {
+                    if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTimeValue))
+                    {
+                        return new OpenApiDateTime(dateTimeValue);
+                    }
+                }
+
+                if (type == "string" && format == "password")
+                {
+                    return new OpenApiPassword(value);
+                }
+
+                if (type == "string")
+                {
+                    return new OpenApiString(value);
+                }
+
+                if (type == "boolean")
+                {
+                    if (bool.TryParse(value, out var booleanValue))
+                    {
+                        return new OpenApiBoolean(booleanValue);
+                    }
                 }
             }
 
             // If data conflicts with the given type, return a string.
             // This converter is used in the parser, so it does not perform any validations, 
             // but the validator can be used to validate whether the data and given type conflicts.
-            return new OpenApiString(value);
+            return openApiAny;
         }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/ValueNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/ValueNode.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System;
-using System.Globalization;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Readers.Exceptions;
+using SharpYaml;
 using SharpYaml.Serialization;
 
 namespace Microsoft.OpenApi.Readers.ParseNodes
@@ -36,7 +35,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
         public override IOpenApiAny CreateAny()
         {
             var value = GetScalarValue();
-            return new OpenApiString(value);
+            return new OpenApiString(value, this._node.Style == ScalarStyle.SingleQuoted || this._node.Style == ScalarStyle.DoubleQuoted || this._node.Style == ScalarStyle.Literal || this._node.Style == ScalarStyle.Folded);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Any/OpenApiString.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiString.cs
@@ -8,18 +8,29 @@ namespace Microsoft.OpenApi.Any
     /// </summary>
     public class OpenApiString : OpenApiPrimitive<string>
     {
+        private bool isExplicit;
+
         /// <summary>
         /// Initializes the <see cref="OpenApiString"/> class.
         /// </summary>
         /// <param name="value"></param>
-        public OpenApiString(string value)
+        public OpenApiString(string value, bool isExplicit = false)
             : base(value)
         {
+            this.isExplicit = isExplicit;
         }
 
         /// <summary>
         /// The primitive class this object represents.
         /// </summary>
         public override PrimitiveType PrimitiveType { get; } = PrimitiveType.String;
+
+        /// <summary>
+        /// True if string was specified explicitly by the means of double quotes, single quotes, or literal or folded style.
+        /// </summary>
+        public bool IsExplicit()
+        {
+            return this.isExplicit;
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -143,6 +143,7 @@
       <EmbeddedResource Include="V3Tests\Samples\OpenApiExample\advancedExample.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiExample\explicitString.yaml" />
       <EmbeddedResource Include="V3Tests\Samples\OpenApiInfo\basicInfo.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiExampleTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiExampleTests.cs
@@ -75,5 +75,15 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                     });
             }
         }
+
+        [Fact]
+        public void ParseExampleForcedStringSucceed()
+        {
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "explicitString.yaml")))
+            {
+                new OpenApiStreamReader().Read(stream, out var diagnostic);
+                diagnostic.Errors.Should().BeEmpty();
+            }
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiInfoTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiInfoTests.cs
@@ -71,8 +71,8 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                             },
                             ["x-list"] = new OpenApiArray
                             {
-                                new OpenApiInteger(1),
-                                new OpenApiInteger(2)
+                                new OpenApiString("1"),
+                                new OpenApiString("2")
                             }
                         }
                     });

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiExample/explicitString.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiExample/explicitString.yaml
@@ -1,0 +1,33 @@
+﻿openapi: 3.0.1
+info:
+  version: 1.0.0
+  title: Test API
+paths:
+  /test-path:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/test-schema'
+      responses:
+        default:
+          description: ''
+components:
+  schemas:
+    test-schema:
+      type: object
+      properties:
+        sub:
+          $ref: '#/components/schemas/test-sub-schema'
+      required:
+        - origin
+      example:
+        sub:
+          test-property: "12345"
+    test-sub-schema:
+      type: object
+      properties:
+        test-property:
+          type: string
+          example: "12345"

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiExample/explicitString.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiExample/explicitString.yaml
@@ -20,14 +20,17 @@ components:
       properties:
         sub:
           $ref: '#/components/schemas/test-sub-schema'
-      required:
-        - origin
       example:
         sub:
-          test-property: "12345"
+          test-property1: "12345"
+          test-property2: "1970-01-01T00:00:00Z"
     test-sub-schema:
       type: object
       properties:
-        test-property:
+        test-property1:
           type: string
           example: "12345"
+        test-property2:
+          type: string
+          format: date-time
+          example: "1970-01-01T00:00:00Z"


### PR DESCRIPTION
If string value was specified in YAML explicitly via quotes, or one of the other string syntaxes it must not be converted into any other type.