### PR TITLE
Reevaluating any objects once schema becomes available if parsing in …

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ParsingContext.cs
+++ b/src/Microsoft.OpenApi.Readers/ParsingContext.cs
@@ -24,7 +24,6 @@ namespace Microsoft.OpenApi.Readers
         private readonly Stack<string> _currentLocation = new Stack<string>();
         private readonly Dictionary<string, object> _tempStorage = new Dictionary<string, object>();
         private readonly Dictionary<object, Dictionary<string, object>> _scopedTempStorage = new Dictionary<object, Dictionary<string, object>>();
-        private IOpenApiVersionService _versionService;
         private readonly Dictionary<string, Stack<string>> _loopStacks = new Dictionary<string, Stack<string>>();
         internal Dictionary<string, Func<IOpenApiAny, OpenApiSpecVersion, IOpenApiExtension>> ExtensionParsers { get; set; } = new Dictionary<string, Func<IOpenApiAny, OpenApiSpecVersion, IOpenApiExtension>>();
         internal RootNode RootNode { get; set; }
@@ -115,17 +114,7 @@ namespace Microsoft.OpenApi.Readers
         /// <summary>
         /// Service providing all Version specific conversion functions
         /// </summary>
-        internal IOpenApiVersionService VersionService
-        {
-            get
-            {
-                return _versionService;
-            }
-            set
-            {
-                _versionService = value;
-            }
-        }
+        internal IOpenApiVersionService VersionService { get; set; }
 
         /// <summary>
         /// End the current object.
@@ -141,6 +130,27 @@ namespace Microsoft.OpenApi.Readers
         public string GetLocation()
         {
             return "#/" + string.Join("/", _currentLocation.Reverse().ToArray());
+        }
+
+        /// <summary>
+        /// Serializes current location
+        /// </summary>
+        public string[] CaptureLocation()
+        {
+            return this._currentLocation.Reverse().ToArray();
+        }
+
+
+        /// <summary>
+        /// Serializes current location
+        /// </summary>
+        public void SetLocation(string[] location)
+        {
+            this._currentLocation.Clear();
+            foreach (var part in location)
+            {
+                this._currentLocation.Push(part);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
@@ -221,9 +221,9 @@ namespace Microsoft.OpenApi.Readers.V2
         public static OpenApiDocument LoadOpenApi(RootNode rootNode)
         {
             var openApidoc = new OpenApiDocument();
-
             var openApiNode = rootNode.GetMap();
 
+            SetupDelayedAnyFieldConversion(rootNode.Context);
             ParseMap(openApiNode, openApidoc, _openApiFixedFields, _openApiPatternFields);
 
             if (openApidoc.Paths != null)
@@ -237,6 +237,7 @@ namespace Microsoft.OpenApi.Readers.V2
             }
 
             ProcessResponsesMediaTypes(rootNode.GetMap(), openApidoc.Components?.Responses?.Values, openApiNode.Context);
+            ProcessAnyFieldConversion(rootNode.Context, openApidoc);
 
             // Post Process OpenApi Object
             if (openApidoc.Servers == null)
@@ -257,14 +258,6 @@ namespace Microsoft.OpenApi.Readers.V2
                 foreach (var response in responses)
                 {
                     ProcessProduces(mapNode, response, context);
-
-                    if (response.Content != null)
-                    {
-                        foreach (var mediaType in response.Content.Values)
-                        {
-                            ProcessAnyFields(mapNode, mediaType, _mediaTypeAnyFields);
-                        }
-                    }
                 }
             }
         }

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Any;
@@ -47,9 +48,18 @@ namespace Microsoft.OpenApi.Readers.V2
                 {
                     mapNode.Context.StartObject(anyFieldName);
 
-                    var convertedOpenApiAny = OpenApiAnyConverter.GetSpecificOpenApiAny(
-                        anyFieldMap[anyFieldName].PropertyGetter(domainObject),
-                        anyFieldMap[anyFieldName].SchemaGetter(domainObject));
+                    var value = anyFieldMap[anyFieldName].PropertyGetter(domainObject);
+                    var schema = anyFieldMap[anyFieldName].SchemaGetter(domainObject);
+                    if (schema?.Reference != null)
+                    {
+                        ScheduleAnyFieldConversion(
+                            mapNode,
+                            value,
+                            schema,
+                            v => anyFieldMap[anyFieldName].PropertySetter(domainObject, v));
+                    }
+
+                    var convertedOpenApiAny = OpenApiAnyConverter.GetSpecificOpenApiAny(value, schema);
 
                     anyFieldMap[anyFieldName].PropertySetter(domainObject, convertedOpenApiAny);
                 }
@@ -83,10 +93,19 @@ namespace Microsoft.OpenApi.Readers.V2
                     {
                         foreach (var propertyElement in list)
                         {
-                            newProperty.Add(
-                                OpenApiAnyConverter.GetSpecificOpenApiAny(
+                            var schema = anyListFieldMap[anyListFieldName].SchemaGetter(domainObject);
+                            if (schema?.Reference != null)
+                            {
+                                var index = newProperty.Count;
+                                ScheduleAnyFieldConversion(
+                                    mapNode,
                                     propertyElement,
-                                    anyListFieldMap[anyListFieldName].SchemaGetter(domainObject)));
+                                    schema,
+                                    v => newProperty[index] = v);
+                            }
+
+                            newProperty.Add(
+                                OpenApiAnyConverter.GetSpecificOpenApiAny(propertyElement, schema));
                         }
                     }
 
@@ -114,6 +133,7 @@ namespace Microsoft.OpenApi.Readers.V2
                 try
                 {
                     var newProperty = new List<IOpenApiAny>();
+                    var schema = anyMapFieldMap[anyMapFieldName].SchemaGetter(domainObject);
 
                     mapNode.Context.StartObject(anyMapFieldName);
 
@@ -124,11 +144,16 @@ namespace Microsoft.OpenApi.Readers.V2
                             mapNode.Context.StartObject(propertyMapElement.Key);
 
                             var any = anyMapFieldMap[anyMapFieldName].PropertyGetter(propertyMapElement.Value);
-
-                            var newAny = OpenApiAnyConverter.GetSpecificOpenApiAny(
+                            if (schema?.Reference != null)
+                            {
+                                ScheduleAnyFieldConversion(
+                                    mapNode,
                                     any,
-                                    anyMapFieldMap[anyMapFieldName].SchemaGetter(domainObject));
+                                    schema,
+                                    v => anyMapFieldMap[anyMapFieldName].PropertySetter(propertyMapElement.Value, v));
+                            }
 
+                            var newAny = OpenApiAnyConverter.GetSpecificOpenApiAny(any, schema);
                             anyMapFieldMap[anyMapFieldName].PropertySetter(propertyMapElement.Value, newAny);
                         }
                     }
@@ -141,6 +166,58 @@ namespace Microsoft.OpenApi.Readers.V2
                 finally
                 {
                     mapNode.Context.EndObject();
+                }
+            }
+        }
+
+        private static void SetupDelayedAnyFieldConversion(ParsingContext context)
+        {
+            context.SetTempStorage("anyFieldConversion", new List<Tuple<ParsingContext, OpenApiDiagnostic, string[], IOpenApiAny, OpenApiSchema, Action<IOpenApiAny>>>());
+        }
+
+        private static void ScheduleAnyFieldConversion(MapNode mapNode, IOpenApiAny value, OpenApiSchema schema, Action<IOpenApiAny> setter)
+        {
+            var schedule = mapNode.Context.GetFromTempStorage<List<Tuple<ParsingContext, OpenApiDiagnostic, string[], IOpenApiAny, OpenApiSchema, Action<IOpenApiAny>>>>("anyFieldConversion");
+            if (schedule != null)
+            {
+                schedule.Add(Tuple.Create(mapNode.Context, mapNode.Diagnostic, mapNode.Context.CaptureLocation(), value, schema, setter));
+            }
+        }
+
+        private static void ProcessAnyFieldConversion(ParsingContext context, OpenApiDocument document)
+        {
+            var schedule = context.GetFromTempStorage<List<Tuple<ParsingContext, OpenApiDiagnostic, string[], IOpenApiAny, OpenApiSchema, Action<IOpenApiAny>>>>("anyFieldConversion");
+            if (schedule == null)
+            {
+                return;
+            }
+            context.SetTempStorage("anyFieldConversion", null);
+
+            foreach (var item in schedule)
+            {
+                if (item.Item5.Reference == null)
+                {
+                    continue;
+                }
+
+                if (document.ResolveReference(item.Item5.Reference) is OpenApiSchema schema)
+                {
+                    var oldLocation = context.CaptureLocation();
+                    try
+                    {
+                        context.SetLocation(item.Item3);
+                        var convertedOpenApiAny = OpenApiAnyConverter.GetSpecificOpenApiAny(item.Item4, schema);
+                        item.Item6(convertedOpenApiAny);
+                    }
+                    catch (OpenApiException exception)
+                    {
+                        exception.Pointer = context.GetLocation();
+                        item.Item2.Errors.Add(new OpenApiError(exception));
+                    }
+                    finally
+                    {
+                        context.SetLocation(oldLocation);
+                    }
                 }
             }
         }

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiDocumentDeserializer.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System.Collections.Generic;
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
-using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
 
@@ -29,13 +26,13 @@ namespace Microsoft.OpenApi.Readers.V3
             {"components", (o, n) => o.Components = LoadComponents(n)},
             {"tags", (o, n) => {o.Tags = n.CreateList(LoadTag);
                 foreach (var tag in o.Tags)
-    {
+                {
                     tag.Reference = new OpenApiReference()
                     {
                         Id = tag.Name,
                         Type = ReferenceType.Tag
                     };
-    }
+                }
             } },
             {"externalDocs", (o, n) => o.ExternalDocs = LoadExternalDocs(n)},
             {"security", (o, n) => o.SecurityRequirements = n.CreateList(LoadSecurityRequirement)}
@@ -50,10 +47,11 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiDocument LoadOpenApi(RootNode rootNode)
         {
             var openApidoc = new OpenApiDocument();
-
             var openApiNode = rootNode.GetMap();
 
+            SetupDelayedAnyFieldConversion(rootNode.Context);
             ParseMap(openApiNode, openApidoc, _openApiFixedFields, _openApiPatternFields);
+            ProcessAnyFieldConversion(rootNode.Context, openApidoc);
 
             return openApidoc;
         }

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiReferenceResolver.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiReferenceResolver.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Interfaces
+{
+    /// <summary>
+    /// Represents an Open API element capable of resolving references.
+    /// </summary>
+    public interface IOpenApiReferenceResolver
+    {
+        /// <summary>
+        /// Load the referenced <see cref="IOpenApiReferenceable"/> object from a <see cref="OpenApiReference"/> object
+        /// </summary>
+        IOpenApiReferenceable ResolveReference(OpenApiReference reference);
+    }
+}

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -14,7 +13,7 @@ namespace Microsoft.OpenApi.Models
     /// <summary>
     /// Describes an OpenAPI object (OpenAPI document). See: https://swagger.io/specification
     /// </summary>
-    public class OpenApiDocument : IOpenApiSerializable, IOpenApiExtensible
+    public class OpenApiDocument : IOpenApiSerializable, IOpenApiExtensible, IOpenApiReferenceResolver
     {
         /// <summary>
         /// REQUIRED. Provides metadata about the API. The metadata MAY be used by tooling as required.
@@ -282,7 +281,7 @@ namespace Microsoft.OpenApi.Models
             if (reference.IsExternal)
             {
                 // Should not attempt to resolve external references against a single document.
-                throw new ArgumentException(Properties.SRResource.RemoteReferenceNotSupported); 
+                throw new ArgumentException(Properties.SRResource.RemoteReferenceNotSupported);
             }
 
             if (!reference.Type.HasValue)
@@ -305,7 +304,8 @@ namespace Microsoft.OpenApi.Models
                 return null;
             }
 
-            if (this.Components == null) {
+            if (this.Components == null)
+            {
                 throw new OpenApiException(string.Format(Properties.SRResource.InvalidReferenceId, reference.Id));
             }
 
@@ -343,9 +343,10 @@ namespace Microsoft.OpenApi.Models
                     default:
                         throw new OpenApiException(Properties.SRResource.InvalidReferenceType);
                 }
-            } catch(KeyNotFoundException)
+            }
+            catch (KeyNotFoundException)
             {
-                throw new OpenApiException(string.Format(Properties.SRResource.InvalidReferenceId,reference.Id));
+                throw new OpenApiException(string.Format(Properties.SRResource.InvalidReferenceId, reference.Id));
             }
         }
     }

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -143,6 +143,7 @@
       <EmbeddedResource Include="V3Tests\Samples\OpenApiExample\advancedExample.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiExample\integerTypes.yaml" />
       <EmbeddedResource Include="V3Tests\Samples\OpenApiInfo\basicInfo.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiExampleTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiExampleTests.cs
@@ -75,5 +75,15 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                     });
             }
         }
+
+        [Fact]
+        public void ParseExampleIntegerFormatSucceed()
+        {
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "integerTypes.yaml")))
+            {
+                new OpenApiStreamReader().Read(stream, out var diagnostic);
+                diagnostic.Errors.Should().BeEmpty();
+            }
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiExample/integerTypes.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiExample/integerTypes.yaml
@@ -1,0 +1,26 @@
+﻿openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+paths:
+  /test-path:
+    post:
+      summary: Adds a new user
+      requestBody:
+        content:
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/test-schema'
+            example:
+              test-property: 10
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    test-schema:
+      type: object
+      properties:
+        test-property:
+          type: integer
+          format: int64

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiExample/integerTypes.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiExample/integerTypes.yaml
@@ -13,6 +13,14 @@ paths:
               $ref: '#/components/schemas/test-schema'
             example:
               test-property: 10
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/test-schema'
+            example:
+            - test-property: 11
+            - test-property-string: 12
       responses:
         '200':
           description: OK
@@ -24,3 +32,5 @@ components:
         test-property:
           type: integer
           format: int64
+        test-property-string:
+          type: string


### PR DESCRIPTION
In most general case we can't do any type conversion as we parse YAML tree since schemas may not yet be available if referenced via $ref. That is only possible when whole document is parsed and we can resolve such references to reference schema for type information.

But it is also often the case that we do not parse whole document or maybe schema is available and is not a reference.

This change still tries to convert any value as parsing is performed, but for scenarios when whole document is being parsed it also schedules delayed any value conversion. After document is fully parsed delayed conversion is performed.

This issue has surfaced numerous times for us and is reported at least once here as well #407.