### PR TITLE
Diagnostic moved from MapNode to ParsingContext

### DIFF
--- a/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
@@ -55,7 +55,7 @@ namespace Microsoft.OpenApi.Readers
                 return new OpenApiDocument();
             }
 
-            context = new ParsingContext
+            context = new ParsingContext(diagnostic)
             {
                 ExtensionParsers = _settings.ExtensionParsers,
                 BaseUrl = _settings.BaseUrl
@@ -66,7 +66,7 @@ namespace Microsoft.OpenApi.Readers
             try
             {
                 // Parse the OpenAPI Document
-                document = context.Parse(yamlDocument, diagnostic);
+                document = context.Parse(yamlDocument);
 
                 // Resolve References if requested
                 switch (_settings.ReferenceResolution)
@@ -128,7 +128,7 @@ namespace Microsoft.OpenApi.Readers
                 return default(T);
             }
 
-            context = new ParsingContext
+            context = new ParsingContext(diagnostic)
             {
                 ExtensionParsers = _settings.ExtensionParsers
             };
@@ -138,7 +138,7 @@ namespace Microsoft.OpenApi.Readers
             try
             {
                 // Parse the OpenAPI element
-                element = context.ParseFragment<T>(yamlDocument, version, diagnostic);
+                element = context.ParseFragment<T>(yamlDocument, version);
             }
             catch (OpenApiException ex)
             {

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/ListNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/ListNode.cs
@@ -17,9 +17,8 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
     {
         private readonly YamlSequenceNode _nodeList;
 
-        public ListNode(ParsingContext context, OpenApiDiagnostic diagnostic, YamlSequenceNode sequenceNode) : base(
-            context,
-            diagnostic)
+        public ListNode(ParsingContext context, YamlSequenceNode sequenceNode) : base(
+            context)
         {
             _nodeList = sequenceNode;
         }
@@ -32,14 +31,14 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                     $"Expected list at line {_nodeList.Start.Line} while parsing {typeof(T).Name}");
             }
 
-            return _nodeList.Select(n => map(new MapNode(Context, Diagnostic, n as YamlMappingNode)))
+            return _nodeList.Select(n => map(new MapNode(Context, n as YamlMappingNode)))
                 .Where(i => i != null)
                 .ToList();
         }
 
         public override List<IOpenApiAny> CreateListOfAny()
         {
-            return _nodeList.Select(n => ParseNode.Create(Context, Diagnostic,n).CreateAny())
+            return _nodeList.Select(n => ParseNode.Create(Context, n).CreateAny())
                 .Where(i => i != null)
                 .ToList();
         }
@@ -52,12 +51,12 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                     $"Expected list at line {_nodeList.Start.Line} while parsing {typeof(T).Name}");
             }
 
-            return _nodeList.Select(n => map(new ValueNode(Context, Diagnostic, n))).ToList();
+            return _nodeList.Select(n => map(new ValueNode(Context, n))).ToList();
         }
 
         public IEnumerator<ParseNode> GetEnumerator()
         {
-            return _nodeList.Select(n => Create(Context, Diagnostic, n)).ToList().GetEnumerator();
+            return _nodeList.Select(n => Create(Context, n)).ToList().GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/MapNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/MapNode.cs
@@ -23,14 +23,13 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
         private readonly YamlMappingNode _node;
         private readonly List<PropertyNode> _nodes;
 
-        public MapNode(ParsingContext context, OpenApiDiagnostic diagnostic, string yamlString) :
-            this(context, diagnostic, (YamlMappingNode)YamlHelper.ParseYamlString(yamlString))
+        public MapNode(ParsingContext context, string yamlString) :
+            this(context, (YamlMappingNode)YamlHelper.ParseYamlString(yamlString))
         {
         }
 
-        public MapNode(ParsingContext context, OpenApiDiagnostic diagnostic, YamlNode node) : base(
-            context,
-            diagnostic)
+        public MapNode(ParsingContext context, YamlNode node) : base(
+            context)
         {
             if (!(node is YamlMappingNode mapNode))
             {
@@ -40,7 +39,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             this._node = mapNode;
 
             _nodes = this._node.Children
-                .Select(kvp => new PropertyNode(Context, Diagnostic, kvp.Key.GetScalarValue(), kvp.Value))
+                .Select(kvp => new PropertyNode(Context, kvp.Key.GetScalarValue(), kvp.Value))
                 .Cast<PropertyNode>()
                 .ToList();
         }
@@ -52,7 +51,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 YamlNode node = null;
                 if (this._node.Children.TryGetValue(new YamlScalarNode(key), out node))
                 {
-                    return new PropertyNode(Context, Diagnostic, key, this._node.Children[new YamlScalarNode(key)]);
+                    return new PropertyNode(Context, key, this._node.Children[new YamlScalarNode(key)]);
                 }
 
                 return null;
@@ -73,43 +72,44 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                     key = n.Key.GetScalarValue(),
                     value = n.Value as YamlMappingNode == null
                         ? default(T)
-                        : map(new MapNode(Context, Diagnostic, n.Value as YamlMappingNode))
+                        : map(new MapNode(Context, n.Value as YamlMappingNode))
                 });
 
             return nodes.ToDictionary(k => k.key, v => v.value);
         }
 
-         public override Dictionary<string, T> CreateMapWithReference<T>(
-             ReferenceType referenceType,
-             Func<MapNode, T> map)
-         {
-             var yamlMap = _node;
-             if (yamlMap == null)
-             {
-                 throw new OpenApiException($"Expected map at line {yamlMap.Start.Line} while parsing {typeof(T).Name}");
-             }
+        public override Dictionary<string, T> CreateMapWithReference<T>(
+            ReferenceType referenceType,
+            Func<MapNode, T> map)
+        {
+            var yamlMap = _node;
+            if (yamlMap == null)
+            {
+                throw new OpenApiException($"Expected map at line {yamlMap.Start.Line} while parsing {typeof(T).Name}");
+            }
 
-             var nodes = yamlMap.Select(
-                 n => {
-                     var entry = new
-                     {
-                         key = n.Key.GetScalarValue(),
-                         value = map(new MapNode(Context, Diagnostic, (YamlMappingNode)n.Value))
-                     };
-                     if (entry.value == null)
-                     {
-                         return null;  // Body Parameters shouldn't be converted to Parameters
-                     }
-                     entry.value.Reference = new OpenApiReference()
-                     {
-                         Type = referenceType,
-                         Id = entry.key
-                     };
-                     return entry;
-                 }
-                 );
-             return nodes.Where(n => n!= null).ToDictionary(k => k.key, v => v.value);
-         }
+            var nodes = yamlMap.Select(
+                n =>
+                {
+                    var entry = new
+                    {
+                        key = n.Key.GetScalarValue(),
+                        value = map(new MapNode(Context, (YamlMappingNode)n.Value))
+                    };
+                    if (entry.value == null)
+                    {
+                        return null;  // Body Parameters shouldn't be converted to Parameters
+                    }
+                    entry.value.Reference = new OpenApiReference()
+                    {
+                        Type = referenceType,
+                        Id = entry.key
+                    };
+                    return entry;
+                }
+                );
+            return nodes.Where(n => n != null).ToDictionary(k => k.key, v => v.value);
+        }
 
         public override Dictionary<string, T> CreateSimpleMap<T>(Func<ValueNode, T> map)
         {
@@ -123,7 +123,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 n => new
                 {
                     key = n.Key.GetScalarValue(),
-                    value = map(new ValueNode(Context, Diagnostic, (YamlScalarNode)n.Value))
+                    value = map(new ValueNode(Context, (YamlScalarNode)n.Value))
                 });
             return nodes.ToDictionary(k => k.key, v => v.value);
         }
@@ -140,7 +140,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
         public override string GetRaw()
         {
-            var x = new Serializer(new SerializerSettings(new JsonSchema()) {EmitJsonComptible = true});
+            var x = new Serializer(new SerializerSettings(new JsonSchema()) { EmitJsonComptible = true });
             return x.Serialize(_node);
         }
 
@@ -148,10 +148,10 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             where T : IOpenApiReferenceable, new()
         {
             return new T()
-                    {
-                        UnresolvedReference = true,
-                        Reference = Context.VersionService.ConvertToOpenApiReference(referenceId,referenceType)  
-                    };
+            {
+                UnresolvedReference = true,
+                Reference = Context.VersionService.ConvertToOpenApiReference(referenceId, referenceType)
+            };
         }
 
         public string GetReferencePointer()

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/ParseNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/ParseNode.cs
@@ -15,15 +15,12 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 {
     internal abstract class ParseNode
     {
-        protected ParseNode(ParsingContext parsingContext, OpenApiDiagnostic diagnostic)
+        protected ParseNode(ParsingContext parsingContext)
         {
             Context = parsingContext;
-            Diagnostic = diagnostic;
         }
 
         public ParsingContext Context { get; }
-
-        public OpenApiDiagnostic Diagnostic { get; }
 
         public MapNode CheckMapNode(string nodeName)
         {
@@ -35,20 +32,20 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             return mapNode;
         }
 
-        public static ParseNode Create(ParsingContext context, OpenApiDiagnostic diagnostic, YamlNode node)
+        public static ParseNode Create(ParsingContext context, YamlNode node)
         {
 
             if (node is YamlSequenceNode listNode)
             {
-                return new ListNode(context, diagnostic, listNode);
+                return new ListNode(context, listNode);
             }
 
             if (node is YamlMappingNode mapNode)
             {
-                return new MapNode(context, diagnostic, mapNode);
+                return new MapNode(context, mapNode);
             }
 
-            return new ValueNode(context, diagnostic, node as YamlScalarNode);
+            return new ValueNode(context, node as YamlScalarNode);
         }
 
         public virtual List<T> CreateList<T>(Func<MapNode, T> map)

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/PropertyNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/PropertyNode.cs
@@ -14,12 +14,11 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 {
     internal class PropertyNode : ParseNode
     {
-        public PropertyNode(ParsingContext context, OpenApiDiagnostic diagnostic, string name, YamlNode node) : base(
-            context,
-            diagnostic)
+        public PropertyNode(ParsingContext context, string name, YamlNode node) : base(
+            context)
         {
             Name = name;
-            Value = Create(context, diagnostic, node);
+            Value = Create(context, node);
         }
 
         public string Name { get; set; }
@@ -43,12 +42,12 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 }
                 catch (OpenApiReaderException ex)
                 {
-                    Diagnostic.Errors.Add(new OpenApiError(ex));
+                    Context.Diagnostic.Errors.Add(new OpenApiError(ex));
                 }
                 catch (OpenApiException ex)
                 {
                     ex.Pointer = Context.GetLocation();
-                    Diagnostic.Errors.Add(new OpenApiError(ex));
+                    Context.Diagnostic.Errors.Add(new OpenApiError(ex));
                 }
                 finally
                 {
@@ -67,12 +66,12 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                     }
                     catch (OpenApiReaderException ex)
                     {
-                        Diagnostic.Errors.Add(new OpenApiError(ex));
+                        Context.Diagnostic.Errors.Add(new OpenApiError(ex));
                     }
                     catch (OpenApiException ex)
                     {
                         ex.Pointer = Context.GetLocation();
-                        Diagnostic.Errors.Add(new OpenApiError(ex));
+                        Context.Diagnostic.Errors.Add(new OpenApiError(ex));
                     }
                     finally
                     {
@@ -81,7 +80,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 }
                 else
                 {
-                    Diagnostic.Errors.Add(
+                    Context.Diagnostic.Errors.Add(
                         new OpenApiError("", $"{Name} is not a valid property at {Context.GetLocation()}"));
                 }
             }

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/RootNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/RootNode.cs
@@ -14,8 +14,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
         public RootNode(
             ParsingContext context,
-            OpenApiDiagnostic diagnostic,
-            YamlDocument yamlDocument) : base(context, diagnostic)
+            YamlDocument yamlDocument) : base(context)
         {
             _yamlDocument = yamlDocument;
         }
@@ -28,12 +27,12 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 return null;
             }
 
-            return Create(Context, Diagnostic, yamlNode);
+            return Create(Context, yamlNode);
         }
 
         public MapNode GetMap()
         {
-            return new MapNode(Context, Diagnostic, (YamlMappingNode)_yamlDocument.RootNode);
+            return new MapNode(Context, (YamlMappingNode)_yamlDocument.RootNode);
         }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/ValueNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/ValueNode.cs
@@ -13,9 +13,8 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
     {
         private readonly YamlScalarNode _node;
 
-        public ValueNode(ParsingContext context, OpenApiDiagnostic diagnostic, YamlNode node) : base(
-            context,
-            diagnostic)
+        public ValueNode(ParsingContext context, YamlNode node) : base(
+            context)
         {
             if (!(node is YamlScalarNode scalarNode))
             {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
@@ -137,7 +137,7 @@ namespace Microsoft.OpenApi.Readers.V2
             //Validate host
             if (host != null && !IsHostValid(host))
             {
-                rootNode.Diagnostic.Errors.Add(new OpenApiError(rootNode.Context.GetLocation(), "Invalid host"));
+                rootNode.Context.Diagnostic.Errors.Add(new OpenApiError(rootNode.Context.GetLocation(), "Invalid host"));
                 return;
             }
 

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiOperationDeserializer.cs
@@ -23,7 +23,6 @@ namespace Microsoft.OpenApi.Readers.V2
                         valueNode =>
                             LoadTagByReference(
                                 valueNode.Context,
-                                valueNode.Diagnostic,
                                 valueNode.GetScalarValue()))
                 },
                 {
@@ -210,7 +209,6 @@ namespace Microsoft.OpenApi.Readers.V2
 
         private static OpenApiTag LoadTagByReference(
             ParsingContext context,
-            OpenApiDiagnostic diagnostic,
             string tagName)
         {
             var tagObject = new OpenApiTag()

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiSecurityRequirementDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiSecurityRequirementDeserializer.cs
@@ -22,7 +22,6 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 var scheme = LoadSecuritySchemeByReference(
                     mapNode.Context,
-                    mapNode.Diagnostic,
                     property.Name);
 
                 var scopes = property.Value.CreateSimpleList(n2 => n2.GetScalarValue());
@@ -33,8 +32,8 @@ namespace Microsoft.OpenApi.Readers.V2
                 }
                 else
                 {
-                    node.Diagnostic.Errors.Add(
-                        new OpenApiError(node.Context.GetLocation(), 
+                    mapNode.Context.Diagnostic.Errors.Add(
+                        new OpenApiError(node.Context.GetLocation(),
                         $"Scheme {property.Name} is not found"));
                 }
             }
@@ -44,7 +43,6 @@ namespace Microsoft.OpenApi.Readers.V2
 
         private static OpenApiSecurityScheme LoadSecuritySchemeByReference(
             ParsingContext context,
-            OpenApiDiagnostic diagnostic,
             string schemeName)
         {
             var securitySchemeObject = new OpenApiSecurityScheme()

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
@@ -56,7 +56,7 @@ namespace Microsoft.OpenApi.Readers.V2
                 catch (OpenApiException exception)
                 {
                     exception.Pointer = mapNode.Context.GetLocation();
-                    mapNode.Diagnostic.Errors.Add(new OpenApiError(exception));
+                    mapNode.Context.Diagnostic.Errors.Add(new OpenApiError(exception));
                 }
                 finally
                 {
@@ -95,7 +95,7 @@ namespace Microsoft.OpenApi.Readers.V2
                 catch (OpenApiException exception)
                 {
                     exception.Pointer = mapNode.Context.GetLocation();
-                    mapNode.Diagnostic.Errors.Add(new OpenApiError(exception));
+                    mapNode.Context.Diagnostic.Errors.Add(new OpenApiError(exception));
                 }
                 finally
                 {
@@ -136,7 +136,7 @@ namespace Microsoft.OpenApi.Readers.V2
                 catch (OpenApiException exception)
                 {
                     exception.Pointer = mapNode.Context.GetLocation();
-                    mapNode.Diagnostic.Errors.Add(new OpenApiError(exception));
+                    mapNode.Context.Diagnostic.Errors.Add(new OpenApiError(exception));
                 }
                 finally
                 {

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiOperationDeserializer.cs
@@ -21,7 +21,6 @@ namespace Microsoft.OpenApi.Readers.V3
                         valueNode =>
                             LoadTagByReference(
                                 valueNode.Context,
-                                valueNode.Diagnostic,
                                 valueNode.GetScalarValue()))
                 },
                 {
@@ -111,7 +110,6 @@ namespace Microsoft.OpenApi.Readers.V3
 
         private static OpenApiTag LoadTagByReference(
             ParsingContext context,
-            OpenApiDiagnostic diagnostic,
             string tagName)
         {
             var tagObject = new OpenApiTag()
@@ -123,7 +121,7 @@ namespace Microsoft.OpenApi.Readers.V3
                     Id = tagName
                 }
             };
-            
+
             return tagObject;
         }
     }

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSecurityRequirementDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSecurityRequirementDeserializer.cs
@@ -22,7 +22,6 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 var scheme = LoadSecuritySchemeByReference(
                     mapNode.Context,
-                    mapNode.Diagnostic,
                     property.Name);
 
                 var scopes = property.Value.CreateSimpleList(value => value.GetScalarValue());
@@ -33,7 +32,7 @@ namespace Microsoft.OpenApi.Readers.V3
                 }
                 else
                 {
-                    node.Diagnostic.Errors.Add(
+                    mapNode.Context.Diagnostic.Errors.Add(
                         new OpenApiError(node.Context.GetLocation(), $"Scheme {property.Name} is not found"));
                 }
             }
@@ -43,7 +42,6 @@ namespace Microsoft.OpenApi.Readers.V3
 
         private static OpenApiSecurityScheme LoadSecuritySchemeByReference(
             ParsingContext context,
-            OpenApiDiagnostic diagnostic,
             string schemeName)
         {
             var securitySchemeObject = new OpenApiSecurityScheme()

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiV3Deserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiV3Deserializer.cs
@@ -56,7 +56,7 @@ namespace Microsoft.OpenApi.Readers.V3
                 catch (OpenApiException exception)
                 {
                     exception.Pointer = mapNode.Context.GetLocation();
-                    mapNode.Diagnostic.Errors.Add(new OpenApiError(exception));
+                    mapNode.Context.Diagnostic.Errors.Add(new OpenApiError(exception));
                 }
                 finally
                 {
@@ -91,7 +91,7 @@ namespace Microsoft.OpenApi.Readers.V3
                 catch (OpenApiException exception)
                 {
                     exception.Pointer = mapNode.Context.GetLocation();
-                    mapNode.Diagnostic.Errors.Add(new OpenApiError(exception));
+                    mapNode.Context.Diagnostic.Errors.Add(new OpenApiError(exception));
                 }
                 finally
                 {
@@ -132,7 +132,7 @@ namespace Microsoft.OpenApi.Readers.V3
                 catch (OpenApiException exception)
                 {
                     exception.Pointer = mapNode.Context.GetLocation();
-                    mapNode.Diagnostic.Errors.Add(new OpenApiError(exception));
+                    mapNode.Context.Diagnostic.Errors.Add(new OpenApiError(exception));
                 }
                 finally
                 {

--- a/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/OpenApiAnyConverterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/OpenApiAnyConverterTests.cs
@@ -31,10 +31,10 @@ aDate: 2017-01-02
             yamlStream.Load(new StringReader(input));
             var yamlNode = yamlStream.Documents.First().RootNode;
 
-            var context = new ParsingContext();
             var diagnostic = new OpenApiDiagnostic();
+            var context = new ParsingContext(diagnostic);
 
-            var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+            var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
             var anyMap = node.CreateAny();
 
@@ -84,7 +84,7 @@ aDate: 2017-01-02
                     ["aDate"] = new OpenApiDate(DateTimeOffset.Parse("2017-01-02", CultureInfo.InvariantCulture).Date),
                 });
         }
-    
+
 
         [Fact]
         public void ParseNestedObjectAsAnyShouldSucceed()
@@ -117,10 +117,10 @@ aDate: 2017-01-02
             yamlStream.Load(new StringReader(input));
             var yamlNode = yamlStream.Documents.First().RootNode;
 
-            var context = new ParsingContext();
             var diagnostic = new OpenApiDiagnostic();
+            var context = new ParsingContext(diagnostic);
 
-            var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+            var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
             var anyMap = node.CreateAny();
 
@@ -264,7 +264,7 @@ aDate: 2017-01-02
                     ["aDateTime"] = new OpenApiDateTime(DateTimeOffset.Parse("2017-01-01", CultureInfo.InvariantCulture))
                 });
         }
-    
+
 
         [Fact]
         public void ParseNestedObjectAsAnyWithPartialSchemaShouldSucceed()
@@ -297,10 +297,10 @@ aDate: 2017-01-02
             yamlStream.Load(new StringReader(input));
             var yamlNode = yamlStream.Documents.First().RootNode;
 
-            var context = new ParsingContext();
             var diagnostic = new OpenApiDiagnostic();
+            var context = new ParsingContext(diagnostic);
 
-            var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+            var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
             var anyMap = node.CreateAny();
 
@@ -452,10 +452,10 @@ aDate: 2017-01-02
             yamlStream.Load(new StringReader(input));
             var yamlNode = yamlStream.Documents.First().RootNode;
 
-            var context = new ParsingContext();
             var diagnostic = new OpenApiDiagnostic();
+            var context = new ParsingContext(diagnostic);
 
-            var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+            var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
             var anyMap = node.CreateAny();
 

--- a/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/OpenApiAnyTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/OpenApiAnyTests.cs
@@ -27,10 +27,10 @@ aDateTime: 2017-01-01
             yamlStream.Load(new StringReader(input));
             var yamlNode = yamlStream.Documents.First().RootNode;
 
-            var context = new ParsingContext();
             var diagnostic = new OpenApiDiagnostic();
+            var context = new ParsingContext(diagnostic);
 
-            var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+            var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
             var anyMap = node.CreateAny();
 
@@ -59,10 +59,10 @@ aDateTime: 2017-01-01
             yamlStream.Load(new StringReader(input));
             var yamlNode = yamlStream.Documents.First().RootNode;
 
-            var context = new ParsingContext();
             var diagnostic = new OpenApiDiagnostic();
+            var context = new ParsingContext(diagnostic);
 
-            var node = new ListNode(context, diagnostic, (YamlSequenceNode)yamlNode);
+            var node = new ListNode(context, (YamlSequenceNode)yamlNode);
 
             var any = node.CreateAny();
 
@@ -88,10 +88,10 @@ aDateTime: 2017-01-01
             yamlStream.Load(new StringReader(input));
             var yamlNode = yamlStream.Documents.First().RootNode;
 
-            var context = new ParsingContext();
             var diagnostic = new OpenApiDiagnostic();
+            var context = new ParsingContext(diagnostic);
 
-            var node = new ValueNode(context, diagnostic, (YamlScalarNode)yamlNode);
+            var node = new ValueNode(context, (YamlScalarNode)yamlNode);
 
             var any = node.CreateAny();
 
@@ -112,10 +112,10 @@ aDateTime: 2017-01-01
             yamlStream.Load(new StringReader(input));
             var yamlNode = yamlStream.Documents.First().RootNode;
 
-            var context = new ParsingContext();
             var diagnostic = new OpenApiDiagnostic();
+            var context = new ParsingContext(diagnostic);
 
-            var node = new ValueNode(context, diagnostic, (YamlScalarNode)yamlNode);
+            var node = new ValueNode(context, (YamlScalarNode)yamlNode);
 
             var any = node.CreateAny();
 

--- a/test/Microsoft.OpenApi.Readers.Tests/TestHelper.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/TestHelper.cs
@@ -16,10 +16,9 @@ namespace Microsoft.OpenApi.Readers.Tests
             yamlStream.Load(new StreamReader(stream));
             var yamlNode = yamlStream.Documents.First().RootNode;
 
-            var context = new ParsingContext();
-            var diagnostic = new OpenApiDiagnostic();
+            var context = new ParsingContext(new OpenApiDiagnostic());
 
-            return new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+            return new MapNode(context, (YamlMappingNode)yamlNode);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiSecuritySchemeTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiSecuritySchemeTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
@@ -25,10 +24,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             {
                 var document = OpenApiStreamReader.LoadYamlDocument(stream);
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)document.RootNode);
+                var node = new MapNode(context, (YamlMappingNode)document.RootNode);
 
                 // Act
                 var securityScheme = OpenApiV2Deserializer.LoadSecurityScheme(node);
@@ -49,10 +48,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "apiKeySecurityScheme.yaml")))
             {
                 var document = OpenApiStreamReader.LoadYamlDocument(stream);
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)document.RootNode);
+                var node = new MapNode(context, (YamlMappingNode)document.RootNode);
 
                 // Act
                 var securityScheme = OpenApiV2Deserializer.LoadSecurityScheme(node);
@@ -74,10 +73,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "oauth2ImplicitSecurityScheme.yaml")))
             {
                 var document = OpenApiStreamReader.LoadYamlDocument(stream);
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)document.RootNode);
+                var node = new MapNode(context, (YamlMappingNode)document.RootNode);
 
                 // Act
                 var securityScheme = OpenApiV2Deserializer.LoadSecurityScheme(node);
@@ -109,10 +108,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "oauth2PasswordSecurityScheme.yaml")))
             {
                 var document = OpenApiStreamReader.LoadYamlDocument(stream);
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)document.RootNode);
+                var node = new MapNode(context, (YamlMappingNode)document.RootNode);
 
                 // Act
                 var securityScheme = OpenApiV2Deserializer.LoadSecurityScheme(node);
@@ -144,10 +143,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "oauth2ApplicationSecurityScheme.yaml")))
             {
                 var document = OpenApiStreamReader.LoadYamlDocument(stream);
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)document.RootNode);
+                var node = new MapNode(context, (YamlMappingNode)document.RootNode);
 
                 // Act
                 var securityScheme = OpenApiV2Deserializer.LoadSecurityScheme(node);
@@ -180,10 +179,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             {
                 var document = OpenApiStreamReader.LoadYamlDocument(stream);
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)document.RootNode);
+                var node = new MapNode(context, (YamlMappingNode)document.RootNode);
 
                 // Act
                 var securityScheme = OpenApiV2Deserializer.LoadSecurityScheme(node);

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiCallbackTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiCallbackTests.cs
@@ -28,10 +28,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var callback = OpenApiV3Deserializer.LoadCallback(node);
@@ -94,7 +94,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 callback.ShouldBeEquivalentTo(
                     new OpenApiCallback
                     {
-                        PathItems = 
+                        PathItems =
                         {
                             [RuntimeExpression.Build("$request.body#/url")]= new OpenApiPathItem {
                                 Operations = {
@@ -135,17 +135,17 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         [Fact]
         public void ParseMultipleCallbacksWithReferenceShouldSucceed()
         {
-            using ( var stream = Resources.GetStream( Path.Combine( SampleFolderPath, "multipleCallbacksWithReference.yaml" ) ) )
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "multipleCallbacksWithReference.yaml")))
             {
                 // Act
-                var openApiDoc = new OpenApiStreamReader().Read( stream, out var diagnostic );
+                var openApiDoc = new OpenApiStreamReader().Read(stream, out var diagnostic);
 
                 // Assert
                 var path = openApiDoc.Paths.First().Value;
                 var subscribeOperation = path.Operations[OperationType.Post];
 
                 diagnostic.ShouldBeEquivalentTo(
-                    new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0 } );
+                    new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0 });
 
                 var callback1 = subscribeOperation.Callbacks["simpleHook"];
 
@@ -186,7 +186,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                             Type = ReferenceType.Callback,
                             Id = "simpleHook",
                         }
-                    } );
+                    });
 
                 var callback2 = subscribeOperation.Callbacks["callback2"];
                 callback2.ShouldBeEquivalentTo(
@@ -222,7 +222,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                                 },
                             }
                         }
-                    } );
+                    });
 
                 var callback3 = subscribeOperation.Callbacks["callback3"];
                 callback3.ShouldBeEquivalentTo(
@@ -265,7 +265,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                                 }
                             }
                         }
-                    } );
+                    });
             }
         }
     }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDiscriminatorTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDiscriminatorTests.cs
@@ -26,10 +26,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var discriminator = OpenApiV3Deserializer.LoadDiscriminator(node);

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiEncodingTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiEncodingTests.cs
@@ -26,10 +26,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var encoding = OpenApiV3Deserializer.LoadEncoding(node);
@@ -52,10 +52,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var encoding = OpenApiV3Deserializer.LoadEncoding(node);

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiExampleTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiExampleTests.cs
@@ -27,10 +27,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 var example = OpenApiV3Deserializer.LoadExample(node);
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiInfoTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiInfoTests.cs
@@ -28,10 +28,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var openApiInfo = OpenApiV3Deserializer.LoadInfo(node);
@@ -56,7 +56,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                         },
                         License = new OpenApiLicense
                         {
-                            Extensions = {["x-disclaimer"] = new OpenApiString("Sample Extension String Disclaimer")},
+                            Extensions = { ["x-disclaimer"] = new OpenApiString("Sample Extension String Disclaimer") },
                             Name = "licenseName",
                             Url = new Uri("http://www.example.com/url2")
                         },
@@ -88,10 +88,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var openApiInfo = OpenApiV3Deserializer.LoadInfo(node);
@@ -128,10 +128,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var openApiInfo = OpenApiV3Deserializer.LoadInfo(node);

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
@@ -28,10 +28,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var schema = OpenApiV3Deserializer.LoadSchema(node);
@@ -119,7 +119,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 new OpenApiObject
                 {
                     ["foo"] = new OpenApiString("bar"),
-                    ["baz"] = new OpenApiArray() { 
+                    ["baz"] = new OpenApiArray() {
                         new OpenApiInteger(1),
                         new OpenApiInteger(2)
                     }
@@ -160,10 +160,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var schema = OpenApiV3Deserializer.LoadSchema(node);
@@ -196,7 +196,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                                 Minimum = 0
                             }
                         },
-                        AdditionalPropertiesAllowed = false  
+                        AdditionalPropertiesAllowed = false
                     });
             }
         }
@@ -230,8 +230,9 @@ get:
                         {
                             Responses = new OpenApiResponses
                             {
-                                ["200"] = new OpenApiResponse {
-                                   Description = "Ok"
+                                ["200"] = new OpenApiResponse
+                                {
+                                    Description = "Ok"
                                 }
                             }
                         }
@@ -248,10 +249,10 @@ get:
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var schema = OpenApiV3Deserializer.LoadSchema(node);
@@ -280,10 +281,10 @@ get:
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var schema = OpenApiV3Deserializer.LoadSchema(node);
@@ -464,7 +465,7 @@ get:
                                 {
                                     "name",
                                     "petType"
-                                }, 
+                                },
                                 Reference = new OpenApiReference()
                                 {
                                     Id= "Pet",

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSecuritySchemeTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSecuritySchemeTests.cs
@@ -27,10 +27,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var securityScheme = OpenApiV3Deserializer.LoadSecurityScheme(node);
@@ -54,10 +54,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var securityScheme = OpenApiV3Deserializer.LoadSecurityScheme(node);
@@ -82,10 +82,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var securityScheme = OpenApiV3Deserializer.LoadSecurityScheme(node);
@@ -110,10 +110,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var securityScheme = OpenApiV3Deserializer.LoadSecurityScheme(node);
@@ -148,10 +148,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var securityScheme = OpenApiV3Deserializer.LoadSecurityScheme(node);

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiXmlTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiXmlTests.cs
@@ -27,10 +27,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 yamlStream.Load(new StreamReader(stream));
                 var yamlNode = yamlStream.Documents.First().RootNode;
 
-                var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
+                var context = new ParsingContext(diagnostic);
 
-                var node = new MapNode(context, diagnostic, (YamlMappingNode)yamlNode);
+                var node = new MapNode(context, (YamlMappingNode)yamlNode);
 
                 // Act
                 var xml = OpenApiV3Deserializer.LoadXml(node);


### PR DESCRIPTION
Is there a reason to have Diagnostic on ParseNode rather than in context as in this PR? Judging from code they both go hand in hand always and I can't really see any valuable scenario when one would need to change diagnostic between nodes.