### PR TITLE
Small readers optimization

### DIFF
--- a/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
@@ -1,18 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System;
 using System.IO;
-using System.Linq;
-using Microsoft.OpenApi.Exceptions;
-using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.Interface;
-using Microsoft.OpenApi.Readers.Services;
-using Microsoft.OpenApi.Services;
-using SharpYaml;
-using SharpYaml.Serialization;
 
 namespace Microsoft.OpenApi.Readers
 {
@@ -21,7 +13,7 @@ namespace Microsoft.OpenApi.Readers
     /// </summary>
     public class OpenApiStreamReader : IOpenApiReader<Stream, OpenApiDiagnostic>
     {
-        private OpenApiReaderSettings _settings;
+        private readonly OpenApiReaderSettings _settings;
 
         /// <summary>
         /// Create stream reader with custom settings if desired.
@@ -30,8 +22,8 @@ namespace Microsoft.OpenApi.Readers
         public OpenApiStreamReader(OpenApiReaderSettings settings = null)
         {
             _settings = settings ?? new OpenApiReaderSettings();
-
         }
+
         /// <summary>
         /// Reads the stream input and parses it into an Open API document.
         /// </summary>
@@ -40,68 +32,10 @@ namespace Microsoft.OpenApi.Readers
         /// <returns>Instance of newly created OpenApiDocument</returns>
         public OpenApiDocument Read(Stream input, out OpenApiDiagnostic diagnostic)
         {
-            ParsingContext context;
-            YamlDocument yamlDocument;
-            diagnostic = new OpenApiDiagnostic();
-
-            // Parse the YAML/JSON
-            try
+            using (var reader = new StreamReader(input))
             {
-                yamlDocument = LoadYamlDocument(input);
+                return new OpenApiTextReaderReader(_settings).Read(reader, out diagnostic);
             }
-            catch (YamlException ex)
-            {
-                diagnostic.Errors.Add(new OpenApiError($"#char={ex.Start.Line}", ex.Message));
-                return new OpenApiDocument();
-            }
-
-            context = new ParsingContext
-            {
-                ExtensionParsers = _settings.ExtensionParsers,
-                BaseUrl = _settings.BaseUrl
-            };
-
-            OpenApiDocument document = null;
-
-            try
-            {
-                // Parse the OpenAPI Document
-                document = context.Parse(yamlDocument, diagnostic);
-
-                // Resolve References if requested
-                switch (_settings.ReferenceResolution)
-                {
-                    case ReferenceResolutionSetting.ResolveAllReferences:
-                        throw new ArgumentException(Properties.SRResource.CannotResolveRemoteReferencesSynchronously);
-                    case ReferenceResolutionSetting.ResolveLocalReferences:
-                        var resolver = new OpenApiReferenceResolver(document);
-                        var walker = new OpenApiWalker(resolver);
-                        walker.Walk(document);
-                        foreach (var item in resolver.Errors)
-                        {
-                            diagnostic.Errors.Add(item);
-                        }
-                        break;
-                    case ReferenceResolutionSetting.DoNotResolveReferences:
-                        break;
-                }
-            }
-            catch (OpenApiException ex)
-            {
-                diagnostic.Errors.Add(new OpenApiError(ex));
-            }
-
-            // Validate the document
-            if (_settings.RuleSet != null && _settings.RuleSet.Rules.Count > 0)
-            {
-                var errors = document.Validate(_settings.RuleSet);
-                foreach (var item in errors)
-                {
-                    diagnostic.Errors.Add(item);
-                }
-            }
-
-            return document;
         }
 
         /// <summary>
@@ -113,66 +47,10 @@ namespace Microsoft.OpenApi.Readers
         /// <returns>Instance of newly created OpenApiDocument</returns>
         public T ReadFragment<T>(Stream input, OpenApiSpecVersion version, out OpenApiDiagnostic diagnostic) where T : IOpenApiElement
         {
-            ParsingContext context;
-            YamlDocument yamlDocument;
-            diagnostic = new OpenApiDiagnostic();
-
-            // Parse the YAML/JSON
-            try
+            using (var reader = new StreamReader(input))
             {
-                yamlDocument = LoadYamlDocument(input);
+                return new OpenApiTextReaderReader(_settings).ReadFragment<T>(reader, version, out diagnostic);
             }
-            catch (YamlException ex)
-            {
-                diagnostic.Errors.Add(new OpenApiError($"#line={ex.Start.Line}", ex.Message));
-                return default(T);
-            }
-
-            context = new ParsingContext
-            {
-                ExtensionParsers = _settings.ExtensionParsers
-            };
-
-            IOpenApiElement element = null;
-
-            try
-            {
-                // Parse the OpenAPI element
-                element = context.ParseFragment<T>(yamlDocument, version, diagnostic);
-            }
-            catch (OpenApiException ex)
-            {
-                diagnostic.Errors.Add(new OpenApiError(ex));
-            }
-
-            // Validate the element
-            if (_settings.RuleSet != null && _settings.RuleSet.Rules.Count > 0)
-            {
-                var errors = element.Validate(_settings.RuleSet);
-                foreach (var item in errors)
-                {
-                    diagnostic.Errors.Add(item);
-                }
-            }
-
-            return (T)element;
-        }
-
-        /// <summary>
-        /// Helper method to turn streams into YamlDocument
-        /// </summary>
-        /// <param name="input">Stream containing YAML formatted text</param>
-        /// <returns>Instance of a YamlDocument</returns>
-        internal static YamlDocument LoadYamlDocument(Stream input)
-        {
-            YamlDocument yamlDocument;
-            using (var streamReader = new StreamReader(input))
-            {
-                var yamlStream = new YamlStream();
-                yamlStream.Load(streamReader);
-                yamlDocument = yamlStream.Documents.First();
-            }
-            return yamlDocument;
         }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/OpenApiStringReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiStringReader.cs
@@ -29,14 +29,9 @@ namespace Microsoft.OpenApi.Readers
         /// </summary>
         public OpenApiDocument Read(string input, out OpenApiDiagnostic diagnostic)
         {
-            using (var memoryStream = new MemoryStream())
+            using (var reader = new StringReader(input))
             {
-                var writer = new StreamWriter(memoryStream);
-                writer.Write(input);
-                writer.Flush();
-                memoryStream.Position = 0;
-
-                return new OpenApiStreamReader(_settings).Read(memoryStream, out diagnostic);
+                return new OpenApiTextReaderReader(_settings).Read(reader, out diagnostic);
             }
         }
 
@@ -45,14 +40,9 @@ namespace Microsoft.OpenApi.Readers
         /// </summary>
         public T ReadFragment<T>(string input, OpenApiSpecVersion version, out OpenApiDiagnostic diagnostic) where T : IOpenApiElement
         {
-            using (var memoryStream = new MemoryStream())
+            using (var reader = new StringReader(input))
             {
-                var writer = new StreamWriter(memoryStream);
-                writer.Write(input);
-                writer.Flush();
-                memoryStream.Position = 0;
-
-                return new OpenApiStreamReader(_settings).ReadFragment<T>(memoryStream, version, out diagnostic);
+                return new OpenApiTextReaderReader(_settings).ReadFragment<T>(reader, version, out diagnostic);
             }
         }
     }

--- a/src/Microsoft.OpenApi.Readers/OpenApiTextReaderReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiTextReaderReader.cs
@@ -1,0 +1,172 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.OpenApi.Exceptions;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.Interface;
+using Microsoft.OpenApi.Readers.Services;
+using Microsoft.OpenApi.Services;
+using SharpYaml;
+using SharpYaml.Serialization;
+
+namespace Microsoft.OpenApi.Readers
+{
+    /// <summary>
+    /// Service class for converting contents of TextReader into OpenApiDocument instances
+    /// </summary>
+    public class OpenApiTextReaderReader : IOpenApiReader<TextReader, OpenApiDiagnostic>
+    {
+        private readonly OpenApiReaderSettings _settings;
+
+        /// <summary>
+        /// Create stream reader with custom settings if desired.
+        /// </summary>
+        /// <param name="settings"></param>
+        public OpenApiTextReaderReader(OpenApiReaderSettings settings = null)
+        {
+            _settings = settings ?? new OpenApiReaderSettings();
+        }
+
+        /// <summary>
+        /// Reads the stream input and parses it into an Open API document.
+        /// </summary>
+        /// <param name="input">TextReader containing OpenAPI description to parse.</param>
+        /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing</param>
+        /// <returns>Instance of newly created OpenApiDocument</returns>
+        public OpenApiDocument Read(TextReader input, out OpenApiDiagnostic diagnostic)
+        {
+            ParsingContext context;
+            YamlDocument yamlDocument;
+            diagnostic = new OpenApiDiagnostic();
+
+            // Parse the YAML/JSON
+            try
+            {
+                yamlDocument = LoadYamlDocument(input);
+            }
+            catch (YamlException ex)
+            {
+                diagnostic.Errors.Add(new OpenApiError($"#char={ex.Start.Line}", ex.Message));
+                return new OpenApiDocument();
+            }
+
+            context = new ParsingContext
+            {
+                ExtensionParsers = _settings.ExtensionParsers,
+                BaseUrl = _settings.BaseUrl
+            };
+
+            OpenApiDocument document = null;
+
+            try
+            {
+                // Parse the OpenAPI Document
+                document = context.Parse(yamlDocument, diagnostic);
+
+                // Resolve References if requested
+                switch (_settings.ReferenceResolution)
+                {
+                    case ReferenceResolutionSetting.ResolveAllReferences:
+                        throw new ArgumentException(Properties.SRResource.CannotResolveRemoteReferencesSynchronously);
+                    case ReferenceResolutionSetting.ResolveLocalReferences:
+                        var resolver = new OpenApiReferenceResolver(document);
+                        var walker = new OpenApiWalker(resolver);
+                        walker.Walk(document);
+                        foreach (var item in resolver.Errors)
+                        {
+                            diagnostic.Errors.Add(item);
+                        }
+                        break;
+                    case ReferenceResolutionSetting.DoNotResolveReferences:
+                        break;
+                }
+            }
+            catch (OpenApiException ex)
+            {
+                diagnostic.Errors.Add(new OpenApiError(ex));
+            }
+
+            // Validate the document
+            if (_settings.RuleSet != null && _settings.RuleSet.Rules.Count > 0)
+            {
+                var errors = document.Validate(_settings.RuleSet);
+                foreach (var item in errors)
+                {
+                    diagnostic.Errors.Add(item);
+                }
+            }
+
+            return document;
+        }
+        /// <summary>
+        /// Reads the stream input and parses the fragment of an OpenAPI description into an Open API Element.
+        /// </summary>
+        /// <param name="input">TextReader containing OpenAPI description to parse.</param>
+        /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
+        /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing</param>
+        /// <returns>Instance of newly created OpenApiDocument</returns>
+        public T ReadFragment<T>(TextReader input, OpenApiSpecVersion version, out OpenApiDiagnostic diagnostic) where T : IOpenApiElement
+        {
+            ParsingContext context;
+            YamlDocument yamlDocument;
+            diagnostic = new OpenApiDiagnostic();
+
+            // Parse the YAML/JSON
+            try
+            {
+                yamlDocument = LoadYamlDocument(input);
+            }
+            catch (YamlException ex)
+            {
+                diagnostic.Errors.Add(new OpenApiError($"#line={ex.Start.Line}", ex.Message));
+                return default(T);
+            }
+
+            context = new ParsingContext
+            {
+                ExtensionParsers = _settings.ExtensionParsers
+            };
+
+            IOpenApiElement element = null;
+
+            try
+            {
+                // Parse the OpenAPI element
+                element = context.ParseFragment<T>(yamlDocument, version, diagnostic);
+            }
+            catch (OpenApiException ex)
+            {
+                diagnostic.Errors.Add(new OpenApiError(ex));
+            }
+
+            // Validate the element
+            if (_settings.RuleSet != null && _settings.RuleSet.Rules.Count > 0)
+            {
+                var errors = element.Validate(_settings.RuleSet);
+                foreach (var item in errors)
+                {
+                    diagnostic.Errors.Add(item);
+                }
+            }
+
+            return (T)element;
+        }
+
+        /// <summary>
+        /// Helper method to turn streams into YamlDocument
+        /// </summary>
+        /// <param name="input">Stream containing YAML formatted text</param>
+        /// <returns>Instance of a YamlDocument</returns>
+        static YamlDocument LoadYamlDocument(TextReader input)
+        {
+            var yamlStream = new YamlStream();
+            yamlStream.Load(input);
+            return yamlStream.Documents.First();
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.Readers/OpenApiYamlDocumentReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiYamlDocumentReader.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.OpenApi.Exceptions;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.Interface;
+using Microsoft.OpenApi.Readers.Services;
+using Microsoft.OpenApi.Services;
+using SharpYaml.Serialization;
+
+namespace Microsoft.OpenApi.Readers
+{
+    /// <summary>
+    /// Service class for converting contents of TextReader into OpenApiDocument instances
+    /// </summary>
+    public class OpenApiYamlDocumentReader : IOpenApiReader<YamlDocument, OpenApiDiagnostic>
+    {
+        private readonly OpenApiReaderSettings _settings;
+
+        /// <summary>
+        /// Create stream reader with custom settings if desired.
+        /// </summary>
+        /// <param name="settings"></param>
+        public OpenApiYamlDocumentReader(OpenApiReaderSettings settings = null)
+        {
+            _settings = settings ?? new OpenApiReaderSettings();
+        }
+
+        /// <summary>
+        /// Reads the stream input and parses it into an Open API document.
+        /// </summary>
+        /// <param name="input">TextReader containing OpenAPI description to parse.</param>
+        /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing</param>
+        /// <returns>Instance of newly created OpenApiDocument</returns>
+        public OpenApiDocument Read(YamlDocument input, out OpenApiDiagnostic diagnostic)
+        {
+            diagnostic = new OpenApiDiagnostic();
+            var context = new ParsingContext
+            {
+                ExtensionParsers = _settings.ExtensionParsers,
+                BaseUrl = _settings.BaseUrl
+            };
+
+            OpenApiDocument document = null;
+            try
+            {
+                // Parse the OpenAPI Document
+                document = context.Parse(input, diagnostic);
+
+                // Resolve References if requested
+                switch (_settings.ReferenceResolution)
+                {
+                    case ReferenceResolutionSetting.ResolveAllReferences:
+                        throw new ArgumentException(Properties.SRResource.CannotResolveRemoteReferencesSynchronously);
+                    case ReferenceResolutionSetting.ResolveLocalReferences:
+                        var resolver = new OpenApiReferenceResolver(document);
+                        var walker = new OpenApiWalker(resolver);
+                        walker.Walk(document);
+                        foreach (var item in resolver.Errors)
+                        {
+                            diagnostic.Errors.Add(item);
+                        }
+                        break;
+                    case ReferenceResolutionSetting.DoNotResolveReferences:
+                        break;
+                }
+            }
+            catch (OpenApiException ex)
+            {
+                diagnostic.Errors.Add(new OpenApiError(ex));
+            }
+
+            // Validate the document
+            if (_settings.RuleSet != null && _settings.RuleSet.Rules.Count > 0)
+            {
+                var errors = document.Validate(_settings.RuleSet);
+                foreach (var item in errors)
+                {
+                    diagnostic.Errors.Add(item);
+                }
+            }
+
+            return document;
+        }
+        /// <summary>
+        /// Reads the stream input and parses the fragment of an OpenAPI description into an Open API Element.
+        /// </summary>
+        /// <param name="input">TextReader containing OpenAPI description to parse.</param>
+        /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
+        /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing</param>
+        /// <returns>Instance of newly created OpenApiDocument</returns>
+        public T ReadFragment<T>(YamlDocument input, OpenApiSpecVersion version, out OpenApiDiagnostic diagnostic) where T : IOpenApiElement
+        {
+            diagnostic = new OpenApiDiagnostic();
+            var context = new ParsingContext
+            {
+                ExtensionParsers = _settings.ExtensionParsers
+            };
+
+            IOpenApiElement element = null;
+            try
+            {
+                // Parse the OpenAPI element
+                element = context.ParseFragment<T>(input, version, diagnostic);
+            }
+            catch (OpenApiException ex)
+            {
+                diagnostic.Errors.Add(new OpenApiError(ex));
+            }
+
+            // Validate the element
+            if (_settings.RuleSet != null && _settings.RuleSet.Rules.Count > 0)
+            {
+                var errors = element.Validate(_settings.RuleSet);
+                foreach (var item in errors)
+                {
+                    diagnostic.Errors.Add(item);
+                }
+            }
+
+            return (T)element;
+        }
+
+        /// <summary>
+        /// Helper method to turn streams into YamlDocument
+        /// </summary>
+        /// <param name="input">Stream containing YAML formatted text</param>
+        /// <returns>Instance of a YamlDocument</returns>
+        static YamlDocument LoadYamlDocument(TextReader input)
+        {
+            var yamlStream = new YamlStream();
+            yamlStream.Load(input);
+            return yamlStream.Documents.First();
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.Readers/OpenApiYamlDocumentReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiYamlDocumentReader.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. 
 
 using System;
-using System.IO;
-using System.Linq;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
@@ -124,18 +122,6 @@ namespace Microsoft.OpenApi.Readers
             }
 
             return (T)element;
-        }
-
-        /// <summary>
-        /// Helper method to turn streams into YamlDocument
-        /// </summary>
-        /// <param name="input">Stream containing YAML formatted text</param>
-        /// <returns>Instance of a YamlDocument</returns>
-        static YamlDocument LoadYamlDocument(TextReader input)
-        {
-            var yamlStream = new YamlStream();
-            yamlStream.Load(input);
-            return yamlStream.Documents.First();
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiSecuritySchemeTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiSecuritySchemeTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         {
             using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "basicSecurityScheme.yaml")))
             {
-                var document = OpenApiStreamReader.LoadYamlDocument(stream);
+                var document = LoadYamlDocument(stream);
 
                 var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         {
             using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "apiKeySecurityScheme.yaml")))
             {
-                var document = OpenApiStreamReader.LoadYamlDocument(stream);
+                var document = LoadYamlDocument(stream);
                 var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
 
@@ -73,7 +73,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         {
             using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "oauth2ImplicitSecurityScheme.yaml")))
             {
-                var document = OpenApiStreamReader.LoadYamlDocument(stream);
+                var document = LoadYamlDocument(stream);
                 var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
 
@@ -108,7 +108,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         {
             using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "oauth2PasswordSecurityScheme.yaml")))
             {
-                var document = OpenApiStreamReader.LoadYamlDocument(stream);
+                var document = LoadYamlDocument(stream);
                 var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
 
@@ -143,7 +143,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         {
             using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "oauth2ApplicationSecurityScheme.yaml")))
             {
-                var document = OpenApiStreamReader.LoadYamlDocument(stream);
+                var document = LoadYamlDocument(stream);
                 var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
 
@@ -178,7 +178,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         {
             using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "oauth2AccessCodeSecurityScheme.yaml")))
             {
-                var document = OpenApiStreamReader.LoadYamlDocument(stream);
+                var document = LoadYamlDocument(stream);
 
                 var context = new ParsingContext();
                 var diagnostic = new OpenApiDiagnostic();
@@ -206,6 +206,16 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                             }
                         }
                     });
+            }
+        }
+
+        static YamlDocument LoadYamlDocument(Stream input)
+        {
+            using (var reader = new StreamReader(input))
+            {
+                var yamlStream = new YamlStream();
+                yamlStream.Load(reader);
+                return yamlStream.Documents.First();
             }
         }
     }


### PR DESCRIPTION
This is a small optimization to expose ability to read OpenAPI documents and fragments from TextReader. This allows one to parse string more efficiently without need to put it into memory stream first.