### PR TITLE
'produces' at operation level must override one specified globally

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ParsingContext.cs
+++ b/src/Microsoft.OpenApi.Readers/ParsingContext.cs
@@ -146,7 +146,7 @@ namespace Microsoft.OpenApi.Readers
         /// <summary>
         /// Gets the value from the temporary storage matching the given key.
         /// </summary>
-        public T GetFromTempStorage<T>(string key, object scope = null) where T : class
+        public T GetFromTempStorage<T>(string key, object scope = null)
         {
             Dictionary<string, object> storage;
 
@@ -156,10 +156,10 @@ namespace Microsoft.OpenApi.Readers
             }
             else if (!_scopedTempStorage.TryGetValue(scope, out storage))
             {
-                return null;
+                return default(T);
             }
 
-            return storage.TryGetValue(key, out var value) ? (T)value : null;
+            return storage.TryGetValue(key, out var value) ? (T)value : default(T);
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi.Readers/V2/TempStorageKeys.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/TempStorageKeys.cs
@@ -12,6 +12,7 @@ namespace Microsoft.OpenApi.Readers.V2
         public const string BodyParameter = "bodyParameter";
         public const string FormParameters = "formParameters";
         public const string OperationProduces = "operationProduces";
+        public const string ResponseProducesSet = "responseProducesSet";
         public const string OperationConsumes = "operationConsumes";
         public const string GlobalConsumes = "globalConsumes";
         public const string GlobalProduces = "globalProduces";

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiOperationTests.cs
@@ -352,6 +352,18 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                                         new OpenApiFloat(6),
                                         new OpenApiFloat(7),
                                     }
+                                },
+                                ["application/xml"] = new OpenApiMediaType()
+                                {
+                                    Schema = new OpenApiSchema()
+                                    {
+                                        Type = "array",
+                                        Items = new OpenApiSchema()
+                                        {
+                                            Type = "number",
+                                            Format = "float"
+                                        }
+                                    }
                                 }
                             }
                         }}

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/operationWithResponseExamples.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/operationWithResponseExamples.yaml
@@ -1,5 +1,6 @@
 ﻿produces:
     - application/json
+    - application/xml
 responses:
     200:
         description: An array of float response

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/twoResponses.json
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/twoResponses.json
@@ -78,7 +78,7 @@
         }
     },
     "produces": [
-        "application/json"
+        "html/text"
     ],
     "definitions": {
         "Item": {


### PR DESCRIPTION
Before the fix they were combined, but spec clearly says this should not be done: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields-5