### PR TITLE
Always emitting description property for response object. It's required

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
 
@@ -45,7 +44,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Indicates if object is populated with data or is just a reference to the data
         /// </summary>
-        public bool UnresolvedReference { get; set;}
+        public bool UnresolvedReference { get; set; }
 
         /// <summary>
         /// Reference pointer.
@@ -79,7 +78,7 @@ namespace Microsoft.OpenApi.Models
             writer.WriteStartObject();
 
             // description
-            writer.WriteProperty(OpenApiConstants.Description, Description);
+            writer.WriteRequiredProperty(OpenApiConstants.Description, Description);
 
             // headers
             writer.WriteOptionalMap(OpenApiConstants.Headers, Headers, (w, h) => h.SerializeAsV3(w));
@@ -123,7 +122,7 @@ namespace Microsoft.OpenApi.Models
             writer.WriteStartObject();
 
             // description
-            writer.WriteProperty(OpenApiConstants.Description, Description);
+            writer.WriteRequiredProperty(OpenApiConstants.Description, Description);
             if (Content != null)
             {
                 var mediatype = Content.FirstOrDefault();

--- a/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
@@ -78,14 +78,7 @@ namespace Microsoft.OpenApi.Models
             writer.WriteStartObject();
 
             // description
-            if (this.Reference == null)
-            {
-                writer.WriteRequiredProperty(OpenApiConstants.Description, Description);
-            }
-            else
-            {
-                writer.WriteProperty(OpenApiConstants.Description, Description);
-            }
+            writer.WriteRequiredProperty(OpenApiConstants.Description, Description);
 
             // headers
             writer.WriteOptionalMap(OpenApiConstants.Headers, Headers, (w, h) => h.SerializeAsV3(w));
@@ -129,14 +122,7 @@ namespace Microsoft.OpenApi.Models
             writer.WriteStartObject();
 
             // description
-            if (this.Reference == null)
-            {
-                writer.WriteRequiredProperty(OpenApiConstants.Description, Description);
-            }
-            else
-            {
-                writer.WriteProperty(OpenApiConstants.Description, Description);
-            }
+            writer.WriteRequiredProperty(OpenApiConstants.Description, Description);
 
             if (Content != null)
             {

--- a/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
@@ -78,7 +78,14 @@ namespace Microsoft.OpenApi.Models
             writer.WriteStartObject();
 
             // description
-            writer.WriteRequiredProperty(OpenApiConstants.Description, Description);
+            if (this.Reference == null)
+            {
+                writer.WriteRequiredProperty(OpenApiConstants.Description, Description);
+            }
+            else
+            {
+                writer.WriteProperty(OpenApiConstants.Description, Description);
+            }
 
             // headers
             writer.WriteOptionalMap(OpenApiConstants.Headers, Headers, (w, h) => h.SerializeAsV3(w));
@@ -122,7 +129,15 @@ namespace Microsoft.OpenApi.Models
             writer.WriteStartObject();
 
             // description
-            writer.WriteRequiredProperty(OpenApiConstants.Description, Description);
+            if (this.Reference == null)
+            {
+                writer.WriteRequiredProperty(OpenApiConstants.Description, Description);
+            }
+            else
+            {
+                writer.WriteProperty(OpenApiConstants.Description, Description);
+            }
+
             if (Content != null)
             {
                 var mediatype = Content.FirstOrDefault();

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterExtensions.cs
@@ -33,6 +33,19 @@ namespace Microsoft.OpenApi.Writers
         }
 
         /// <summary>
+        /// Write required string property.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        /// <param name="name">The property name.</param>
+        /// <param name="value">The property value.</param>
+        public static void WriteRequiredProperty(this IOpenApiWriter writer, string name, string value)
+        {
+            CheckArguments(writer, name);
+            writer.WritePropertyName(name);
+            writer.WriteValue(value);
+        }
+
+        /// <summary>
         /// Write a boolean property.
         /// </summary>
         /// <param name="writer">The writer.</param>

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterExtensions.cs
@@ -42,7 +42,14 @@ namespace Microsoft.OpenApi.Writers
         {
             CheckArguments(writer, name);
             writer.WritePropertyName(name);
-            writer.WriteValue(value);
+            if (value == null)
+            {
+                writer.WriteNull();
+            }
+            else
+            {
+                writer.WriteValue(value);
+            }
         }
 
         /// <summary>

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiOperationTests.cs
@@ -359,6 +359,7 @@ namespace Microsoft.OpenApi.Tests.Models
       ""$ref"": ""#/components/responses/response1""
     },
     ""400"": {
+      ""description"": null,
       ""content"": {
         ""application/json"": {
           ""schema"": {
@@ -431,6 +432,7 @@ namespace Microsoft.OpenApi.Tests.Models
       ""$ref"": ""#/components/responses/response1""
     },
     ""400"": {
+      ""description"": null,
       ""content"": {
         ""application/json"": {
           ""schema"": {
@@ -554,7 +556,7 @@ namespace Microsoft.OpenApi.Tests.Models
 
             // Act
             var actual = _operationWithFormData.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
-            
+
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
@@ -607,7 +609,7 @@ namespace Microsoft.OpenApi.Tests.Models
 
             // Act
             var actual = _operationWithFormData.SerializeAsJson(OpenApiSpecVersion.OpenApi2_0);
-            
+
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
@@ -658,6 +660,7 @@ namespace Microsoft.OpenApi.Tests.Models
       ""$ref"": ""#/responses/response1""
     },
     ""400"": {
+      ""description"": null,
       ""schema"": {
         ""maximum"": 10,
         ""minimum"": 5,
@@ -672,7 +675,7 @@ namespace Microsoft.OpenApi.Tests.Models
 
             // Act
             var actual = _operationWithBody.SerializeAsJson(OpenApiSpecVersion.OpenApi2_0);
-            
+
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
@@ -727,6 +730,7 @@ namespace Microsoft.OpenApi.Tests.Models
       ""$ref"": ""#/responses/response1""
     },
     ""400"": {
+      ""description"": null,
       ""schema"": {
         ""maximum"": 10,
         ""minimum"": 5,

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiResponseTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiResponseTests.cs
@@ -116,11 +116,18 @@ namespace Microsoft.OpenApi.Tests.Models
             OpenApiSpecVersion version,
             OpenApiFormat format)
         {
-            // Arrange & Act
+            // Arrange
+            var expected = format == OpenApiFormat.Json ? @"{
+  ""description"": null
+}" : @"description: ";
+
+            // Act
             var actual = BasicResponse.Serialize(version, format);
 
             // Assert
-            actual.Should().Be("{ }");
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
         }
 
         [Fact]


### PR DESCRIPTION
Right now if empty response is provided it will be serialized as empty object thus producing invalid spec.