### PR TITLE
[441] Use AbsoluteUri instead of ToString

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiOAuthFlow.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOAuthFlow.cs
@@ -54,13 +54,13 @@ namespace Microsoft.OpenApi.Models
             writer.WriteStartObject();
 
             // authorizationUrl
-            writer.WriteProperty(OpenApiConstants.AuthorizationUrl, AuthorizationUrl?.ToString());
+            writer.WriteProperty(OpenApiConstants.AuthorizationUrl, AuthorizationUrl?.AbsoluteUri;
 
             // tokenUrl
-            writer.WriteProperty(OpenApiConstants.TokenUrl, TokenUrl?.ToString());
+            writer.WriteProperty(OpenApiConstants.TokenUrl, TokenUrl?.AbsoluteUri);
 
             // refreshUrl
-            writer.WriteProperty(OpenApiConstants.RefreshUrl, RefreshUrl?.ToString());
+            writer.WriteProperty(OpenApiConstants.RefreshUrl, RefreshUrl?.AbsoluteUri);
 
             // scopes
             writer.WriteRequiredMap(OpenApiConstants.Scopes, Scopes, (w, s) => w.WriteValue(s));


### PR DESCRIPTION
ToString unescape the characters and create a non-compliant Uri
https://github.com/microsoft/OpenAPI.NET/issues/441