### PR TITLE
Adds missing oneOf child object in walker method for OpenApiSchema

### DIFF
--- a/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
@@ -771,6 +771,11 @@ namespace Microsoft.OpenApi.Services
                 Walk("anyOf", () => Walk(schema.AnyOf));
             }
 
+            if (schema.OneOf != null)
+            {
+                Walk("oneOf", () => Walk(schema.OneOf));
+            }
+
             if (schema.Properties != null)
             {
                 Walk("properties", () =>


### PR DESCRIPTION
Proposes:
- Adding the missing `oneOf` child object in walker method for an `OpenApiSchema` to be able to extract out references within this object.