### PR TITLE
Add literal style support for OpenApiYamlWriter

### DIFF
--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OpenApi.Writers
         /// <summary>
         /// The indentation string to prepand to each line for each indentation level.
         /// </summary>
-        private const string IndentationString = "  ";
+        protected const string IndentationString = "  ";
 
         /// <summary>
         /// Scope of the Open API element - object, array, property.

--- a/src/Microsoft.OpenApi/Writers/OpenApiYamlWriter.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiYamlWriter.cs
@@ -198,39 +198,24 @@ namespace Microsoft.OpenApi.Writers
 
                 IncreaseIndentation();
 
-                var start = 0;
-                while (start < value.Length && value.IndexOfAny(new [] {'\n', '\r'}, start) is var lineBreak)
+                using (var reader = new StringReader(value))
                 {
-                    if (lineBreak == -1)
+                    bool firstLine = true;
+                    while (reader.ReadLine() is var line && line != null)
                     {
-                        break;
+                        if (firstLine)
+                            firstLine = false;
+                        else
+                            Writer.WriteLine();
+                        
+                        // Indentations for empty lines aren't needed.
+                        if (line.Length > 0)
+                        {
+                            WriteIndentation();
+                        }
+
+                        Writer.Write(line);
                     }
-
-                    // To preserves line break characters.
-                    var end = lineBreak;
-                    if (lineBreak + 1 < value.Length && value[lineBreak] == '\r' && value[lineBreak + 1] == '\n')
-                    { 
-                        // The line ends with "\r\n". YAML 1.2 specifies only three line breaks. "\r\n" | "\r" | "\n"
-                        end++;
-                    }
-                    
-                    if (lineBreak - start != 0)
-                    {
-                        // Indentation for empty lines aren't needed.
-                        WriteIndentation();
-                    }
-
-                    var line = value.Substring(start, end - start + 1);
-                    Writer.Write(line);
-
-                    start = end + 1;
-                }
-
-                // Last line
-                if (start < value.Length)
-                {
-                    WriteIndentation(); 
-                    Writer.Write(value.Substring(start));
                 }
 
                 DecreaseIndentation();

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterSpecialCharacterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterSpecialCharacterTests.cs
@@ -77,16 +77,10 @@ namespace Microsoft.OpenApi.Tests.Writers
         }
         
         [Theory]
-        [InlineData("multiline\r\nstring", "test: |\n  multiline\r\n  string")]
-        [InlineData("multiline\nstring", "test: |\n  multiline\n  string")]
-        [InlineData("multiline\rstring", "test: |\n  multiline\r  string")]
-        [InlineData("multiline\n\rstring", "test: |\n  multiline\n\r  string")]
-        [InlineData("ends with\r\nline break\r\n", "test: |+\n  ends with\r\n  line break\r\n")]
-        [InlineData("ends with\nline break\n", "test: |+\n  ends with\n  line break\n")]
-        [InlineData("ends with\rline break\r", "test: |+\n  ends with\r  line break\r")]
-        [InlineData("ends with\n\rline break\n\r", "test: |+\n  ends with\n\r  line break\n\r")]
+        [InlineData("multiline\r\nstring", "test: |\n  multiline\n  string")]
+        [InlineData("ends with\r\nline break\r\n", "test: |+\n  ends with\n  line break")]
         [InlineData("  starts with\nspaces", "test: |2\n    starts with\n  spaces")]
-        [InlineData("  starts with\nspaces, and ends with line break\n", "test: |+2\n    starts with\n  spaces, and ends with line break\n")]
+        [InlineData("  starts with\nspaces, and ends with line break\n", "test: |+2\n    starts with\n  spaces, and ends with line break")]
         [InlineData("contains\n\n\nempty lines", "test: |\n  contains\n\n\n  empty lines")]
         [InlineData("no line breaks fallback ", "test: 'no line breaks fallback '")]
         public void WriteStringWithNewlineCharactersInObjectAsYamlWorks(string input, string expected)
@@ -100,23 +94,19 @@ namespace Microsoft.OpenApi.Tests.Writers
             writer.WritePropertyName("test");
             writer.WriteValue(input);
             writer.WriteEndObject();
-            var actual = outputStringWriter.GetStringBuilder().ToString();
+            var actual = outputStringWriter.GetStringBuilder().ToString()
+                // Normalize newline for cross platform
+                .Replace("\r", "");
 
             // Assert
             actual.Should().Be(expected);
         }
         
         [Theory]
-        [InlineData("multiline\r\nstring", "- |\n  multiline\r\n  string")]
-        [InlineData("multiline\nstring", "- |\n  multiline\n  string")]
-        [InlineData("multiline\rstring", "- |\n  multiline\r  string")]
-        [InlineData("multiline\n\rstring", "- |\n  multiline\n\r  string")]
-        [InlineData("ends with\r\nline break\r\n", "- |+\n  ends with\r\n  line break\r\n")]
-        [InlineData("ends with\nline break\n", "- |+\n  ends with\n  line break\n")]
-        [InlineData("ends with\rline break\r", "- |+\n  ends with\r  line break\r")]
-        [InlineData("ends with\n\rline break\n\r", "- |+\n  ends with\n\r  line break\n\r")]
+        [InlineData("multiline\r\nstring", "- |\n  multiline\n  string")]
+        [InlineData("ends with\r\nline break\r\n", "- |+\n  ends with\n  line break")]
         [InlineData("  starts with\nspaces", "- |2\n    starts with\n  spaces")]
-        [InlineData("  starts with\nspaces, and ends with line break\n", "- |+2\n    starts with\n  spaces, and ends with line break\n")]
+        [InlineData("  starts with\nspaces, and ends with line break\n", "- |+2\n    starts with\n  spaces, and ends with line break")]
         [InlineData("contains\n\n\nempty lines", "- |\n  contains\n\n\n  empty lines")]
         [InlineData("no line breaks fallback ", "- 'no line breaks fallback '")]
         public void WriteStringWithNewlineCharactersInArrayAsYamlWorks(string input, string expected)
@@ -128,7 +118,9 @@ namespace Microsoft.OpenApi.Tests.Writers
             // Act
             writer.WriteStartArray();
             writer.WriteValue(input);
-            var actual = outputStringWriter.GetStringBuilder().ToString();
+            var actual = outputStringWriter.GetStringBuilder().ToString()
+                // Normalize newline for cross platform
+                .Replace("\r", "");
 
             // Assert
             actual.Should().Be(expected);

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterSpecialCharacterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterSpecialCharacterTests.cs
@@ -77,11 +77,13 @@ namespace Microsoft.OpenApi.Tests.Writers
         }
         
         [Theory]
-        [InlineData("multiline\r\nstring", "test: |\n  multiline\n  string")]
-        [InlineData("ends with\r\nline break\r\n", "test: |+\n  ends with\n  line break")]
-        [InlineData("  starts with\nspaces", "test: |2\n    starts with\n  spaces")]
-        [InlineData("  starts with\nspaces, and ends with line break\n", "test: |+2\n    starts with\n  spaces, and ends with line break")]
-        [InlineData("contains\n\n\nempty lines", "test: |\n  contains\n\n\n  empty lines")]
+        [InlineData("multiline\r\nstring", "test: |-\n  multiline\n  string")]
+        [InlineData("ends with\r\nline break\r\n", "test: |\n  ends with\n  line break")]
+        [InlineData("ends with\r\n2 line breaks\r\n\r\n", "test: |+\n  ends with\n  2 line breaks\n")]
+        [InlineData("ends with\r\n3 line breaks\r\n\r\n\r\n", "test: |+\n  ends with\n  3 line breaks\n\n")]
+        [InlineData("  starts with\nspaces", "test: |-2\n    starts with\n  spaces")]
+        [InlineData("  starts with\nspaces, and ends with line break\n", "test: |2\n    starts with\n  spaces, and ends with line break")]
+        [InlineData("contains\n\n\nempty lines", "test: |-\n  contains\n\n\n  empty lines")]
         [InlineData("no line breaks fallback ", "test: 'no line breaks fallback '")]
         public void WriteStringWithNewlineCharactersInObjectAsYamlWorks(string input, string expected)
         {
@@ -103,11 +105,13 @@ namespace Microsoft.OpenApi.Tests.Writers
         }
         
         [Theory]
-        [InlineData("multiline\r\nstring", "- |\n  multiline\n  string")]
-        [InlineData("ends with\r\nline break\r\n", "- |+\n  ends with\n  line break")]
-        [InlineData("  starts with\nspaces", "- |2\n    starts with\n  spaces")]
-        [InlineData("  starts with\nspaces, and ends with line break\n", "- |+2\n    starts with\n  spaces, and ends with line break")]
-        [InlineData("contains\n\n\nempty lines", "- |\n  contains\n\n\n  empty lines")]
+        [InlineData("multiline\r\nstring", "- |-\n  multiline\n  string")]
+        [InlineData("ends with\r\nline break\r\n", "- |\n  ends with\n  line break")]
+        [InlineData("ends with\r\n2 line breaks\r\n\r\n", "- |+\n  ends with\n  2 line breaks\n")]
+        [InlineData("ends with\r\n3 line breaks\r\n\r\n\r\n", "- |+\n  ends with\n  3 line breaks\n\n")]
+        [InlineData("  starts with\nspaces", "- |-2\n    starts with\n  spaces")]
+        [InlineData("  starts with\nspaces, and ends with line break\n", "- |2\n    starts with\n  spaces, and ends with line break")]
+        [InlineData("contains\n\n\nempty lines", "- |-\n  contains\n\n\n  empty lines")]
         [InlineData("no line breaks fallback ", "- 'no line breaks fallback '")]
         public void WriteStringWithNewlineCharactersInArrayAsYamlWorks(string input, string expected)
         {

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterSpecialCharacterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterSpecialCharacterTests.cs
@@ -75,5 +75,63 @@ namespace Microsoft.OpenApi.Tests.Writers
             // Assert
             actual.Should().Be(expected);
         }
+        
+        [Theory]
+        [InlineData("multiline\r\nstring", "test: |\n  multiline\r\n  string")]
+        [InlineData("multiline\nstring", "test: |\n  multiline\n  string")]
+        [InlineData("multiline\rstring", "test: |\n  multiline\r  string")]
+        [InlineData("multiline\n\rstring", "test: |\n  multiline\n\r  string")]
+        [InlineData("ends with\r\nline break\r\n", "test: |+\n  ends with\r\n  line break\r\n")]
+        [InlineData("ends with\nline break\n", "test: |+\n  ends with\n  line break\n")]
+        [InlineData("ends with\rline break\r", "test: |+\n  ends with\r  line break\r")]
+        [InlineData("ends with\n\rline break\n\r", "test: |+\n  ends with\n\r  line break\n\r")]
+        [InlineData("  starts with\nspaces", "test: |2\n    starts with\n  spaces")]
+        [InlineData("  starts with\nspaces, and ends with line break\n", "test: |+2\n    starts with\n  spaces, and ends with line break\n")]
+        [InlineData("contains\n\n\nempty lines", "test: |\n  contains\n\n\n  empty lines")]
+        [InlineData("no line breaks fallback ", "test: 'no line breaks fallback '")]
+        public void WriteStringWithNewlineCharactersInObjectAsYamlWorks(string input, string expected)
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiYamlWriter(outputStringWriter) { UseLiteralStyle = true, };
+
+            // Act
+            writer.WriteStartObject();
+            writer.WritePropertyName("test");
+            writer.WriteValue(input);
+            writer.WriteEndObject();
+            var actual = outputStringWriter.GetStringBuilder().ToString();
+
+            // Assert
+            actual.Should().Be(expected);
+        }
+        
+        [Theory]
+        [InlineData("multiline\r\nstring", "- |\n  multiline\r\n  string")]
+        [InlineData("multiline\nstring", "- |\n  multiline\n  string")]
+        [InlineData("multiline\rstring", "- |\n  multiline\r  string")]
+        [InlineData("multiline\n\rstring", "- |\n  multiline\n\r  string")]
+        [InlineData("ends with\r\nline break\r\n", "- |+\n  ends with\r\n  line break\r\n")]
+        [InlineData("ends with\nline break\n", "- |+\n  ends with\n  line break\n")]
+        [InlineData("ends with\rline break\r", "- |+\n  ends with\r  line break\r")]
+        [InlineData("ends with\n\rline break\n\r", "- |+\n  ends with\n\r  line break\n\r")]
+        [InlineData("  starts with\nspaces", "- |2\n    starts with\n  spaces")]
+        [InlineData("  starts with\nspaces, and ends with line break\n", "- |+2\n    starts with\n  spaces, and ends with line break\n")]
+        [InlineData("contains\n\n\nempty lines", "- |\n  contains\n\n\n  empty lines")]
+        [InlineData("no line breaks fallback ", "- 'no line breaks fallback '")]
+        public void WriteStringWithNewlineCharactersInArrayAsYamlWorks(string input, string expected)
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiYamlWriter(outputStringWriter) { UseLiteralStyle = true, };
+
+            // Act
+            writer.WriteStartArray();
+            writer.WriteValue(input);
+            var actual = outputStringWriter.GetStringBuilder().ToString();
+
+            // Assert
+            actual.Should().Be(expected);
+        }
     }
 }


### PR DESCRIPTION
OpenAPI allows `description` to be written in Markdown. Markdown descriptions can be multiple lines.
Current `OpenApiYamlWriter` escapes all control characters and joins and serializes them in one line.

I read description from external `README.md` file, and put it to `document.Info.Description`, and publishes the generated OpenAPI document.
Users can `diff` with previous versions of documents to track any public changes.
However, it is quite daunting when you have to look these long concatenated Markdown description to find diffs.

With literal style block scalar, I can preserve my line breaks of `README.md` as is.