### PR TITLE
Prevent breaking change on optional parameter #487

### DIFF
--- a/src/Microsoft.OpenApi/Any/OpenApiString.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiString.cs
@@ -14,8 +14,17 @@ namespace Microsoft.OpenApi.Any
         /// Initializes the <see cref="OpenApiString"/> class.
         /// </summary>
         /// <param name="value"></param>
+        public OpenApiString(string value)
+            : this(value, false)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes the <see cref="OpenApiString"/> class.
+        /// </summary>
+        /// <param name="value"></param>
         /// <param name="isExplicit">Used to indicate if a string is quoted.</param>
-        public OpenApiString(string value, bool isExplicit = false)
+        public OpenApiString(string value, bool isExplicit)
             : base(value)
         {
             this.isExplicit = isExplicit;


### PR DESCRIPTION
1.2.0 added an optional parameter on OpenApiString. This is a breaking change for indirect consumers resulting in a MissingMethodException.