### PR TITLE
Make default parameter overloads binary compatible

### DIFF
--- a/src/Microsoft.OpenApi/Extensions/OpenApiSerializableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiSerializableExtensions.cs
@@ -50,13 +50,32 @@ namespace Microsoft.OpenApi.Extensions
         /// <param name="stream">The given stream.</param>
         /// <param name="specVersion">The Open API specification version.</param>
         /// <param name="format">The output format (JSON or YAML).</param>
+        public static void Serialize<T>(
+            this T element,
+            Stream stream,
+            OpenApiSpecVersion specVersion,
+            OpenApiFormat format)
+            where T : IOpenApiSerializable
+        {
+            element.Serialize(stream, specVersion, format, null);
+        }
+
+        /// <summary>
+        /// Serializes the <see cref="IOpenApiSerializable"/> to the Open API document using
+        /// the given stream, specification version and the format.
+        /// </summary>
+        /// <typeparam name="T">the <see cref="IOpenApiSerializable"/></typeparam>
+        /// <param name="element">The Open API element.</param>
+        /// <param name="stream">The given stream.</param>
+        /// <param name="specVersion">The Open API specification version.</param>
+        /// <param name="format">The output format (JSON or YAML).</param>
         /// <param name="settings">Provide configuration settings for controlling writing output</param>
         public static void Serialize<T>(
             this T element,
             Stream stream,
             OpenApiSpecVersion specVersion,
             OpenApiFormat format, 
-            OpenApiWriterSettings settings = null)
+            OpenApiWriterSettings settings)
             where T : IOpenApiSerializable
         {
             if (stream == null)

--- a/src/Microsoft.OpenApi/Writers/OpenApiJsonWriter.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiJsonWriter.cs
@@ -14,8 +14,16 @@ namespace Microsoft.OpenApi.Writers
         /// Initializes a new instance of the <see cref="OpenApiJsonWriter"/> class.
         /// </summary>
         /// <param name="textWriter">The text writer.</param>
+        public OpenApiJsonWriter(TextWriter textWriter) : base(textWriter, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenApiJsonWriter"/> class.
+        /// </summary>
+        /// <param name="textWriter">The text writer.</param>
         /// <param name="settings">Settings for controlling how the OpenAPI document will be written out.</param>
-        public OpenApiJsonWriter(TextWriter textWriter, OpenApiWriterSettings settings = null) : base(textWriter, settings)
+        public OpenApiJsonWriter(TextWriter textWriter, OpenApiWriterSettings settings) : base(textWriter, settings)
         {
         }
 

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.OpenApi.Exceptions;
-using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Properties;
 
 namespace Microsoft.OpenApi.Writers

--- a/src/Microsoft.OpenApi/Writers/OpenApiYamlWriter.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiYamlWriter.cs
@@ -14,10 +14,17 @@ namespace Microsoft.OpenApi.Writers
         /// Initializes a new instance of the <see cref="OpenApiYamlWriter"/> class.
         /// </summary>
         /// <param name="textWriter">The text writer.</param>
-        /// <param name="settings"></param>
-        public OpenApiYamlWriter(TextWriter textWriter, OpenApiWriterSettings settings = null) : base(textWriter, settings)
+        public OpenApiYamlWriter(TextWriter textWriter) : this(textWriter, null)
         {
-           
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenApiYamlWriter"/> class.
+        /// </summary>
+        /// <param name="textWriter">The text writer.</param>
+        /// <param name="settings"></param>
+        public OpenApiYamlWriter(TextWriter textWriter, OpenApiWriterSettings settings) : base(textWriter, settings)
+        {
         }
 
         /// <summary>


### PR DESCRIPTION
This changes all overloads from https://github.com/microsoft/OpenAPI.NET/commit/f00c27cc0e104dd67ae26f85323950a7ae44e5d4 to be binary compatible for not having 1.2.0 break 1.1.4 upgrades