### PR TITLE
OpenAPI Workspace Document Fragments

### DIFF
--- a/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
@@ -45,7 +45,7 @@ namespace Microsoft.OpenApi.Readers
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
         /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing</param>
         /// <returns>Instance of newly created OpenApiDocument</returns>
-        public T ReadFragment<T>(Stream input, OpenApiSpecVersion version, out OpenApiDiagnostic diagnostic) where T : IOpenApiElement
+        public T ReadFragment<T>(Stream input, OpenApiSpecVersion version, out OpenApiDiagnostic diagnostic) where T : IOpenApiReferenceable
         {
             using (var reader = new StreamReader(input))
             {

--- a/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
@@ -30,6 +30,10 @@ namespace Microsoft.OpenApi.Extensions
                 return element;
             try
             {
+                if (element.GetType() == typeof(OpenApiHeader))
+                {
+                    return ResolveReferenceOnHeaderElement((OpenApiHeader)element, jsonPointer);
+                }
                 if (element.GetType() == typeof(OpenApiParameter))
                 {
                     return ResolveReferenceOnParameterElement((OpenApiParameter)element, jsonPointer);
@@ -40,6 +44,24 @@ namespace Microsoft.OpenApi.Extensions
                 throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
             }
             throw new NotImplementedException();
+        }
+
+        private static IOpenApiReferenceable ResolveReferenceOnHeaderElement(OpenApiHeader headerElement, string jsonPointer)
+        {
+            var jsonPointerTokens = jsonPointer.Split('/');
+            var propertyName = jsonPointerTokens.ElementAtOrDefault(1);
+            switch (propertyName)
+            {
+                case OpenApiConstants.Schema:
+                    return headerElement.Schema;
+                case OpenApiConstants.Examples:
+                    {
+                        var mapKey = jsonPointerTokens.ElementAtOrDefault(2);
+                        return headerElement.Examples[mapKey];
+                    }
+                default:
+                    throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
+            }
         }
 
         private static IOpenApiReferenceable ResolveReferenceOnParameterElement(OpenApiParameter parameterElement, string jsonPointer)

--- a/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
@@ -43,11 +43,15 @@ namespace Microsoft.OpenApi.Extensions
             {
                 throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
             }
-            throw new NotImplementedException();
+            throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
         }
 
         private static IOpenApiReferenceable ResolveReferenceOnHeaderElement(OpenApiHeader headerElement, string jsonPointer)
         {
+            if (string.IsNullOrEmpty(jsonPointer))
+            {
+                throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
+            }
             var jsonPointerTokens = jsonPointer.Split('/');
             var propertyName = jsonPointerTokens.ElementAtOrDefault(1);
             switch (propertyName)
@@ -56,6 +60,8 @@ namespace Microsoft.OpenApi.Extensions
                     return headerElement.Schema;
                 case OpenApiConstants.Examples:
                     {
+                        if (jsonPointerTokens.Length < 3)
+                            throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
                         var mapKey = jsonPointerTokens.ElementAtOrDefault(2);
                         return headerElement.Examples[mapKey];
                     }
@@ -66,6 +72,10 @@ namespace Microsoft.OpenApi.Extensions
 
         private static IOpenApiReferenceable ResolveReferenceOnParameterElement(OpenApiParameter parameterElement, string jsonPointer)
         {
+            if (string.IsNullOrEmpty(jsonPointer))
+            {
+                throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
+            }
             var jsonPointerTokens = jsonPointer.Split('/');
             var propertyName = jsonPointerTokens.ElementAtOrDefault(1);
             switch (propertyName)
@@ -74,6 +84,8 @@ namespace Microsoft.OpenApi.Extensions
                     return parameterElement.Schema;
                 case OpenApiConstants.Examples:
                     {
+                        if (jsonPointerTokens.Length < 3)
+                            throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
                         var mapKey = jsonPointerTokens.ElementAtOrDefault(2);
                         return parameterElement.Examples[mapKey];
                     }

--- a/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
@@ -23,7 +24,30 @@ namespace Microsoft.OpenApi.Extensions
         /// <returns>An IEnumerable of errors.  This function will never return null.</returns>
         public static IOpenApiReferenceable ResolveReference(this IOpenApiReferenceable element, string jsonPointer)
         {
-            return element;
+            if (jsonPointer == string.Empty)
+                return element;
+            if (element.GetType() == typeof(OpenApiParameter))
+            {
+                return ResolveReferenceOnParameterElement((OpenApiParameter)element, jsonPointer);
+            }
+            throw new NotImplementedException();
+        }
+
+        private static IOpenApiReferenceable ResolveReferenceOnParameterElement(OpenApiParameter parameterElement, string jsonPointer)
+        {
+            var jsonPointerTokens = jsonPointer.Split('/');
+            switch (jsonPointerTokens.First())
+            {
+                case OpenApiConstants.Schema:
+                    return parameterElement.Schema;
+                case OpenApiConstants.Examples:
+                    {
+                        var mapKey = jsonPointerTokens.ElementAt(1);
+                        return parameterElement.Examples[mapKey];
+                    }
+                default:
+                    throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OpenApi.Extensions
         /// <returns>An IEnumerable of errors.  This function will never return null.</returns>
         public static IOpenApiReferenceable ResolveReference(this IOpenApiReferenceable element, string jsonPointer)
         {
-            if (jsonPointer == string.Empty)
+            if (jsonPointer == "/")
                 return element;
             try
             {
@@ -45,16 +45,14 @@ namespace Microsoft.OpenApi.Extensions
         private static IOpenApiReferenceable ResolveReferenceOnParameterElement(OpenApiParameter parameterElement, string jsonPointer)
         {
             var jsonPointerTokens = jsonPointer.Split('/');
-            var propertyName = jsonPointerTokens.First();
+            var propertyName = jsonPointerTokens.ElementAtOrDefault(1);
             switch (propertyName)
             {
                 case OpenApiConstants.Schema:
                     return parameterElement.Schema;
                 case OpenApiConstants.Examples:
                     {
-                        var mapKey = jsonPointerTokens.ElementAtOrDefault(1);
-                        if (!(jsonPointerTokens.Length >= 2 && parameterElement.Examples.ContainsKey(mapKey)))
-                            throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
+                        var mapKey = jsonPointerTokens.ElementAtOrDefault(2);
                         return parameterElement.Examples[mapKey];
                     }
                 default:

--- a/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
@@ -38,6 +38,10 @@ namespace Microsoft.OpenApi.Extensions
                 {
                     return ResolveReferenceOnParameterElement((OpenApiParameter)element, jsonPointer);
                 }
+                if (element.GetType() == typeof(OpenApiResponse))
+                {
+                    return ResolveReferenceOnResponseElement((OpenApiResponse)element, jsonPointer);
+                }
             }
             catch (KeyNotFoundException)
             {
@@ -88,6 +92,35 @@ namespace Microsoft.OpenApi.Extensions
                             throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
                         var mapKey = jsonPointerTokens.ElementAtOrDefault(2);
                         return parameterElement.Examples[mapKey];
+                    }
+                default:
+                    throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
+            }
+        }
+
+        private static IOpenApiReferenceable ResolveReferenceOnResponseElement(OpenApiResponse responseElement, string jsonPointer)
+        {
+            if (string.IsNullOrEmpty(jsonPointer))
+            {
+                throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
+            }
+            var jsonPointerTokens = jsonPointer.Split('/');
+            var propertyName = jsonPointerTokens.ElementAtOrDefault(1);
+            switch (propertyName)
+            {
+                case OpenApiConstants.Headers:
+                    {
+                        if (jsonPointerTokens.Length < 3)
+                            throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
+                        var mapKey = jsonPointerTokens.ElementAtOrDefault(2);
+                        return responseElement.Headers[mapKey];
+                    }
+                case OpenApiConstants.Links:
+                    {
+                        if (jsonPointerTokens.Length < 3)
+                            throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
+                        var mapKey = jsonPointerTokens.ElementAtOrDefault(2);
+                        return responseElement.Links[mapKey];
                     }
                 default:
                     throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));

--- a/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.Extensions
         /// <returns>An IEnumerable of errors.  This function will never return null.</returns>
         public static IOpenApiReferenceable ResolveReference(this IOpenApiReferenceable element, string jsonPointer)
         {
-            throw new NotImplementedException();
+            return element;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
@@ -8,22 +8,20 @@ using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Properties;
-using Microsoft.OpenApi.Services;
-using Microsoft.OpenApi.Validations;
 
 namespace Microsoft.OpenApi.Extensions
 {
     /// <summary>
-    /// TODO: tmpDbg comment
+    /// Extension methods for resolving references on <see cref="IOpenApiReferenceable"/> elements.
     /// </summary>
     public static class OpenApiReferencableExtensions
     {
         /// <summary>
         /// TODO: tmpDbg comment
         /// </summary>
-        /// <param name="element">Element to validate</param>
-        /// <param name="ruleSet">Optional set of rules to use for validation</param>
-        /// <returns>An IEnumerable of errors.  This function will never return null.</returns>
+        /// <param name="element">The referencable Open API element on which to apply the JSON pointer</param>
+        /// <param name="jsonPointer">a JSON Pointer [RFC 6901](https://tools.ietf.org/html/rfc6901).</param>
+        /// <returns>The element pointed to by the JSON pointer.</returns>
         public static IOpenApiReferenceable ResolveReference(this IOpenApiReferenceable element, string jsonPointer)
         {
             if (jsonPointer == "/")

--- a/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System;
+using System.Collections.Generic;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Services;
+using Microsoft.OpenApi.Validations;
+
+namespace Microsoft.OpenApi.Extensions
+{
+    /// <summary>
+    /// TODO: tmpDbg comment
+    /// </summary>
+    public static class OpenApiReferencableExtensions
+    {
+        /// <summary>
+        /// TODO: tmpDbg comment
+        /// </summary>
+        /// <param name="element">Element to validate</param>
+        /// <param name="ruleSet">Optional set of rules to use for validation</param>
+        /// <returns>An IEnumerable of errors.  This function will never return null.</returns>
+        public static IOpenApiReferenceable ResolveReference(this IOpenApiReferenceable element, string jsonPointer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiReferencableExtensions.cs
@@ -16,51 +16,46 @@ namespace Microsoft.OpenApi.Extensions
     public static class OpenApiReferencableExtensions
     {
         /// <summary>
-        /// TODO: tmpDbg comment
+        /// Resolves a JSON Pointer with respect to an element, returning the referenced element.
         /// </summary>
         /// <param name="element">The referencable Open API element on which to apply the JSON pointer</param>
-        /// <param name="jsonPointer">a JSON Pointer [RFC 6901](https://tools.ietf.org/html/rfc6901).</param>
+        /// <param name="pointer">a JSON Pointer [RFC 6901](https://tools.ietf.org/html/rfc6901).</param>
         /// <returns>The element pointed to by the JSON pointer.</returns>
-        public static IOpenApiReferenceable ResolveReference(this IOpenApiReferenceable element, string jsonPointer)
+        public static IOpenApiReferenceable ResolveReference(this IOpenApiReferenceable element, JsonPointer pointer)
         {
-            if (jsonPointer == "/")
+            if (!pointer.Tokens.Any())
             {
                 return element;
             }
-            if (string.IsNullOrEmpty(jsonPointer))
-            {
-                throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
-            }
-            var jsonPointerTokens = jsonPointer.Split('/');
-            var propertyName = jsonPointerTokens.ElementAtOrDefault(1);
-            var mapKey = jsonPointerTokens.ElementAtOrDefault(2);
+            var propertyName = pointer.Tokens.FirstOrDefault();
+            var mapKey = pointer.Tokens.ElementAtOrDefault(1);
             try
             {
                 if (element.GetType() == typeof(OpenApiHeader))
                 {
-                    return ResolveReferenceOnHeaderElement((OpenApiHeader)element, propertyName, mapKey, jsonPointer);
+                    return ResolveReferenceOnHeaderElement((OpenApiHeader)element, propertyName, mapKey, pointer);
                 }
                 if (element.GetType() == typeof(OpenApiParameter))
                 {
-                    return ResolveReferenceOnParameterElement((OpenApiParameter)element, propertyName, mapKey, jsonPointer);
+                    return ResolveReferenceOnParameterElement((OpenApiParameter)element, propertyName, mapKey, pointer);
                 }
                 if (element.GetType() == typeof(OpenApiResponse))
                 {
-                    return ResolveReferenceOnResponseElement((OpenApiResponse)element, propertyName, mapKey, jsonPointer);
+                    return ResolveReferenceOnResponseElement((OpenApiResponse)element, propertyName, mapKey, pointer);
                 }
             }
             catch (KeyNotFoundException)
             {
-                throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
+                throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, pointer));
             }
-            throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
+            throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, pointer));
         }
 
         private static IOpenApiReferenceable ResolveReferenceOnHeaderElement(
             OpenApiHeader headerElement,
             string propertyName,
             string mapKey,
-            string jsonPointer)
+            JsonPointer pointer)
         {
             switch (propertyName)
             {
@@ -69,7 +64,7 @@ namespace Microsoft.OpenApi.Extensions
                 case OpenApiConstants.Examples when mapKey != null:
                     return headerElement.Examples[mapKey];
                 default:
-                    throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
+                    throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, pointer));
             }
         }
 
@@ -77,7 +72,7 @@ namespace Microsoft.OpenApi.Extensions
             OpenApiParameter parameterElement,
             string propertyName,
             string mapKey,
-            string jsonPointer)
+            JsonPointer pointer)
         {
             switch (propertyName)
             {
@@ -86,7 +81,7 @@ namespace Microsoft.OpenApi.Extensions
                 case OpenApiConstants.Examples when mapKey != null:
                     return parameterElement.Examples[mapKey];
                 default:
-                    throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
+                    throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, pointer));
             }
         }
 
@@ -94,7 +89,7 @@ namespace Microsoft.OpenApi.Extensions
             OpenApiResponse responseElement,
             string propertyName,
             string mapKey,
-            string jsonPointer)
+            JsonPointer pointer)
         {
             switch (propertyName)
             {
@@ -103,7 +98,7 @@ namespace Microsoft.OpenApi.Extensions
                 case OpenApiConstants.Links when mapKey != null:
                     return responseElement.Links[mapKey];
                 default:
-                    throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, jsonPointer));
+                    throw new OpenApiException(string.Format(SRResource.InvalidReferenceId, pointer));
             }
         }
     }

--- a/src/Microsoft.OpenApi/JsonPointer.cs
+++ b/src/Microsoft.OpenApi/JsonPointer.cs
@@ -17,7 +17,9 @@ namespace Microsoft.OpenApi
         /// <param name="pointer">Pointer as string.</param>
         public JsonPointer(string pointer)
         {
-            Tokens = pointer.Split('/').Skip(1).Select(Decode).ToArray();
+            Tokens = string.IsNullOrEmpty(pointer) || pointer == "/"
+                ? new string[0]
+                : pointer.Split('/').Skip(1).Select(Decode).ToArray();
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Services/OpenApiWorkspace.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWorkspace.cs
@@ -121,7 +121,7 @@ namespace Microsoft.OpenApi.Services
             }
             else if (_fragments.TryGetValue(new Uri(BaseUrl, reference.ExternalResource), out var fragment))
             {
-                var jsonPointer = $"/{reference.Id ?? string.Empty}";
+                var jsonPointer = new JsonPointer($"/{reference.Id ?? string.Empty}");
                 return fragment.ResolveReference(jsonPointer);
             }
             return null;

--- a/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.OpenApi.Tests.Workspaces
             new object[] { _responseFragment, "/links/link1", _responseFragment.Links["link1"] },
             new object[] { _schemaFragment, "/", _schemaFragment},
             new object[] { _securitySchemeFragment, "/", _securitySchemeFragment},
-            new object[] { _tagFragment, "/", _tagFragment},
+            new object[] { _tagFragment, "/", _tagFragment}
         };
 
         [Theory]
@@ -79,7 +79,7 @@ namespace Microsoft.OpenApi.Tests.Workspaces
             IOpenApiElement expectedResolvedElement)
         {
             // Act
-            var actualResolvedElement = element.ResolveReference(jsonPointer);
+            var actualResolvedElement = element.ResolveReference(new JsonPointer(jsonPointer));
 
             // Assert
             Assert.Same(expectedResolvedElement, actualResolvedElement);
@@ -88,30 +88,22 @@ namespace Microsoft.OpenApi.Tests.Workspaces
         public static IEnumerable<object[]> ResolveReferenceShouldThrowOnInvalidReferenceIdTestData =>
         new List<object[]>
         {
-            new object[] { _callbackFragment, null },
-            new object[] { _callbackFragment, "" },
             new object[] { _callbackFragment, "/a" },
-            new object[] { _headerFragment, null },
-            new object[] { _headerFragment, "" },
             new object[] { _headerFragment, "/a" },
             new object[] { _headerFragment, "/examples" },
             new object[] { _headerFragment, "/examples/" },
             new object[] { _headerFragment, "/examples/a" },
-            new object[] { _parameterFragment, null },
-            new object[] { _parameterFragment, "" },
             new object[] { _parameterFragment, "/a" },
             new object[] { _parameterFragment, "/examples" },
             new object[] { _parameterFragment, "/examples/" },
             new object[] { _parameterFragment, "/examples/a" },
-            new object[] { _responseFragment, null },
-            new object[] { _responseFragment, "" },
             new object[] { _responseFragment, "/a" },
             new object[] { _responseFragment, "/headers" },
             new object[] { _responseFragment, "/headers/" },
             new object[] { _responseFragment, "/headers/a" },
             new object[] { _responseFragment, "/content" },
             new object[] { _responseFragment, "/content/" },
-            new object[] { _responseFragment, "/content/a" },
+            new object[] { _responseFragment, "/content/a" }
 
         };
 
@@ -120,7 +112,7 @@ namespace Microsoft.OpenApi.Tests.Workspaces
         public void ResolveReferenceShouldThrowOnInvalidReferenceId(IOpenApiReferenceable element, string jsonPointer)
         {
             // Act
-            Action resolveReference = () => element.ResolveReference(jsonPointer);
+            Action resolveReference = () => element.ResolveReference(new JsonPointer(jsonPointer));
 
             // Assert
             var exception = Assert.Throws<OpenApiException>(resolveReference);

--- a/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using System.Collections.Generic;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Workspaces
+{
+
+    public class OpenApiReferencableTests
+    {
+        public static IEnumerable<object[]> ReferencableElementResolvesEmptyJsonPointerToItselfTestData =>
+        new List<object[]>
+        {
+            new object[] { new OpenApiCallback() },
+            new object[] { new OpenApiExample() },
+            new object[] { new OpenApiHeader() },
+            new object[] { new OpenApiLink() },
+            new object[] { new OpenApiParameter() },
+            new object[] { new OpenApiRequestBody() },
+            new object[] { new OpenApiResponse() },
+            new object[] { new OpenApiSchema() },
+            new object[] { new OpenApiSecurityScheme() },
+            new object[] { new OpenApiTag() }
+
+        };
+
+        [Theory]
+        [MemberData(nameof(ReferencableElementResolvesEmptyJsonPointerToItselfTestData))]
+        public void ReferencableElementResolvesEmptyJsonPointerToItself(IOpenApiReferenceable referencableElement)
+        {
+            // Arrange - above
+
+            // Act
+            var resolvedReference = referencableElement.ResolveReference(string.Empty);
+
+            // Assert
+            Assert.Same(referencableElement, resolvedReference);
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
+using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Properties;
 using Xunit;
 
 namespace Microsoft.OpenApi.Tests.Workspaces
@@ -74,6 +77,37 @@ namespace Microsoft.OpenApi.Tests.Workspaces
 
             // Assert
             Assert.Same(parameterElement.Examples["example1"], resolvedReference);
+        }
+
+        public static IEnumerable<object[]> ParameterElementShouldThrowOnInvalidReferenceIdTestData =>
+        new List<object[]>
+        {
+            new object[] { "/" },
+            new object[] { "a" },
+            new object[] { "examples" },
+            new object[] { "examples/a" },
+
+        };
+
+        [Theory]
+        [MemberData(nameof(ParameterElementShouldThrowOnInvalidReferenceIdTestData))]
+        public void ParameterElementShouldThrowOnInvalidReferenceId(string jsonPointer)
+        {
+            // Arrange
+            var parameterElement = new OpenApiParameter
+            {
+                Examples = new Dictionary<string, OpenApiExample>()
+            {
+                { "example1", new OpenApiExample() }
+            },
+            };
+
+            // Act
+            Action resolveReference = () => parameterElement.ResolveReference(jsonPointer);
+
+            // Assert
+            var exception = Assert.Throws<OpenApiException>(resolveReference);
+            Assert.Equal(String.Format(SRResource.InvalidReferenceId, jsonPointer), exception.Message);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
@@ -40,5 +40,40 @@ namespace Microsoft.OpenApi.Tests.Workspaces
             // Assert
             Assert.Same(referencableElement, resolvedReference);
         }
+
+        [Fact]
+        public void ParameterElementCanResolveReferenceToSchemaProperty()
+        {
+            // Arrange
+            var parameterElement = new OpenApiParameter
+            {
+                Schema = new OpenApiSchema()
+            };
+
+            // Act
+            var resolvedReference = parameterElement.ResolveReference("schema");
+
+            // Assert
+            Assert.Same(parameterElement.Schema, resolvedReference);
+        }
+
+        [Fact]
+        public void ParameterElementCanResolveReferenceToExampleTmpDbgImproveMyName()
+        {
+            // Arrange
+            var parameterElement = new OpenApiParameter
+            {
+                Examples = new Dictionary<string, OpenApiExample>()
+            {
+                { "example1", new OpenApiExample() }
+            },
+            };
+
+            // Act
+            var resolvedReference = parameterElement.ResolveReference("examples/example1");
+
+            // Assert
+            Assert.Same(parameterElement.Examples["example1"], resolvedReference);
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.OpenApi.Tests.Workspaces
         private static readonly OpenApiSecurityScheme _securitySchemeFragment = new OpenApiSecurityScheme();
         private static readonly OpenApiTag _tagFragment = new OpenApiTag();
 
-        public static IEnumerable<object[]> ReferencableElementsCanResolveReferencesTestData =>
+        public static IEnumerable<object[]> ResolveReferenceCanResolveValidJsonPointersTestData =>
         new List<object[]>
         {
             new object[] { _callbackFragment, "/", _callbackFragment },
@@ -60,36 +60,46 @@ namespace Microsoft.OpenApi.Tests.Workspaces
         };
 
         [Theory]
-        [MemberData(nameof(ReferencableElementsCanResolveReferencesTestData))]
-        public void ReferencableElementsCanResolveReferences(
+        [MemberData(nameof(ResolveReferenceCanResolveValidJsonPointersTestData))]
+        public void ResolveReferenceCanResolveValidJsonPointers(
             IOpenApiReferenceable element,
-            string pointer,
+            string jsonPointer,
             IOpenApiElement expectedResolvedElement)
         {
             // Act
-            var actualResolvedElement = element.ResolveReference(pointer);
+            var actualResolvedElement = element.ResolveReference(jsonPointer);
 
             // Assert
             Assert.Same(expectedResolvedElement, actualResolvedElement);
         }
 
-        public static IEnumerable<object[]> ParameterElementShouldThrowOnInvalidReferenceIdTestData =>
+        public static IEnumerable<object[]> ResolveReferenceShouldThrowOnInvalidReferenceIdTestData =>
         new List<object[]>
         {
-            new object[] { "" },
-            new object[] { "a" },
-            new object[] { "examples" },
-            new object[] { "examples/" },
-            new object[] { "examples/a" },
+            new object[] { _callbackFragment, null },
+            new object[] { _callbackFragment, "" },
+            new object[] { _callbackFragment, "/a" },
+            new object[] { _headerFragment, null },
+            new object[] { _headerFragment, "" },
+            new object[] { _headerFragment, "/a" },
+            new object[] { _headerFragment, "/examples" },
+            new object[] { _headerFragment, "/examples/" },
+            new object[] { _headerFragment, "/examples/a" },
+            new object[] { _parameterFragment, null },
+            new object[] { _parameterFragment, "" },
+            new object[] { _parameterFragment, "/a" },
+            new object[] { _parameterFragment, "/examples" },
+            new object[] { _parameterFragment, "/examples/" },
+            new object[] { _parameterFragment, "/examples/a" }
 
         };
 
         [Theory]
-        [MemberData(nameof(ParameterElementShouldThrowOnInvalidReferenceIdTestData))]
-        public void ParameterElementShouldThrowOnInvalidReferenceId(string jsonPointer)
+        [MemberData(nameof(ResolveReferenceShouldThrowOnInvalidReferenceIdTestData))]
+        public void ResolveReferenceShouldThrowOnInvalidReferenceId(IOpenApiReferenceable element, string jsonPointer)
         {
             // Act
-            Action resolveReference = () => _parameterFragment.ResolveReference(jsonPointer);
+            Action resolveReference = () => element.ResolveReference(jsonPointer);
 
             // Assert
             var exception = Assert.Throws<OpenApiException>(resolveReference);

--- a/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
@@ -18,7 +18,14 @@ namespace Microsoft.OpenApi.Tests.Workspaces
         private static readonly OpenApiCallback _callbackFragment = new OpenApiCallback();
         private static readonly OpenApiExample _exampleFragment = new OpenApiExample();
         private static readonly OpenApiLink _linkFragment = new OpenApiLink();
-        private static readonly OpenApiHeader _headerFragment = new OpenApiHeader();
+        private static readonly OpenApiHeader _headerFragment = new OpenApiHeader()
+        {
+            Schema = new OpenApiSchema(),
+            Examples = new Dictionary<string, OpenApiExample>
+            {
+                { "example1", new OpenApiExample() }
+            }
+        };
         private static readonly OpenApiParameter _parameterFragment = new OpenApiParameter
         {
             Schema = new OpenApiSchema(),
@@ -40,6 +47,8 @@ namespace Microsoft.OpenApi.Tests.Workspaces
             new object[] { _exampleFragment, "/", _exampleFragment },
             new object[] { _linkFragment, "/", _linkFragment },
             new object[] { _headerFragment, "/", _headerFragment },
+            new object[] { _headerFragment, "/schema", _headerFragment.Schema },
+            new object[] { _headerFragment, "/examples/example1", _headerFragment.Examples["example1"] },
             new object[] { _parameterFragment, "/", _parameterFragment },
             new object[] { _parameterFragment, "/schema", _parameterFragment.Schema },
             new object[] { _parameterFragment, "/examples/example1", _parameterFragment.Examples["example1"] },

--- a/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
@@ -35,7 +35,17 @@ namespace Microsoft.OpenApi.Tests.Workspaces
             }
         };
         private static readonly OpenApiRequestBody _requestBodyFragment = new OpenApiRequestBody();
-        private static readonly OpenApiResponse _responseFragment = new OpenApiResponse();
+        private static readonly OpenApiResponse _responseFragment = new OpenApiResponse()
+        {
+            Headers = new Dictionary<string, OpenApiHeader>
+            {
+                { "header1", new OpenApiHeader() }
+            },
+            Links = new Dictionary<string, OpenApiLink>
+            {
+                { "link1", new OpenApiLink() }
+            }
+        };
         private static readonly OpenApiSchema _schemaFragment = new OpenApiSchema();
         private static readonly OpenApiSecurityScheme _securitySchemeFragment = new OpenApiSecurityScheme();
         private static readonly OpenApiTag _tagFragment = new OpenApiTag();
@@ -54,6 +64,8 @@ namespace Microsoft.OpenApi.Tests.Workspaces
             new object[] { _parameterFragment, "/examples/example1", _parameterFragment.Examples["example1"] },
             new object[] { _requestBodyFragment, "/", _requestBodyFragment },
             new object[] { _responseFragment, "/", _responseFragment },
+            new object[] { _responseFragment, "/headers/header1", _responseFragment.Headers["header1"] },
+            new object[] { _responseFragment, "/links/link1", _responseFragment.Links["link1"] },
             new object[] { _schemaFragment, "/", _schemaFragment},
             new object[] { _securitySchemeFragment, "/", _securitySchemeFragment},
             new object[] { _tagFragment, "/", _tagFragment},
@@ -90,7 +102,16 @@ namespace Microsoft.OpenApi.Tests.Workspaces
             new object[] { _parameterFragment, "/a" },
             new object[] { _parameterFragment, "/examples" },
             new object[] { _parameterFragment, "/examples/" },
-            new object[] { _parameterFragment, "/examples/a" }
+            new object[] { _parameterFragment, "/examples/a" },
+            new object[] { _responseFragment, null },
+            new object[] { _responseFragment, "" },
+            new object[] { _responseFragment, "/a" },
+            new object[] { _responseFragment, "/headers" },
+            new object[] { _responseFragment, "/headers/" },
+            new object[] { _responseFragment, "/headers/a" },
+            new object[] { _responseFragment, "/content" },
+            new object[] { _responseFragment, "/content/" },
+            new object[] { _responseFragment, "/content/a" },
 
         };
 

--- a/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiWorkspaceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiWorkspaceTests.cs
@@ -155,6 +155,50 @@ namespace Microsoft.OpenApi.Tests
             Assert.True(false);
         }
 
+        [Fact]
+        public void OpenApiWorkspacesCanResolveReferencesToDocumentFragments()
+        {
+            // Arrange
+            var workspace = new OpenApiWorkspace();
+            var schemaFragment = new OpenApiSchema { Type = "string", Description = "Schema from a fragment" };
+            workspace.AddFragment("fragment", schemaFragment);
+
+            // Act
+            var schema = workspace.ResolveReference(new OpenApiReference()
+            {
+                ExternalResource = "fragment"
+            }) as OpenApiSchema;
+
+            // Assert
+            Assert.NotNull(schema);
+            Assert.Equal("Schema from a fragment", schema.Description);
+        }
+
+        [Fact]
+        public void OpenApiWorkspacesCanResolveReferencesToDocumentFragmentsWithJsonPointers()
+        {
+            // Arrange
+            var workspace = new OpenApiWorkspace();
+            var responseFragment = new OpenApiResponse()
+            {
+                Headers = new Dictionary<string, OpenApiHeader>
+                {
+                    { "header1", new OpenApiHeader() }
+                }
+            };
+            workspace.AddFragment("fragment", responseFragment);
+
+            // Act
+            var resolvedElement = workspace.ResolveReference(new OpenApiReference()
+            {
+                Id = "headers/header1",
+                ExternalResource = "fragment"
+            });
+
+            // Assert
+            Assert.Same(responseFragment.Headers["header1"], resolvedElement);
+        }
+
 
         // Test artifacts
 


### PR DESCRIPTION
- Add `IOpenApiReferenceable ResolveReference(JsonPointer pointer, JsonPointer pointerFromRoot = null);` method to `IOpenApiElement` interface.
- Add `OpenApiElementBase` class which containing an implementation of the `ResolveReference` method used by many of the classes which implement `IOpenApiElement`.
- Update implementation of `OpenApiWorkspace.ResolveReference` method to support referencing document fragments.
- UTs covering the above. 