### PR TITLE
Allow OpenApiString's raw value to be written by the OpenApiWriter

### DIFF
--- a/src/Microsoft.OpenApi/Any/OpenApiPrimitive.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiPrimitive.cs
@@ -70,7 +70,10 @@ namespace Microsoft.OpenApi.Any
 
                 case PrimitiveType.String:
                     var stringValue = (OpenApiString)(IOpenApiPrimitive)this;
-                    writer.WriteValue(stringValue.Value);
+                    if (stringValue.IsRawString())
+                        writer.WriteRaw(stringValue.Value);
+                    else
+                        writer.WriteValue(stringValue.Value);
                     break;
 
                 case PrimitiveType.Byte:

--- a/src/Microsoft.OpenApi/Any/OpenApiString.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiString.cs
@@ -9,6 +9,7 @@ namespace Microsoft.OpenApi.Any
     public class OpenApiString : OpenApiPrimitive<string>
     {
         private bool isExplicit;
+        private bool isRawString;
 
         /// <summary>
         /// Initializes the <see cref="OpenApiString"/> class.
@@ -31,6 +32,19 @@ namespace Microsoft.OpenApi.Any
         }
 
         /// <summary>
+        /// Initializes the <see cref="OpenApiString"/> class.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="isExplicit">Used to indicate if a string is quoted.</param>
+        /// <param name="isRawString">Used to indicate to the writer that the value should be written without encoding.</param>
+        public OpenApiString(string value, bool isExplicit, bool isRawString)
+            : base(value)
+        {
+            this.isExplicit = isExplicit;
+            this.isRawString = isRawString;
+        }
+
+        /// <summary>
         /// The primitive class this object represents.
         /// </summary>
         public override PrimitiveType PrimitiveType { get; } = PrimitiveType.String;
@@ -41,6 +55,14 @@ namespace Microsoft.OpenApi.Any
         public bool IsExplicit()
         {
             return this.isExplicit;
+        }
+
+        /// <summary>
+        /// True if the writer should process the value as supplied without encoding.
+        /// </summary>
+        public bool IsRawString()
+        {
+            return this.isRawString;
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -99,8 +99,10 @@ namespace Microsoft.OpenApi.Any
     {
         public OpenApiString(string value) { }
         public OpenApiString(string value, bool isExplicit) { }
+        public OpenApiString(string value, bool isExplicit, bool isRawString) { }
         public override Microsoft.OpenApi.Any.PrimitiveType PrimitiveType { get; }
         public bool IsExplicit() { }
+        public bool IsRawString() { }
     }
     public enum PrimitiveType
     {


### PR DESCRIPTION
#527 
Added parameter to OpenApiString that allows its value to be written raw without any encoding by the selected writer.
Modified the base OpenApiPrimitive string case to support the new OpenApiString.IsRawString() and select the correct writer.Write function.