### PR TITLE
Support for scientific notation in parsing of "multipleOf" FixedFieldMap.

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "multipleOf", (o, n) =>
                 {
-                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
+                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
                 }
             },
             {

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "multipleOf", (o, n) =>
                 {
-                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
+                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture); 
                 }
             },
             {


### PR DESCRIPTION
I stumbled upon this issue while trying to parse OpenAPI docs from SAP. Within their docs they use scientific notation to describe percentages (ex. discounts). When trying to parse those docs a System.FormatException would be thrown due to the scientific notation. If I manually convert those values to their decimal equivalents (ex. 1.0e-3 == 0.003) everything works fine.

After researching this a bit I found that including the NumberStyles.Float flag in the call to Decimal.Parse() would address the issue without changing the handling of whole number input (ex. 1). This essentially tacks on the AllowExponent flag.