### PR TITLE
Further exponential notation fix.

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
@@ -26,13 +26,13 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "multipleOf", (o, n) =>
                 {
-                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
+                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
                 }
             },
             {
                 "maximum", (o, n) =>
                 {
-                    o.Maximum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
+                    o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -44,7 +44,7 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "minimum", (o, n) =>
                 {
-                    o.Minimum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
+                    o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
                 }
             },
             {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
@@ -26,13 +26,13 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "multipleOf", (o, n) =>
                 {
-                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
+                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Any, CultureInfo.InvariantCulture);
                 }
             },
             {
                 "maximum", (o, n) =>
                 {
-                    o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
+                    o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Any, CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -44,7 +44,7 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "minimum", (o, n) =>
                 {
-                    o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
+                    o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Any, CultureInfo.InvariantCulture);
                 }
             },
             {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
@@ -26,13 +26,13 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "multipleOf", (o, n) =>
                 {
-                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Any, CultureInfo.InvariantCulture);
+                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
                 }
             },
             {
                 "maximum", (o, n) =>
                 {
-                    o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Any, CultureInfo.InvariantCulture);
+                    o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -44,7 +44,7 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 "minimum", (o, n) =>
                 {
-                    o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Any, CultureInfo.InvariantCulture);
+                    o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
                 }
             },
             {

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "maximum", (o, n) =>
                 {
-                    o.Maximum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
+                    o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -45,7 +45,7 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "minimum", (o, n) =>
                 {
-                    o.Minimum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
+                    o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
                 }
             },
             {

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -27,13 +27,13 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "multipleOf", (o, n) =>
                 {
-                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture); 
+                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Any, CultureInfo.InvariantCulture); 
                 }
             },
             {
                 "maximum", (o, n) =>
                 {
-                    o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
+                    o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Any, CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -45,7 +45,7 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "minimum", (o, n) =>
                 {
-                    o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
+                    o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Any, CultureInfo.InvariantCulture);
                 }
             },
             {

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -27,13 +27,13 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "multipleOf", (o, n) =>
                 {
-                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Any, CultureInfo.InvariantCulture); 
+                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture); 
                 }
             },
             {
                 "maximum", (o, n) =>
                 {
-                    o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Any, CultureInfo.InvariantCulture);
+                    o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
                 }
             },
             {
@@ -45,7 +45,7 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "minimum", (o, n) =>
                 {
-                    o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Any, CultureInfo.InvariantCulture);
+                    o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
                 }
             },
             {

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
@@ -96,7 +96,7 @@ definitions:
       sampleProperty:
         type: double
         minimum: 100.54
-        maximum: 60,000,000.35
+        maximum: 60000000.35
         exclusiveMaximum: true
         exclusiveMinimum: false
 paths: {}",

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -82,7 +82,7 @@ components:
         sampleProperty:
           type: double
           minimum: 100.54
-          maximum: 60,000,000.35
+          maximum: 60000000.35
           exclusiveMaximum: true
           exclusiveMinimum: false
 paths: {}",


### PR DESCRIPTION
I neglected to apply the NumberStyles.Float fix for supporting exponential notation to the V2 SchemaDeserializer. I also added it to the handling of Maximum and Minimum properties in both V2 and V3 SchemaDeserializer's as hey both leverage decimal.Parse().