### PR TITLE
Fixes issues with the pointer in the OpenApiError object

### DIFF
--- a/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiReaderException.cs
+++ b/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiReaderException.cs
@@ -51,5 +51,6 @@ namespace Microsoft.OpenApi.Readers.Exceptions
         /// <param name="message">Plain text error message for this exception.</param>
         /// <param name="innerException">Inner exception that caused this exception to be thrown.</param>
         public OpenApiReaderException(string message, Exception innerException) : base(message, innerException) { }
+
     }
 }

--- a/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiReaderException.cs
+++ b/src/Microsoft.OpenApi.Readers/Exceptions/OpenApiReaderException.cs
@@ -25,6 +25,15 @@ namespace Microsoft.OpenApi.Readers.Exceptions
         public OpenApiReaderException(string message) : base(message) { }
 
         /// <summary>
+        /// Initializes the <see cref="OpenApiReaderException"/> class with a custom message.
+        /// </summary>
+        /// <param name="message">Plain text error message for this exception.</param>
+        /// <param name="context">Context of current parsing process.</param>
+        public OpenApiReaderException(string message, ParsingContext context) : base(message) {
+            Pointer = context.GetLocation();
+        }
+
+        /// <summary>
         /// Initializes the <see cref="OpenApiReaderException"/> class with a message and line, column location of error.
         /// </summary>
         /// <param name="message">Plain text error message for this exception.</param>

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/ListNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/ListNode.cs
@@ -9,6 +9,7 @@ using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.Exceptions;
 using SharpYaml.Serialization;
 
 namespace Microsoft.OpenApi.Readers.ParseNodes
@@ -27,8 +28,8 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
         {
             if (_nodeList == null)
             {
-                throw new OpenApiException(
-                    $"Expected list at line {_nodeList.Start.Line} while parsing {typeof(T).Name}");
+                throw new OpenApiReaderException(
+                    $"Expected list at line {_nodeList.Start.Line} while parsing {typeof(T).Name}", _nodeList);
             }
 
             return _nodeList.Select(n => map(new MapNode(Context, n as YamlMappingNode)))
@@ -47,8 +48,8 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
         {
             if (_nodeList == null)
             {
-                throw new OpenApiException(
-                    $"Expected list at line {_nodeList.Start.Line} while parsing {typeof(T).Name}");
+                throw new OpenApiReaderException(
+                    $"Expected list at line {_nodeList.Start.Line} while parsing {typeof(T).Name}", _nodeList);
             }
 
             return _nodeList.Select(n => map(new ValueNode(Context, n))).ToList();

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/ListNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/ListNode.cs
@@ -6,9 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Exceptions;
-using Microsoft.OpenApi.Interfaces;
-using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.Exceptions;
 using SharpYaml.Serialization;
 

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/MapNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/MapNode.cs
@@ -63,7 +63,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             var yamlMap = _node;
             if (yamlMap == null)
             {
-                throw new OpenApiException($"Expected map at line {yamlMap.Start.Line} while parsing {typeof(T).Name}");
+                throw new OpenApiReaderException($"Expected map at line {yamlMap.Start.Line} while parsing {typeof(T).Name}", yamlMap);
             }
 
             var nodes = yamlMap.Select(
@@ -99,7 +99,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             var yamlMap = _node;
             if (yamlMap == null)
             {
-                throw new OpenApiException($"Expected map at line {yamlMap.Start.Line} while parsing {typeof(T).Name}");
+                throw new OpenApiReaderException($"Expected map at line {yamlMap.Start.Line} while parsing {typeof(T).Name}", yamlMap);
             }
 
             var nodes = yamlMap.Select(
@@ -134,7 +134,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             var yamlMap = _node;
             if (yamlMap == null)
             {
-                throw new OpenApiException($"Expected map at line {yamlMap.Start.Line} while parsing {typeof(T).Name}");
+                throw new OpenApiReaderException($"Expected map at line {yamlMap.Start.Line} while parsing {typeof(T).Name}", yamlMap);
             }
 
             var nodes = yamlMap.Select(
@@ -189,7 +189,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             var scalarNode = _node.Children[new YamlScalarNode(key.GetScalarValue())] as YamlScalarNode;
             if (scalarNode == null)
             {
-                throw new OpenApiException($"Expected scalar at line {_node.Start.Line} for key {key.GetScalarValue()}");
+                throw new OpenApiReaderException($"Expected scalar at line {_node.Start.Line} for key {key.GetScalarValue()}", _node);
             }
 
             return scalarNode.Value;

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/MapNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/MapNode.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.Exceptions;
@@ -33,7 +32,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
         {
             if (!(node is YamlMappingNode mapNode))
             {
-                throw new OpenApiReaderException("Expected map.", node);
+                throw new OpenApiReaderException("Expected map.", Context);
             }
 
             this._node = mapNode;
@@ -48,10 +47,10 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
         {
             get
             {
-                YamlNode node = null;
+                YamlNode node;
                 if (this._node.Children.TryGetValue(new YamlScalarNode(key), out node))
                 {
-                    return new PropertyNode(Context, key, this._node.Children[new YamlScalarNode(key)]);
+                    return new PropertyNode(Context, key, node);
                 }
 
                 return null;
@@ -63,7 +62,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             var yamlMap = _node;
             if (yamlMap == null)
             {
-                throw new OpenApiReaderException($"Expected map at line {yamlMap.Start.Line} while parsing {typeof(T).Name}", yamlMap);
+                throw new OpenApiReaderException($"Expected map while parsing {typeof(T).Name}", Context);
             }
 
             var nodes = yamlMap.Select(
@@ -99,7 +98,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             var yamlMap = _node;
             if (yamlMap == null)
             {
-                throw new OpenApiReaderException($"Expected map at line {yamlMap.Start.Line} while parsing {typeof(T).Name}", yamlMap);
+                throw new OpenApiReaderException($"Expected map while parsing {typeof(T).Name}", Context);
             }
 
             var nodes = yamlMap.Select(
@@ -133,8 +132,8 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
         {
             var yamlMap = _node;
             if (yamlMap == null)
-            {
-                throw new OpenApiReaderException($"Expected map at line {yamlMap.Start.Line} while parsing {typeof(T).Name}", yamlMap);
+            { 
+                throw new OpenApiReaderException($"Expected map while parsing {typeof(T).Name}", Context);
             }
 
             var nodes = yamlMap.Select(
@@ -189,7 +188,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             var scalarNode = _node.Children[new YamlScalarNode(key.GetScalarValue())] as YamlScalarNode;
             if (scalarNode == null)
             {
-                throw new OpenApiReaderException($"Expected scalar at line {_node.Start.Line} for key {key.GetScalarValue()}", _node);
+                throw new OpenApiReaderException($"Expected scalar at line {_node.Start.Line} for key {key.GetScalarValue()}", Context);
             }
 
             return scalarNode.Value;

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/MapNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/MapNode.cs
@@ -67,12 +67,26 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             }
 
             var nodes = yamlMap.Select(
-                n => new
-                {
-                    key = n.Key.GetScalarValue(),
-                    value = n.Value as YamlMappingNode == null
-                        ? default(T)
-                        : map(new MapNode(Context, n.Value as YamlMappingNode))
+                n => {
+                    
+                    var key = n.Key.GetScalarValue();
+                    T value;
+                    try
+                    {
+                        Context.StartObject(key);
+                        value = n.Value as YamlMappingNode == null
+                          ? default(T)
+                          : map(new MapNode(Context, n.Value as YamlMappingNode));
+                    } 
+                    finally
+                    {
+                        Context.EndObject();
+                    }
+                    return new
+                    {
+                        key = key,
+                        value = value
+                    };
                 });
 
             return nodes.ToDictionary(k => k.key, v => v.value);

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/ParseNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/ParseNode.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
         {
             if (!(this is MapNode mapNode))
             {
-                throw new OpenApiReaderException($"{nodeName} must be a map/object");
+                throw new OpenApiReaderException($"{nodeName} must be a map/object", Context);
             }
 
             return mapNode;
@@ -50,12 +50,12 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
 
         public virtual List<T> CreateList<T>(Func<MapNode, T> map)
         {
-            throw new OpenApiReaderException("Cannot create list from this type of node.");
+            throw new OpenApiReaderException("Cannot create list from this type of node.", Context);
         }
 
         public virtual Dictionary<string, T> CreateMap<T>(Func<MapNode, T> map)
         {
-            throw new OpenApiReaderException("Cannot create map from this type of node.");
+            throw new OpenApiReaderException("Cannot create map from this type of node.", Context);
         }
 
         public virtual Dictionary<string, T> CreateMapWithReference<T>(
@@ -63,38 +63,37 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             Func<MapNode, T> map)
             where T : class, IOpenApiReferenceable
         {
-            throw new OpenApiReaderException("Cannot create map from this reference.");
+            throw new OpenApiReaderException("Cannot create map from this reference.", Context);
         }
 
         public virtual List<T> CreateSimpleList<T>(Func<ValueNode, T> map)
         {
-            throw new OpenApiReaderException("Cannot create simple list from this type of node.");
+            throw new OpenApiReaderException("Cannot create simple list from this type of node.", Context);
         }
 
         public virtual Dictionary<string, T> CreateSimpleMap<T>(Func<ValueNode, T> map)
         {
-            throw new OpenApiReaderException("Cannot create simple map from this type of node.");
+            throw new OpenApiReaderException("Cannot create simple map from this type of node.", Context);
         }
 
         public virtual IOpenApiAny CreateAny()
         {
-            throw new OpenApiReaderException("Cannot create an Any object this type of node.");
+            throw new OpenApiReaderException("Cannot create an Any object this type of node.", Context);
         }
 
         public virtual string GetRaw()
         {
-            throw new OpenApiReaderException("Cannot get raw value from this type of node.");
+            throw new OpenApiReaderException("Cannot get raw value from this type of node.", Context);
         }
 
         public virtual string GetScalarValue()
         {
-            throw new OpenApiReaderException("Cannot create a scalar value from this type of node.");
+            throw new OpenApiReaderException("Cannot create a scalar value from this type of node.", Context);
         }
 
         public virtual List<IOpenApiAny> CreateListOfAny()
         {
-            throw new OpenApiReaderException("Cannot create a list from this type of node.");
+            throw new OpenApiReaderException("Cannot create a list from this type of node.", Context);
         }
-
     }
 }

--- a/src/Microsoft.OpenApi.Readers/ParsingContext.cs
+++ b/src/Microsoft.OpenApi.Readers/ParsingContext.cs
@@ -141,7 +141,7 @@ namespace Microsoft.OpenApi.Readers
         /// </summary>
         public string GetLocation()
         {
-            return "#/" + string.Join("/", _currentLocation.Reverse().ToArray());
+            return "#/" + string.Join("/", _currentLocation.Reverse().Select(s=> s.Replace("~","~0").Replace("/","~1")).ToArray());
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Exceptions/OpenApiException.cs
+++ b/src/Microsoft.OpenApi/Exceptions/OpenApiException.cs
@@ -39,8 +39,14 @@ namespace Microsoft.OpenApi.Exceptions
         }
 
         /// <summary>
-        /// The reference pointer.
+        /// The reference pointer.  This is a fragment identifier used to point to where the error occurred in the document.
+        /// If the document has been parsed as JSON/YAML then the identifier will be a 
+        /// JSON Pointer as per https://tools.ietf.org/html/rfc6901
+        /// If the document fails to parse as JSON/YAML then the fragment will be based on
+        /// a text/plain pointer as defined in https://tools.ietf.org/html/rfc5147 
+        /// Currently only line= is provided because using char= causes tests to break due to CR/LF & LF differences
         /// </summary>
         public string Pointer { get; set; }
+
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/ParseNodeTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ParseNodeTests.cs
@@ -31,5 +31,34 @@ paths: { }";
                 })
             });
         }
+
+        [Fact]
+        public void BadSchema()
+        {
+            var input = @"openapi: 3.0.0
+info:
+  title: foo
+  version: bar
+paths:
+  '/foo':
+    get:
+      responses:
+        200: 
+          description: ok
+          content:
+            application/json:  
+              schema: asdasd
+";
+
+            var reader = new OpenApiStringReader();
+            reader.Read(input, out var diagnostic);
+
+            diagnostic.Errors.Should().BeEquivalentTo(new List<OpenApiError>() {
+                new OpenApiError(new OpenApiReaderException("Expected a value.") {
+                    Pointer = "#/~1foo/get/responses/200/content/application~1json/schema"
+                })
+            });
+        }
     }
 }
+

--- a/test/Microsoft.OpenApi.Readers.Tests/ParseNodeTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ParseNodeTests.cs
@@ -54,8 +54,8 @@ paths:
             reader.Read(input, out var diagnostic);
 
             diagnostic.Errors.Should().BeEquivalentTo(new List<OpenApiError>() {
-                new OpenApiError(new OpenApiReaderException("Expected a value.") {
-                    Pointer = "#/~1foo/get/responses/200/content/application~1json/schema"
+                new OpenApiError(new OpenApiReaderException("schema must be a map/object") {
+                    Pointer = "#/paths/~1foo/get/responses/200/content/application~1json/schema"
                 })
             });
         }


### PR DESCRIPTION
Fixes #500

- Fixed issues with Pointer encoding and missing segments

```yaml
openapi: 3.0.0
info:
  title: foo
  version: bar
paths:
  '/foo':
    get:
      responses:
        200: 
          description: ok
          content:
            application/json:  
              schema: asdasd
```

Pointer needs to look like
```
#/paths/~1foo/get/responses/200/content/application~1json/schema
```
Previously slashes were not being escaped.  Also, map keys were not getting added to the path.  This affected `content`, `examples`, `headers`, `encoding`

- Added better documentation to the OpenApiException.Pointer property
- Converted OpenApiException to OpenApiReaderException in parsenodes so that line number is always included if JSON Pointer is not possible.