### PR TITLE
Removed DataTypeMismatch as default rule

### DIFF
--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiMediaTypeRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiMediaTypeRules.cs
@@ -8,7 +8,16 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiMediaType"/>.
     /// </summary>
-    [OpenApiRule]
+    /// <remarks>
+    /// Removed this in v1.3 as a default rule as the OpenAPI specification does not require that example
+    /// values validate against the schema.  Validating examples against the schema is particularly difficult
+    /// as it requires parsing of the example using the schema as a guide.  This is not possible when the schema
+    /// is ref'd.  Even if we fix this issue, this rule should be treated as a warning, not an error
+    /// Future versions of the validator should make that distinction.
+    /// Future versions of the example parsers should not try an infer types.
+    /// Example validation should be done as a separate post reading step so all schemas can be fully available.
+    /// </remarks>
+    //[OpenApiRule]
     public static class OpenApiMediaTypeRules
     {
         /// <summary>

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -1154,7 +1154,6 @@ namespace Microsoft.OpenApi.Validations.Rules
     {
         public static Microsoft.OpenApi.Validations.ValidationRule<Microsoft.OpenApi.Models.OpenApiLicense> LicenseRequiredFields { get; }
     }
-    [Microsoft.OpenApi.Validations.Rules.OpenApiRule]
     public static class OpenApiMediaTypeRules
     {
         public static Microsoft.OpenApi.Validations.ValidationRule<Microsoft.OpenApi.Models.OpenApiMediaType> MediaTypeMismatchedDataType { get; }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiMediaTypeValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiMediaTypeValidationTests.cs
@@ -32,7 +32,9 @@ namespace Microsoft.OpenApi.Validations.Tests
             };
 
             // Act
-            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
+            var ruleset = ValidationRuleSet.GetDefaultRuleSet();
+            ruleset.Add(OpenApiMediaTypeRules.MediaTypeMismatchedDataType);
+            var validator = new OpenApiValidator(ruleset);
             var walker = new OpenApiWalker(validator);
             walker.Walk(mediaType);
 
@@ -102,7 +104,9 @@ namespace Microsoft.OpenApi.Validations.Tests
             };
 
             // Act
-            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
+            var ruleset = ValidationRuleSet.GetDefaultRuleSet();
+            ruleset.Add(OpenApiMediaTypeRules.MediaTypeMismatchedDataType);
+            var validator = new OpenApiValidator(ruleset);
             var walker = new OpenApiWalker(validator);
             walker.Walk(mediaType);
 

--- a/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.NotEmpty(rules);
 
             // Update the number if you add new default rule(s).
-            Assert.Equal(21, rules.Count);
+            Assert.Equal(20, rules.Count);
         }
     }
 }


### PR DESCRIPTION
Addresses #407 and #587  by disabling the validation rule by default