### PR TITLE
Adds setting to configure leaving stream open

### DIFF
--- a/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
@@ -72,6 +72,6 @@ namespace Microsoft.OpenApi.Readers
         /// Whether to leave the <see cref="Stream"/> object open after reading
         /// from an <see cref="OpenApiStreamReader"/> object.
         /// </summary>
-        public bool LeaveStreamOpen { get; set; } = false;
+        public bool LeaveStreamOpen { get; set; }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiReaderSettings.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. 
+// Licensed under the MIT license.
 
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
@@ -61,11 +61,17 @@ namespace Microsoft.OpenApi.Readers
         public Uri BaseUrl { get; set; }
 
         /// <summary>
-        /// Function used to provide an alternative loader for accessing external references.  
+        /// Function used to provide an alternative loader for accessing external references.
         /// </summary>
         /// <remarks>
         /// Default loader will attempt to dereference http(s) urls and file urls.
         /// </remarks>
         public IStreamLoader CustomExternalLoader { get; set; }
+
+        /// <summary>
+        /// Whether to leave the <see cref="Stream"/> object open after reading
+        /// from an <see cref="OpenApiStreamReader"/> object.
+        /// </summary>
+        public bool LeaveStreamOpen { get; set; } = false;
     }
 }

--- a/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
@@ -33,17 +33,14 @@ namespace Microsoft.OpenApi.Readers
         /// <returns>Instance of newly created OpenApiDocument.</returns>
         public OpenApiDocument Read(Stream input, out OpenApiDiagnostic diagnostic)
         {
-            if (_settings.LeaveStreamOpen)
+            var reader = new StreamReader(input);
+            var result = new OpenApiTextReaderReader(_settings).Read(reader, out diagnostic);
+            if (!_settings.LeaveStreamOpen)
             {
-                return new OpenApiTextReaderReader(_settings).Read(new StreamReader(input), out diagnostic);
+                reader.Dispose();
             }
-            else
-            {
-                using (var reader = new StreamReader(input))
-                {
-                    return new OpenApiTextReaderReader(_settings).Read(reader, out diagnostic);
-                }
-            }
+
+            return result;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. 
+// Licensed under the MIT license.
 
 using System.IO;
 using System.Threading.Tasks;
@@ -29,13 +29,20 @@ namespace Microsoft.OpenApi.Readers
         /// Reads the stream input and parses it into an Open API document.
         /// </summary>
         /// <param name="input">Stream containing OpenAPI description to parse.</param>
-        /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing</param>
-        /// <returns>Instance of newly created OpenApiDocument</returns>
+        /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing.</param>
+        /// <returns>Instance of newly created OpenApiDocument.</returns>
         public OpenApiDocument Read(Stream input, out OpenApiDiagnostic diagnostic)
         {
-            using (var reader = new StreamReader(input))
+            if (_settings.LeaveStreamOpen)
             {
-                return new OpenApiTextReaderReader(_settings).Read(reader, out diagnostic);
+                return new OpenApiTextReaderReader(_settings).Read(new StreamReader(input), out diagnostic);
+            }
+            else
+            {
+                using (var reader = new StreamReader(input))
+                {
+                    return new OpenApiTextReaderReader(_settings).Read(reader, out diagnostic);
+                }
             }
         }
 
@@ -50,8 +57,8 @@ namespace Microsoft.OpenApi.Readers
             if (input is MemoryStream)
             {
                 bufferedStream = (MemoryStream)input;
-            } 
-            else 
+            }
+            else
             {
                 // Buffer stream so that OpenApiTextReaderReader can process it synchronously
                 // YamlDocument doesn't support async reading.

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiStreamReaderTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiStreamReaderTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.IO;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
+{
+    public class OpenApiStreamReaderTests
+    {
+        private const string SampleFolderPath = "V3Tests/Samples/OpenApiDocument/";
+
+        [Fact]
+        public void StreamShouldCloseIfLeaveStreamOpenSettingEqualsFalse()
+        {
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "petStore.yaml")))
+            {
+                var reader = new OpenApiStreamReader(new OpenApiReaderSettings { LeaveStreamOpen = false });
+                reader.Read(stream, out _);
+                Assert.False(stream.CanRead);
+            }
+        }
+
+        [Fact]
+        public void StreamShouldNotCloseIfLeaveStreamOpenSettingEqualsTrue()
+        {
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "petStore.yaml")))
+            {
+                var reader = new OpenApiStreamReader(new OpenApiReaderSettings { LeaveStreamOpen = true});
+                reader.Read(stream, out _);
+                Assert.True(stream.CanRead);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET/issues/530
Closes https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/583

This PR:
- Adds a new `boolean` setting in `OpenApiReaderSettings.cs`: `LeaveStreamOpen` to flag whether or not to leave the stream object open after reading from an `OpenApiStreamReader` object.
Creating a `StreamReader` object within a `using` statement closes the `stream` when the `Dispose()` method of the `StreamReader` is called.
- Creates `OpenApiStreamReader` tests to validate setting the `LeaveStreamOpen` setting to either `true` or `false`.