### PR TITLE
Allow `exclusiveMinimum and exclusiveMaximum` as numbers as per newer versions of JSON schema

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -5,6 +5,7 @@ using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 
@@ -49,6 +50,10 @@ namespace Microsoft.OpenApi.Readers.V3
                         o.Maximum = doubleValue;
                         o.ExclusiveMaximum = true;
                     }
+                    else
+                    {
+                        throw new FormatException($"String '{strValue}' was not recognized as a valid boolean or decimal");
+                    }
                 }
             },
             {
@@ -69,6 +74,10 @@ namespace Microsoft.OpenApi.Readers.V3
                     {
                         o.Minimum = doubleValue;
                         o.ExclusiveMinimum = true;
+                    }
+                    else
+                    {
+                        throw new FormatException($"String '{strValue}' was not recognized as a valid boolean or decimal");
                     }
                 }
             },

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -39,7 +39,16 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "exclusiveMaximum", (o, n) =>
                 {
-                    o.ExclusiveMaximum = bool.Parse(n.GetScalarValue());
+                    var strValue = n.GetScalarValue();
+                    if (bool.TryParse(strValue, out var boolValue))
+                    {
+                        o.ExclusiveMaximum = boolValue;
+                    }
+                    else if (decimal.TryParse(strValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var doubleValue))
+                    {
+                        o.Maximum = doubleValue;
+                        o.ExclusiveMaximum = true;
+                    }
                 }
             },
             {
@@ -51,7 +60,16 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "exclusiveMinimum", (o, n) =>
                 {
-                    o.ExclusiveMinimum = bool.Parse(n.GetScalarValue());
+                    var strValue = n.GetScalarValue();
+                    if (bool.TryParse(strValue, out var boolValue))
+                    {
+                        o.ExclusiveMinimum = boolValue;
+                    }
+                    else if (decimal.TryParse(strValue, NumberStyles.Float, CultureInfo.InvariantCulture, out var doubleValue))
+                    {
+                        o.Minimum = doubleValue;
+                        o.ExclusiveMinimum = true;
+                    }
                 }
             },
             {

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -129,6 +129,77 @@ paths: {}",
                 new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0 });
         }
 
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("hi-IN")]
+        // The equivalent of English 1,000.36 in French and Danish is 1.000,36
+        [InlineData("fr-FR")]
+        [InlineData("da-DK")]
+        public void ParseDocumentWithDifferentCultureAndNewerJsonSchemaExclusiveMinMaxShouldSucceed(string culture)
+        {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo(culture);
+
+            var openApiDoc = new OpenApiStringReader().Read(
+                @"
+openapi : 3.0.0
+info:
+    title: Simple Document
+    version: 0.9.1
+components:
+  schemas:
+    sampleSchema:
+      type: object
+      properties:
+        sampleProperty:
+          type: double
+          minimum: 100.54
+          exclusiveMaximum: 60000000.35
+          exclusiveMinimum: false
+paths: {}",
+                out var context);
+
+            openApiDoc.Should().BeEquivalentTo(
+                new OpenApiDocument
+                {
+                    Info = new OpenApiInfo
+                    {
+                        Title = "Simple Document",
+                        Version = "0.9.1"
+                    },
+                    Components = new OpenApiComponents()
+                    {
+                        Schemas =
+                        {
+                            ["sampleSchema"] = new OpenApiSchema()
+                            {
+                                Type = "object",
+                                Properties =
+                                {
+                                    ["sampleProperty"] = new OpenApiSchema()
+                                    {
+                                        Type = "double",
+                                        Minimum = (decimal)100.54,
+                                        Maximum = (decimal)60000000.35,
+                                        ExclusiveMaximum = true,
+                                        ExclusiveMinimum = false
+                                    }
+                                },
+                                Reference = new OpenApiReference()
+                                {
+                                    Id = "sampleSchema",
+                                    Type = ReferenceType.Schema
+                                }
+                            }
+                        }
+                    },
+                    Paths = new OpenApiPaths()
+                });
+
+            context.Should().BeEquivalentTo(
+                new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0 });
+        }
+
         [Fact]
         public void ParseBasicDocumentWithMultipleServersShouldSucceed()
         {


### PR DESCRIPTION
The OpenAPI spec for 3.0 spec uses a draft version of the jsonschema spec where `exclusiveMinimum` is a boolean type. In later versions it has become a number. We parse OpenAPI documents generated by libraries in other languages, for instance FastAPI in Python. There is a bug in FastAPI OpenAPI document generation where it apparantly uses a later version of jsonschema spec leading to `exclusiveMinimum` having a number value: https://github.com/tiangolo/fastapi/issues/240

I drafted up this PR just to see if it would be possible to support the implementation of FastAPI. I'm not an OpenAPI expert, so does this look feasible at all?

