### PR TITLE
Added extensions generating for ref properties of definitions

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiReference.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiReference.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Collections.Generic;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -108,9 +109,9 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <summary>
-        /// Serialize <see cref="OpenApiReference"/> to Open Api v3.0.
+        /// Serialize <see cref="OpenApiReference"/> to Open Api v3.0 with extensions if they are exists.
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public void SerializeAsV3(IOpenApiWriter writer, IDictionary<string, IOpenApiExtension> extensions)
         {
             if (writer == null)
             {
@@ -136,13 +137,26 @@ namespace Microsoft.OpenApi.Models
             // $ref
             writer.WriteProperty(OpenApiConstants.DollarRef, ReferenceV3);
 
+            if (extensions != null)
+            {
+                writer.WriteExtensions(extensions, OpenApiSpecVersion.OpenApi3_0);
+            }
+
             writer.WriteEndObject();
+        }
+        
+        /// <summary>
+        /// Serialize <see cref="OpenApiReference"/> to Open Api v3.0.
+        /// </summary>
+        public void SerializeAsV3(IOpenApiWriter writer)
+        {
+            SerializeAsV3(writer, null);
         }
 
         /// <summary>
-        /// Serialize <see cref="OpenApiReference"/> to Open Api v2.0.
+        /// Serialize <see cref="OpenApiReference"/> to Open Api v2.0 with extensions if they are exists.
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public void SerializeAsV2(IOpenApiWriter writer, IDictionary<string, IOpenApiExtension> extensions)
         {
             if (writer == null)
             {
@@ -168,7 +182,20 @@ namespace Microsoft.OpenApi.Models
             // $ref
             writer.WriteProperty(OpenApiConstants.DollarRef, ReferenceV2);
 
+            if (extensions != null)
+            {
+                writer.WriteExtensions(extensions, OpenApiSpecVersion.OpenApi2_0);
+            }
+
             writer.WriteEndObject();
+        }
+
+        /// <summary>
+        /// Serialize <see cref="OpenApiReference"/> to Open Api v2.0.
+        /// </summary>
+        public void SerializeAsV2(IOpenApiWriter writer)
+        {
+            SerializeAsV2(writer, null);
         }
 
         private string GetExternalReference()

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -257,7 +257,7 @@ namespace Microsoft.OpenApi.Models
             {
                 if (settings.ReferenceInline != ReferenceInlineSetting.InlineLocalReferences)
                 {
-                    Reference.SerializeAsV3(writer);
+                    Reference.SerializeAsV3(writer, Extensions);
                     return;
                 }
 
@@ -265,7 +265,7 @@ namespace Microsoft.OpenApi.Models
                 if (!settings.LoopDetector.PushLoop<OpenApiSchema>(this))
                 {
                     settings.LoopDetector.SaveLoop(this);
-                    Reference.SerializeAsV3(writer);
+                    Reference.SerializeAsV3(writer, Extensions);
                     return;
                 }
             }
@@ -447,7 +447,7 @@ namespace Microsoft.OpenApi.Models
                 var settings = writer.GetSettings();
                 if (settings.ReferenceInline != ReferenceInlineSetting.InlineLocalReferences)
                 {
-                    Reference.SerializeAsV2(writer);
+                    Reference.SerializeAsV2(writer, Extensions);
                     return;
                 }
 
@@ -455,7 +455,7 @@ namespace Microsoft.OpenApi.Models
                 if (!settings.LoopDetector.PushLoop<OpenApiSchema>(this))
                 {
                     settings.LoopDetector.SaveLoop(this);
-                    Reference.SerializeAsV2(writer);
+                    Reference.SerializeAsV2(writer, Extensions);
                     return;
                 }
             }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Writers;
 using Xunit;
@@ -158,6 +159,11 @@ namespace Microsoft.OpenApi.Tests.Models
             {
                 Type = ReferenceType.Schema,
                 Id = "schemaObject1"
+            },
+
+            Extensions = new Dictionary<string, IOpenApiExtension>
+            {
+                ["extension1"] = new OpenApiString("value1")
             }
         };
 
@@ -383,7 +389,8 @@ namespace Microsoft.OpenApi.Tests.Models
   ""nullable"": true,
   ""externalDocs"": {
     ""url"": ""http://example.com/externalDocs""
-  }
+  },
+  ""extension1"": ""value1""
 }";
 
             // Act
@@ -405,7 +412,8 @@ namespace Microsoft.OpenApi.Tests.Models
             var writer = new OpenApiJsonWriter(outputStringWriter);
 
             var expected = @"{
-  ""$ref"": ""#/components/schemas/schemaObject1""
+  ""$ref"": ""#/components/schemas/schemaObject1"",
+  ""extension1"": ""value1""
 }";
 
             // Act


### PR DESCRIPTION
Properties of ref type of definitions do not contain extensions though other properties do (it mean "stringProperty" will generate "extension1" property but "refProperty" will not).

```json 
"definitions": {
  "SomeType": {
    "properties": {
      "stringProperty": {
        "format": "string",
        "type": "string",
        "extension1": "value1"
      },
      "refProperty": {
        "$ref": "#/definitions/SomeRefProperty",
      }
    }
  }
}
```