### PR TITLE
Adds --filterByTags Command option 

### DIFF
--- a/src/Microsoft.OpenApi.Tool/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Tool/OpenApiService.cs
@@ -45,9 +45,14 @@ namespace Microsoft.OpenApi.Tool
             document = result.OpenApiDocument;
 
             // Check if filter options are provided, then execute
-            if (!string.IsNullOrEmpty(filterbyOperationIds) || !string.IsNullOrEmpty(filterByTags))
+            if (!string.IsNullOrEmpty(filterbyOperationIds))
             {
-                var predicate = OpenApiFilterService.CreatePredicate(filterbyOperationIds, filterByTags);
+                var predicate = OpenApiFilterService.CreatePredicate(operationIds: filterbyOperationIds);
+                document = OpenApiFilterService.CreateFilteredDocument(document, predicate);
+            }
+            if (!string.IsNullOrEmpty(filterByTags))
+            {
+                var predicate = OpenApiFilterService.CreatePredicate(tags: filterByTags);
                 document = OpenApiFilterService.CreateFilteredDocument(document, predicate);
             }
 

--- a/src/Microsoft.OpenApi.Tool/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Tool/OpenApiService.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OpenApi.Tool
             FileInfo output,
             OpenApiSpecVersion version,
             OpenApiFormat format,
-            string filterbyOperationIds,
+            string filterByOperationIds,
             string filterByTags,
             bool inline,
             bool resolveExternal)
@@ -44,9 +44,14 @@ namespace Microsoft.OpenApi.Tool
             document = result.OpenApiDocument;
 
             // Check if filter options are provided, then execute
-            if (!string.IsNullOrEmpty(filterbyOperationIds))
+            if (!string.IsNullOrEmpty(filterByOperationIds) && !string.IsNullOrEmpty(filterByTags))
             {
-                var predicate = OpenApiFilterService.CreatePredicate(operationIds: filterbyOperationIds);
+                throw new InvalidOperationException("Cannot filter by operationIds and tags at the same time.");
+            }
+
+            if (!string.IsNullOrEmpty(filterByOperationIds))
+            {
+                var predicate = OpenApiFilterService.CreatePredicate(operationIds: filterByOperationIds);
                 document = OpenApiFilterService.CreateFilteredDocument(document, predicate);
             }
             if (!string.IsNullOrEmpty(filterByTags))

--- a/src/Microsoft.OpenApi.Tool/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Tool/OpenApiService.cs
@@ -21,7 +21,8 @@ namespace Microsoft.OpenApi.Tool
             FileInfo output,
             OpenApiSpecVersion version,
             OpenApiFormat format,
-            string filterbyOperationId,
+            string filterbyOperationIds,
+            string filterByTags,
             bool inline,
             bool resolveExternal)
         {
@@ -44,9 +45,9 @@ namespace Microsoft.OpenApi.Tool
             document = result.OpenApiDocument;
 
             // Check if filter options are provided, then execute
-            if (!string.IsNullOrEmpty(filterbyOperationId))
+            if (!string.IsNullOrEmpty(filterbyOperationIds) || !string.IsNullOrEmpty(filterByTags))
             {
-                var predicate = OpenApiFilterService.CreatePredicate(filterbyOperationId);
+                var predicate = OpenApiFilterService.CreatePredicate(filterbyOperationIds, filterByTags);
                 document = OpenApiFilterService.CreateFilteredDocument(document, predicate);
             }
 

--- a/src/Microsoft.OpenApi.Tool/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Tool/OpenApiService.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
 using System.IO;
 using System.Linq;
 using System.Net;

--- a/src/Microsoft.OpenApi.Tool/Program.cs
+++ b/src/Microsoft.OpenApi.Tool/Program.cs
@@ -1,4 +1,7 @@
-﻿using System.CommandLine;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Microsoft.OpenApi.Tool/Program.cs
+++ b/src/Microsoft.OpenApi.Tool/Program.cs
@@ -26,9 +26,10 @@ namespace Microsoft.OpenApi.Tool
                 new Option("--format", "File format",typeof(OpenApiFormat) ),
                 new Option("--inline", "Inline $ref instances", typeof(bool) ),
                 new Option("--resolveExternal","Resolve external $refs", typeof(bool)),
-                new Option("--filterByOperationId", "Filters by OperationId provided", typeof(string))
+                new Option("--filterByOperationId", "Filters OpenApiDocument by OperationId provided", typeof(string)),
+                new Option("--filterByTag", "Filters OpenApiDocument by Tag(s) provided", typeof(string))
             };
-            transformCommand.Handler = CommandHandler.Create<string, FileInfo, OpenApiSpecVersion, OpenApiFormat, string, bool, bool>(
+            transformCommand.Handler = CommandHandler.Create<string, FileInfo, OpenApiSpecVersion, OpenApiFormat, string, string, bool, bool>(
                 OpenApiService.ProcessOpenApiDocument);
 
             rootCommand.Add(transformCommand);

--- a/src/Microsoft.OpenApi.Tool/Program.cs
+++ b/src/Microsoft.OpenApi.Tool/Program.cs
@@ -29,7 +29,7 @@ namespace Microsoft.OpenApi.Tool
                 new Option("--format", "File format",typeof(OpenApiFormat) ),
                 new Option("--inline", "Inline $ref instances", typeof(bool) ),
                 new Option("--resolveExternal","Resolve external $refs", typeof(bool)),
-                new Option("--filterByOperationIds", "Filters OpenApiDocument by OperationId provided", typeof(string)),
+                new Option("--filterByOperationIds", "Filters OpenApiDocument by OperationId(s) provided", typeof(string)),
                 new Option("--filterByTags", "Filters OpenApiDocument by Tag(s) provided", typeof(string))
             };
             transformCommand.Handler = CommandHandler.Create<string, FileInfo, OpenApiSpecVersion, OpenApiFormat, string, string, bool, bool>(

--- a/src/Microsoft.OpenApi.Tool/Program.cs
+++ b/src/Microsoft.OpenApi.Tool/Program.cs
@@ -26,8 +26,8 @@ namespace Microsoft.OpenApi.Tool
                 new Option("--format", "File format",typeof(OpenApiFormat) ),
                 new Option("--inline", "Inline $ref instances", typeof(bool) ),
                 new Option("--resolveExternal","Resolve external $refs", typeof(bool)),
-                new Option("--filterByOperationId", "Filters OpenApiDocument by OperationId provided", typeof(string)),
-                new Option("--filterByTag", "Filters OpenApiDocument by Tag(s) provided", typeof(string))
+                new Option("--filterByOperationIds", "Filters OpenApiDocument by OperationId provided", typeof(string)),
+                new Option("--filterByTags", "Filters OpenApiDocument by Tag(s) provided", typeof(string))
             };
             transformCommand.Handler = CommandHandler.Create<string, FileInfo, OpenApiSpecVersion, OpenApiFormat, string, string, bool, bool>(
                 OpenApiService.ProcessOpenApiDocument);

--- a/src/Microsoft.OpenApi/Services/OpenApiFilterService.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiFilterService.cs
@@ -23,6 +23,10 @@ namespace Microsoft.OpenApi.Services
         public static Func<OpenApiOperation, bool> CreatePredicate(string operationIds = null, string tags = null)
         {
             Func<OpenApiOperation, bool> predicate;
+            if (!string.IsNullOrEmpty(operationIds) && !string.IsNullOrEmpty(tags))
+            {
+                throw new InvalidOperationException("Cannot specify both operationIds and tags at the same time.");
+            }
             if (operationIds != null)
             {
                 if (operationIds == "*")
@@ -49,7 +53,6 @@ namespace Microsoft.OpenApi.Services
                     predicate = (o) => o.Tags.Any(t => tagsArray.Contains(t.Name));
                 }
             }
-
             else
             {
                 throw new InvalidOperationException("Either operationId(s) or tag(s) need to be specified.");

--- a/src/Microsoft.OpenApi/Services/OpenApiFilterService.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiFilterService.cs
@@ -48,8 +48,6 @@ namespace Microsoft.OpenApi.Services
                 {
                     predicate = (o) => o.Tags.Any(t => tagsArray.Contains(t.Name));
                 }
-
-                predicateSource = $"tags: {tags}";
             }
 
             else

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -957,7 +957,7 @@ namespace Microsoft.OpenApi.Services
     public static class OpenApiFilterService
     {
         public static Microsoft.OpenApi.Models.OpenApiDocument CreateFilteredDocument(Microsoft.OpenApi.Models.OpenApiDocument source, System.Func<Microsoft.OpenApi.Models.OpenApiOperation, bool> predicate) { }
-        public static System.Func<Microsoft.OpenApi.Models.OpenApiOperation, bool> CreatePredicate(string operationIds) { }
+        public static System.Func<Microsoft.OpenApi.Models.OpenApiOperation, bool> CreatePredicate(string operationIds = null, string tags = null) { }
     }
     public class OpenApiReferenceError : Microsoft.OpenApi.Models.OpenApiError
     {

--- a/test/Microsoft.OpenApi.Tests/Services/OpenApiFilterServiceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Services/OpenApiFilterServiceTests.cs
@@ -19,19 +19,28 @@ namespace Microsoft.OpenApi.Tests.Services
         }
 
         [Theory]
-        [InlineData("users.user.ListUser")]
-        [InlineData("users.user.GetUser")]
-        [InlineData("administrativeUnits.restore")]
-        [InlineData("graphService.GetGraphService")]
-        public void ReturnFilteredOpenApiDocumentBasedOnOperationIds(string operationId)
+        [InlineData("users.user.ListUser", null)]
+        [InlineData("users.user.GetUser", null)]
+        [InlineData("administrativeUnits.restore", null)]
+        [InlineData("graphService.GetGraphService", null)]
+        [InlineData(null, "users.user")]
+        [InlineData(null, "applications.application")]
+        public void ReturnFilteredOpenApiDocumentBasedOnOperationIds(string operationIds, string tags)
         {
             // Act
-            var predicate = OpenApiFilterService.CreatePredicate(operationId);
+            var predicate = OpenApiFilterService.CreatePredicate(operationIds, tags);
             var subsetOpenApiDocument = OpenApiFilterService.CreateFilteredDocument(_openApiDocumentMock, predicate);
 
             // Assert
             Assert.NotNull(subsetOpenApiDocument);
-            Assert.Single(subsetOpenApiDocument.Paths);
+            if (!string.IsNullOrEmpty(operationIds))
+            {
+                Assert.Single(subsetOpenApiDocument.Paths);
+            }
+            else if (!string.IsNullOrEmpty(tags))
+            {
+                Assert.NotEmpty(subsetOpenApiDocument.Paths);
+            }
         }
 
         [Fact]

--- a/test/Microsoft.OpenApi.Tests/Services/OpenApiFilterServiceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Services/OpenApiFilterServiceTests.cs
@@ -46,8 +46,11 @@ namespace Microsoft.OpenApi.Tests.Services
         public void ThrowsInvalidOperationExceptionInCreatePredicateWhenInvalidArgumentsArePassed()
         {
             // Act and Assert
-            var message = Assert.Throws<InvalidOperationException>(() =>OpenApiFilterService.CreatePredicate(null, null)).Message;
-            Assert.Equal("Either operationId(s) or tag(s) need to be specified.", message);
+            var message1 = Assert.Throws<InvalidOperationException>(() => OpenApiFilterService.CreatePredicate(null, null)).Message;
+            Assert.Equal("Either operationId(s) or tag(s) need to be specified.", message1);
+
+            var message2 = Assert.Throws<InvalidOperationException>(() => OpenApiFilterService.CreatePredicate("users.user.ListUser", "users.user")).Message;
+            Assert.Equal("Cannot specify both operationIds and tags at the same time.", message2);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Services/OpenApiFilterServiceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Services/OpenApiFilterServiceTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.OpenApi.Tests.Services
         [InlineData("graphService.GetGraphService", null)]
         [InlineData(null, "users.user")]
         [InlineData(null, "applications.application")]
+        [InlineData(null, "reports.Functions")]
         public void ReturnFilteredOpenApiDocumentBasedOnOperationIds(string operationIds, string tags)
         {
             // Act
@@ -47,8 +48,8 @@ namespace Microsoft.OpenApi.Tests.Services
         public void ThrowsInvalidOperationExceptionInCreatePredicateWhenInvalidOperationIdIsSpecified()
         {
             // Act and Assert
-            var message = Assert.Throws<InvalidOperationException>(() =>OpenApiFilterService.CreatePredicate(null)).Message;
-            Assert.Equal("OperationId needs to be specified.", message);
+            var message = Assert.Throws<InvalidOperationException>(() =>OpenApiFilterService.CreatePredicate(null, null)).Message;
+            Assert.Equal("Either operationId(s) or tag(s) need to be specified.", message);
         }
     }
 }


### PR DESCRIPTION
This PR proposes:
- Adding a `--filterByTag` command option to the `transform` command in the commandline tool
- Updates the `OpenApiFilterService`  with logic for slicing an OpenApiDocument based on the tags provided
- Adding tests to validate for filtering by `tags`

## Testing Instructions
- Build the project and its dependencies by running the ` .\build.cmd` file
- Reinstall the `openapi-parser` tool locally by running the `.\install-tool.ps1` script
- Invoke the tool by running the .\artifacts\openapi-parser.exe file and call the transform command
- To use the new command option, append the `--filterByTags "tags"` parameter to the transform command
E.g: `.\artifacts\openapi-parser.exe transform --input Mail.yml --format yaml --output Mail2.yml --version OpenApi3_0 --filterByTags users.mailFolder`

Fixes #629