### PR TITLE
Updates ci-build.yml to deploy Commandline tool to Nuget

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -94,6 +94,13 @@ steps:
     configuration: Release
     msbuildArguments: '/t:pack /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
 
+- task: MSBuild@1
+  displayName: 'Pack OpenAPI.Tool'
+  inputs:
+    solution: src/Microsoft.OpenApi.Tool/Microsoft.OpenApi.Tool.csproj
+    configuration: Release
+    msbuildArguments: '/t:pack /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
+
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP CodeSigning Nuget Packages'
   inputs:

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -95,9 +95,9 @@ steps:
     msbuildArguments: '/t:pack /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
 
 - task: MSBuild@1
-  displayName: 'Pack OpenAPI.Tool'
+  displayName: 'Pack Hidi'
   inputs:
-    solution: src/Microsoft.OpenApi.Tool/Microsoft.OpenApi.Tool.csproj
+    solution: src/Microsoft.Hidi/Microsoft.Hidi.csproj
     configuration: Release
     msbuildArguments: '/t:pack /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
 

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -95,9 +95,9 @@ steps:
     msbuildArguments: '/t:pack /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
 
 - task: MSBuild@1
-  displayName: 'Pack Hidi'
+  displayName: 'Pack OpenApi Hidi'
   inputs:
-    solution: src/Microsoft.Hidi/Microsoft.Hidi.csproj
+    solution: src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
     configuration: Release
     msbuildArguments: '/t:pack /p:PackageOutputPath=$(Build.ArtifactStagingDirectory) /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
 


### PR DESCRIPTION
This PR:
- Updates the current build.yml file with an additional build task for packaging the `OpenApi.Tool`, a commandline tool that enables processing of OpenAPI documents through validation, supports conversion for different file formats e.g from `json` to `yaml` and vice versa, and also supports filtering/slicing of OpenApi documents into smaller subset documents based on OperationIds and tags provided.
- This tool will then be published to Nuget as a package and leveraged across multiple projects such as DevX API, Kiota, Powershell, GE autocomplete etc


Fixes #630 