### PR TITLE
Bump up library versions

### DIFF
--- a/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+++ b/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
@@ -10,14 +10,14 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi.Readers</Title>
         <PackageId>Microsoft.OpenApi.Readers</PackageId>
-        <Version>1.3.0-preview</Version>
+        <Version>1.3.1-preview</Version>
         <Description>OpenAPI.NET Readers for JSON and YAML documents</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>
         <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET</RepositoryUrl>
         <PackageReleaseNotes>
 - Publish symbols.
-        </PackageReleaseNotes>        
+        </PackageReleaseNotes>
         <AssemblyName>Microsoft.OpenApi.Readers</AssemblyName>
         <RootNamespace>Microsoft.OpenApi.Readers</RootNamespace>
         <SignAssembly>true</SignAssembly>

--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -11,7 +11,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi</Title>
         <PackageId>Microsoft.OpenApi</PackageId>
-        <Version>1.3.0-preview</Version>
+        <Version>1.3.1-preview</Version>
         <Description>.NET models with JSON and YAML writers for OpenAPI specification</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>


### PR DESCRIPTION
This PR updates the `Microsoft.OpenApi` and `Microsoft.OpenApi.Readers` library versions from `1.3.0-preview` to `1.3.1-preview`