### PR TITLE
Use input file OpenApi format / version as the default output format / version in Hidi

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -204,14 +204,7 @@ namespace Microsoft.OpenApi.Hidi
 
         private static OpenApiFormat GetOpenApiFormat(string input)
         {
-            if (!input.StartsWith("http") && Path.GetExtension(input) == ".json")
-            {
-                return OpenApiFormat.Json;
-            }
-            else
-            {
-                return OpenApiFormat.Yaml;
-            }
+            return !input.StartsWith("http") && Path.GetExtension(input) == ".json" ? OpenApiFormat.Json : OpenApiFormat.Yaml;
         }
     }
 }

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -33,7 +33,7 @@ namespace Microsoft.OpenApi.Hidi
                 new Option("--filterByTags", "Filters OpenApiDocument by Tag(s) provided", typeof(string)),
                 new Option("--filterByCollection", "Filters OpenApiDocument by Postman collection provided", typeof(string))
             };
-            transformCommand.Handler = CommandHandler.Create<string, FileInfo, OpenApiSpecVersion, OpenApiFormat, string, string, string, bool, bool>(
+            transformCommand.Handler = CommandHandler.Create<string, FileInfo, OpenApiSpecVersion?, OpenApiFormat?, string, string, string, bool, bool>(
                 OpenApiService.ProcessOpenApiDocument);
 
             rootCommand.Add(transformCommand);

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -959,7 +959,6 @@ namespace Microsoft.OpenApi.Services
         public static Microsoft.OpenApi.Models.OpenApiDocument CreateFilteredDocument(Microsoft.OpenApi.Models.OpenApiDocument source, System.Func<string, Microsoft.OpenApi.Models.OperationType?, Microsoft.OpenApi.Models.OpenApiOperation, bool> predicate) { }
         public static Microsoft.OpenApi.Services.OpenApiUrlTreeNode CreateOpenApiUrlTreeNode(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiDocument> sources) { }
         public static System.Func<string, Microsoft.OpenApi.Models.OperationType?, Microsoft.OpenApi.Models.OpenApiOperation, bool> CreatePredicate(string operationIds = null, string tags = null, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> requestUrls = null, Microsoft.OpenApi.Models.OpenApiDocument source = null) { }
-        public static System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> ParseJsonCollectionFile(System.IO.Stream stream) { }
     }
     public class OpenApiReferenceError : Microsoft.OpenApi.Models.OpenApiError
     {


### PR DESCRIPTION
Issue: https://github.com/microsoft/OpenAPI.NET/issues/651

The  current `transform` command in Hidi defaults to `JSON` as the output format when no explicit format is specified. This is not the intended behaviour in most  cases.

This PR improves the `transform` command by using the default input file format and OpenApi version as the output format and version when no format or version is explicitly specified.