### PR TITLE
Add version to the OpenApiDocument .

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ParsingContext.cs
+++ b/src/Microsoft.OpenApi.Readers/ParsingContext.cs
@@ -56,6 +56,7 @@ namespace Microsoft.OpenApi.Readers
             var inputVersion = GetVersion(RootNode);
 
             OpenApiDocument doc;
+
             switch (inputVersion)
             {
                 case string version when version == "2.0":

--- a/src/Microsoft.OpenApi.Readers/ParsingContext.cs
+++ b/src/Microsoft.OpenApi.Readers/ParsingContext.cs
@@ -56,7 +56,6 @@ namespace Microsoft.OpenApi.Readers
             var inputVersion = GetVersion(RootNode);
 
             OpenApiDocument doc;
-
             switch (inputVersion)
             {
                 case string version when version == "2.0":

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
@@ -20,11 +20,7 @@ namespace Microsoft.OpenApi.Readers.V2
     {
         private static FixedFieldMap<OpenApiDocument> _openApiFixedFields = new FixedFieldMap<OpenApiDocument>
         {
-            {
-                "swagger", (o, n) =>
-                {
-                } /* Version is valid field but we already parsed it */
-            },
+            {"swagger", (o, n) => o.Version = n.GetScalarValue()},
             {"info", (o, n) => o.Info = LoadInfo(n)},
             {"host", (o, n) => n.Context.SetTempStorage("host", n.GetScalarValue())},
             {"basePath", (o, n) => n.Context.SetTempStorage("basePath", n.GetScalarValue())},

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiDocumentDeserializer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
@@ -18,11 +19,7 @@ namespace Microsoft.OpenApi.Readers.V3
     {
         private static FixedFieldMap<OpenApiDocument> _openApiFixedFields = new FixedFieldMap<OpenApiDocument>
         {
-            {
-                "openapi", (o, n) =>
-                {
-                } /* Version is valid field but we already parsed it */
-            },
+            {"openapi", (o, n) => o.Version = n.GetScalarValue()},
             {"info", (o, n) => o.Info = LoadInfo(n)},
             {"servers", (o, n) => o.Servers = n.CreateList(LoadServer)},
             {"paths", (o, n) => o.Paths = LoadPaths(n)},

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiDocumentDeserializer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System;
 using System.Collections.Generic;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -19,6 +19,11 @@ namespace Microsoft.OpenApi.Models
     public class OpenApiDocument : IOpenApiSerializable, IOpenApiExtensible
     {
         /// <summary>
+        /// REQUIRED. This string MUST be the version number of the OpenAPI Specification that the OpenAPI document uses. This is not related to the API info.version string.
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
         /// Related workspace containing OpenApiDocuments that are referenced in this document
         /// </summary>
         public OpenApiWorkspace Workspace { get; set; }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/ComparisonTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/ComparisonTests.cs
@@ -24,6 +24,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 var openApiDocV2 = new OpenApiStreamReader().Read(streamV2, out var diagnosticV2);
                 var openApiDocV3 = new OpenApiStreamReader().Read(streamV3, out var diagnosticV3);
 
+                // Reset version for equivalence check.
+                openApiDocV2.Version = null;
+                openApiDocV3.Version = null;
+
                 openApiDocV3.Should().BeEquivalentTo(openApiDocV2);
 
                 diagnosticV2.Errors.Should().BeEquivalentTo(diagnosticV3.Errors);

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
@@ -105,6 +105,7 @@ paths: {}",
             openApiDoc.Should().BeEquivalentTo(
                 new OpenApiDocument
                 {
+                    Version = "2.0",
                     Info = new OpenApiInfo
                     {
                         Title = "Simple Document",
@@ -244,6 +245,7 @@ paths: {}",
 
                 doc.Should().BeEquivalentTo(new OpenApiDocument
                 {
+                    Version = "2.0",
                     Info = new OpenApiInfo
                     {
                         Title = "Two responses",

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -45,6 +45,7 @@ paths: {}",
             openApiDoc.Should().BeEquivalentTo(
                 new OpenApiDocument
                 {
+                    Version = "3.0.0",
                     Info = new OpenApiInfo
                     {
                         Title = "Simple Document",
@@ -91,6 +92,7 @@ paths: {}",
             openApiDoc.Should().BeEquivalentTo(
                 new OpenApiDocument
                 {
+                    Version = "3.0.0",
                     Info = new OpenApiInfo
                     {
                         Title = "Simple Document",
@@ -142,6 +144,7 @@ paths: {}",
                 openApiDoc.Should().BeEquivalentTo(
                     new OpenApiDocument
                     {
+                        Version = "3.0.0",
                         Info = new OpenApiInfo
                         {
                             Title = "The API",
@@ -175,6 +178,7 @@ paths: {}",
                 openApiDoc.Should().BeEquivalentTo(
                     new OpenApiDocument
                     {
+                        Version = "3.0.0",
                         Info = new OpenApiInfo
                         {
                             Version = "0.9"
@@ -204,6 +208,7 @@ paths: {}",
                 openApiDoc.Should().BeEquivalentTo(
                     new OpenApiDocument
                     {
+                        Version = "3.0.0",
                         Info = new OpenApiInfo
                         {
                             Title = "Simple Document",
@@ -347,6 +352,7 @@ paths: {}",
 
                 var expected = new OpenApiDocument
                 {
+                    Version = "3.0.0",
                     Info = new OpenApiInfo
                     {
                         Version = "1.0.0",
@@ -832,6 +838,7 @@ paths: {}",
 
                 var expected = new OpenApiDocument
                 {
+                    Version = "3.0.0",
                     Info = new OpenApiInfo
                     {
                         Version = "1.0.0",

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -499,6 +499,7 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiSecurityRequirement> SecurityRequirements { get; set; }
         public System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiServer> Servers { get; set; }
         public System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiTag> Tags { get; set; }
+        public string Version { get; set; }
         public Microsoft.OpenApi.Services.OpenApiWorkspace Workspace { get; set; }
         public Microsoft.OpenApi.Interfaces.IOpenApiReferenceable ResolveReference(Microsoft.OpenApi.Models.OpenApiReference reference) { }
         public Microsoft.OpenApi.Interfaces.IOpenApiReferenceable ResolveReference(Microsoft.OpenApi.Models.OpenApiReference reference, bool useExternal) { }


### PR DESCRIPTION
Ive added a Version property to the `OpenApiDocument` to abstract the difference between `swagger` and `openapi` document types. 

This property is important for further implementing tooling support on top of this library.

Seeks to close  #659 