### PR TITLE
Added PatternProperties to OpenApiSchema

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
@@ -381,6 +381,11 @@ namespace Microsoft.OpenApi.Models
         public const string Properties = "properties";
 
         /// <summary>
+        /// Field: PatternProperties
+        /// </summary>
+        public const string PatternProperties = "patternProperties";
+
+        /// <summary>
         /// Field: AdditionalProperties
         /// </summary>
         public const string AdditionalProperties = "additionalProperties";

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -165,6 +165,15 @@ namespace Microsoft.OpenApi.Models
 
         /// <summary>
         /// Follow JSON Schema definition: https://tools.ietf.org/html/draft-fge-json-schema-validation-00
+        /// PatternProperty definitions MUST be a Schema Object and not a standard JSON Schema (inline or referenced)
+        /// Each property name of this object SHOULD be a valid regular expression according to the ECMA 262 r
+        /// egular expression dialect. Each property value of this object MUST be an object, and each object MUST 
+        /// be a valid Schema Object not a standard JSON Schema.
+        /// </summary>
+        public IDictionary<string, OpenApiSchema> PatternProperties { get; set; } = new Dictionary<string, OpenApiSchema>();
+
+        /// <summary>
+        /// Follow JSON Schema definition: https://tools.ietf.org/html/draft-fge-json-schema-validation-00
         /// </summary>
         public int? MaxProperties { get; set; }
 
@@ -353,6 +362,9 @@ namespace Microsoft.OpenApi.Models
 
             // properties
             writer.WriteOptionalMap(OpenApiConstants.Properties, Properties, (w, s) => s.SerializeAsV3(w));
+
+            // patternProperties
+            writer.WriteOptionalMap(OpenApiConstants.PatternProperties, PatternProperties, (w, s) => s.SerializeAsV3(w));
 
             // additionalProperties
             if (AdditionalPropertiesAllowed)

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -79,6 +79,19 @@ namespace Microsoft.OpenApi.Tests.Models
                     },
                 },
             },
+            PatternProperties = new Dictionary<string, OpenApiSchema>
+            {
+                ["[abc]"] = new OpenApiSchema 
+                {
+                    Type = "string",
+                    MaxLength = 15
+                },
+                ["(^\\d{5}$)"] = new OpenApiSchema
+                {
+                    Type = "integer",
+                    MaxLength = 15
+                }
+            },
             Nullable = true,
             ExternalDocs = new OpenApiExternalDocs
             {
@@ -296,6 +309,16 @@ namespace Microsoft.OpenApi.Tests.Models
           ""type"": ""string""
         }
       }
+    }
+  },
+  ""patternProperties"": {
+    ""[abc]"": {
+      ""maxLength"": 15,
+      ""type"": ""string""
+    },
+    ""(^\\d{5}$)"": {
+      ""maxLength"": 15,
+      ""type"": ""integer""
     }
   },
   ""nullable"": true,

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -427,6 +427,7 @@ namespace Microsoft.OpenApi.Models
         public const string Patch = "patch";
         public const string Paths = "paths";
         public const string Pattern = "pattern";
+        public const string PatternProperties = "patternProperties";
         public const string Post = "post";
         public const string Prefix = "prefix";
         public const string Produces = "produces";
@@ -795,6 +796,7 @@ namespace Microsoft.OpenApi.Models
         public bool Nullable { get; set; }
         public System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiSchema> OneOf { get; set; }
         public string Pattern { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiSchema> PatternProperties { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiSchema> Properties { get; set; }
         public bool ReadOnly { get; set; }
         public Microsoft.OpenApi.Models.OpenApiReference Reference { get; set; }


### PR DESCRIPTION
This PR add adds "patternProperties" to the OpenApiSchema
Reference: [PatternPropeties in json-schema](http://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.10.3.2.2)
Note: PatternProperties are not supported in[ OpenAPI v2](https://swagger.io/docs/specification/data-models/keywords/)

Seeks to close https://github.com/microsoft/OpenAPI.NET/issues/655