### PR TITLE
Fix round-tripping of empty media type objects and parsing of encoding style.

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiEncodingDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiEncodingDeserializer.cs
@@ -31,15 +31,7 @@ namespace Microsoft.OpenApi.Readers.V3
             {
                 "style", (o, n) =>
                 {
-                    ParameterStyle style;
-                    if (Enum.TryParse(n.GetScalarValue(), out style))
-                    {
-                        o.Style = style;
-                    }
-                    else
-                    {
-                        o.Style = null;
-                    }
+                    o.Style = n.GetScalarValue().GetEnumFromDisplayName<ParameterStyle>();
                 }
             },
             {

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiMediaTypeDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiMediaTypeDeserializer.cs
@@ -81,11 +81,6 @@ namespace Microsoft.OpenApi.Readers.V3
         {
             var mapNode = node.CheckMapNode(OpenApiConstants.Content);
 
-            if (!mapNode.Any())
-            {
-                return null;
-            }
-
             var mediaType = new OpenApiMediaType();
 
             ParseMap(mapNode, mediaType, _mediaTypeFixedFields, _mediaTypePatternFields);


### PR DESCRIPTION
Fixes for issue #683

1) Fix for parsing of encoding style.  

2) Add support for both null and empty media type objects:

```yaml
openapi: 3.0.1
info:
  title: empty vs null media type objects
  version: 1.0.0
paths:
  "/":
    get:
      responses:
        '200':
          description: ok
          content:
            text/plain: {}
            application/json: null
```