### PR TITLE
Align hidi params with kiota

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
   </ItemGroup>
 

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -3,12 +3,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Security;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers;
@@ -18,69 +21,75 @@ using Microsoft.OpenApi.Writers;
 
 namespace Microsoft.OpenApi.Hidi
 {
-    public static class OpenApiService
+    public class OpenApiService
     {
         public static void ProcessOpenApiDocument(
             string openapi,
             FileInfo output,
             OpenApiSpecVersion? version,
             OpenApiFormat? format,
+            LogLevel loglevel,
             string filterbyoperationids,
             string filterbytags,
             string filterbycollection,
             bool inline,
             bool resolveexternal)
         {
-            if (string.IsNullOrEmpty(openapi))
-            {
-                throw new ArgumentNullException(nameof(openapi));
-            }
-            if(output == null)
-            {
-                throw new ArgumentException(nameof(output));
-            }
-            if (output.Exists)
-            {
-                throw new IOException("The file you're writing to already exists. Please input a new output path.");
-            }
+            var logger = ConfigureLoggerInstance(loglevel);
 
-            var stream = GetStream(openapi);
+            try
+            {
+                if (string.IsNullOrEmpty(openapi))
+                {
+                    throw new ArgumentNullException(nameof(openapi));
+                }
+            }
+            catch (ArgumentNullException ex)
+            {
+                logger.LogError(ex.Message);
+                return;
+            }
+            try
+            {
+                if(output == null)
+                {
+                    throw new ArgumentException(nameof(output));
+                }
+            }
+            catch (ArgumentException ex)
+            {
+                logger.LogError(ex.Message);
+                return;
+            }
+            try
+            {
+                if (output.Exists)
+                {
+                    throw new IOException("The file you're writing to already exists. Please input a new file path.");
+                }
+            }
+            catch (IOException ex)
+            {
+                logger.LogError(ex.Message);
+                return;
+            }
+            
+            var stream = GetStream(openapi, logger);
+
+            // Parsing OpenAPI file
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            logger.LogTrace("Parsing OpenApi file");
             var result = new OpenApiStreamReader(new OpenApiReaderSettings
             {
                 ReferenceResolution = resolveexternal ? ReferenceResolutionSetting.ResolveAllReferences : ReferenceResolutionSetting.ResolveLocalReferences,
                 RuleSet = ValidationRuleSet.GetDefaultRuleSet()
             }
             ).ReadAsync(stream).GetAwaiter().GetResult();
-
             var document = result.OpenApiDocument;
-            Func<string, OperationType?, OpenApiOperation, bool> predicate;
-
-            // Check if filter options are provided, then execute
-            if (!string.IsNullOrEmpty(filterbyoperationids) && !string.IsNullOrEmpty(filterbytags))
-            {
-                throw new InvalidOperationException("Cannot filter by operationIds and tags at the same time.");
-            }
-            if (!string.IsNullOrEmpty(filterbyoperationids))
-            {
-                predicate = OpenApiFilterService.CreatePredicate(operationIds: filterbyoperationids);
-                document = OpenApiFilterService.CreateFilteredDocument(document, predicate);
-            }
-            if (!string.IsNullOrEmpty(filterbytags))
-            {
-                predicate = OpenApiFilterService.CreatePredicate(tags: filterbytags);
-                document = OpenApiFilterService.CreateFilteredDocument(document, predicate);
-            }
-
-            if (!string.IsNullOrEmpty(filterbycollection))
-            {
-                var fileStream = GetStream(filterbycollection);
-                var requestUrls = ParseJsonCollectionFile(fileStream);
-                predicate = OpenApiFilterService.CreatePredicate(requestUrls: requestUrls, source:document);
-                document = OpenApiFilterService.CreateFilteredDocument(document, predicate);
-            }
+            stopwatch.Stop();
 
             var context = result.OpenApiDiagnostic;
-
             if (context.Errors.Count > 0)
             {
                 var errorReport = new StringBuilder();
@@ -89,20 +98,58 @@ namespace Microsoft.OpenApi.Hidi
                 {
                     errorReport.AppendLine(error.ToString());
                 }
-
-                throw new ArgumentException(string.Join(Environment.NewLine, context.Errors.Select(e => e.Message).ToArray()));
+                logger.LogError($"{stopwatch.ElapsedMilliseconds}ms: OpenApi Parsing errors {string.Join(Environment.NewLine, context.Errors.Select(e => e.Message).ToArray())}");
+            }
+            else
+            {
+                logger.LogTrace("{timestamp}ms: Parsed OpenApi successfully. {count} paths found.", stopwatch.ElapsedMilliseconds, document.Paths.Count);
             }
 
-            using var outputStream = output?.Create();
+            Func<string, OperationType?, OpenApiOperation, bool> predicate;
 
-            var textWriter = outputStream != null ? new StreamWriter(outputStream) : Console.Out;
+            // Check if filter options are provided, then slice the OpenAPI document
+            if (!string.IsNullOrEmpty(filterbyoperationids) && !string.IsNullOrEmpty(filterbytags))
+            {
+                throw new InvalidOperationException("Cannot filter by operationIds and tags at the same time.");
+            }
+            if (!string.IsNullOrEmpty(filterbyoperationids))
+            {
+                logger.LogTrace("Creating predicate based on the operationIds supplied.");
+                predicate = OpenApiFilterService.CreatePredicate(operationIds: filterbyoperationids);
+
+                logger.LogTrace("Creating subset OpenApi document.");
+                document = OpenApiFilterService.CreateFilteredDocument(document, predicate);
+            }
+            if (!string.IsNullOrEmpty(filterbytags))
+            {
+                logger.LogTrace("Creating predicate based on the tags supplied.");
+                predicate = OpenApiFilterService.CreatePredicate(tags: filterbytags);
+
+                logger.LogTrace("Creating subset OpenApi document.");
+                document = OpenApiFilterService.CreateFilteredDocument(document, predicate);
+            }
+            if (!string.IsNullOrEmpty(filterbycollection))
+            {
+                var fileStream = GetStream(filterbycollection, logger);
+                var requestUrls = ParseJsonCollectionFile(fileStream, logger);
+
+                logger.LogTrace("Creating predicate based on the paths and Http methods defined in the Postman collection.");
+                predicate = OpenApiFilterService.CreatePredicate(requestUrls: requestUrls, source:document);
+
+                logger.LogTrace("Creating subset OpenApi document.");
+                document = OpenApiFilterService.CreateFilteredDocument(document, predicate);
+            }
+            
+            logger.LogTrace("Creating a new file");
+            using var outputStream = output?.Create();
+            var textWriter = outputStream != null ? new StreamWriter(outputStream) : Console.Out;            
 
             var settings = new OpenApiWriterSettings()
             {
                 ReferenceInline = inline ? ReferenceInlineSetting.InlineLocalReferences : ReferenceInlineSetting.DoNotInlineReferences
             };
 
-            var openApiFormat = format ?? GetOpenApiFormat(openapi);
+            var openApiFormat = format ?? GetOpenApiFormat(openapi, logger);
             var openApiVersion = version ?? result.OpenApiDiagnostic.SpecificationVersion;
             IOpenApiWriter writer = openApiFormat switch
             {
@@ -110,31 +157,64 @@ namespace Microsoft.OpenApi.Hidi
                 OpenApiFormat.Yaml => new OpenApiYamlWriter(textWriter, settings),
                 _ => throw new ArgumentException("Unknown format"),
             };
+
+            logger.LogTrace("Serializing to OpenApi document using the provided spec version and writer");
+            
+            stopwatch.Start();
             document.Serialize(writer, openApiVersion);
+            stopwatch.Stop();
+
+            logger.LogTrace($"Finished serializing in {stopwatch.ElapsedMilliseconds}ms");
 
             textWriter.Flush();
         }
 
-        private static Stream GetStream(string input)
+        private static Stream GetStream(string input, ILogger logger)
         {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
             Stream stream;
             if (input.StartsWith("http"))
             {
-                var httpClient = new HttpClient(new HttpClientHandler()
+                try
                 {
-                    SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
-                })
+                    var httpClient = new HttpClient(new HttpClientHandler()
+                    {
+                        SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
+                    })
+                    {
+                        DefaultRequestVersion = HttpVersion.Version20
+                    };
+                    stream = httpClient.GetStreamAsync(input).Result;
+                }
+                catch (HttpRequestException ex)
                 {
-                    DefaultRequestVersion = HttpVersion.Version20
-                };
-                stream = httpClient.GetStreamAsync(input).Result;
+                    logger.LogError($"Could not download the file at {input}, reason{ex}");
+                    return null;
+                }
             }
             else
             {
-                var fileInput = new FileInfo(input);
-                stream = fileInput.OpenRead();
+                try
+                {
+                    var fileInput = new FileInfo(input);
+                    stream = fileInput.OpenRead();
+                }
+                catch (Exception ex) when (ex is FileNotFoundException ||
+                    ex is PathTooLongException ||
+                    ex is DirectoryNotFoundException ||
+                    ex is IOException ||
+                    ex is UnauthorizedAccessException ||
+                    ex is SecurityException ||
+                    ex is NotSupportedException)
+                {
+                    logger.LogError($"Could not open the file at {input}, reason: {ex.Message}");
+                    return null;
+                }
             }
-
+            stopwatch.Stop();
+            logger.LogTrace("{timestamp}ms: Read file {input}", stopwatch.ElapsedMilliseconds, input);
             return stream;
         }
 
@@ -143,11 +223,11 @@ namespace Microsoft.OpenApi.Hidi
         /// </summary>
         /// <param name="stream"> A file stream.</param>
         /// <returns> A dictionary of request urls and http methods from a collection.</returns>
-        public static Dictionary<string, List<string>> ParseJsonCollectionFile(Stream stream)
+        public static Dictionary<string, List<string>> ParseJsonCollectionFile(Stream stream, ILogger logger)
         {
             var requestUrls = new Dictionary<string, List<string>>();
 
-            // Convert file to JsonDocument
+            logger.LogTrace("Parsing the json collection file into a JsonDocument");
             using var document = JsonDocument.Parse(stream);
             var root = document.RootElement;
             var itemElement = root.GetProperty("item");
@@ -166,21 +246,21 @@ namespace Microsoft.OpenApi.Hidi
                     requestUrls[path].Add(method);
                 }
             }
-
+            logger.LogTrace("Finished fetching the list of paths and Http methods defined in the Postman collection.");
             return requestUrls;
         }
 
-        internal static void ValidateOpenApiDocument(string openapi)
+        internal static void ValidateOpenApiDocument(string openapi, LogLevel loglevel)
         {
-            if (openapi == null)
+            if (string.IsNullOrEmpty(openapi))
             {
-                throw new ArgumentNullException("openapi");
+                throw new ArgumentNullException(nameof(openapi));
             }
-
-            var stream = GetStream(openapi);
+            var logger = ConfigureLoggerInstance(loglevel);
+            var stream = GetStream(openapi, logger);
 
             OpenApiDocument document;
-
+            logger.LogTrace("Parsing the OpenApi file");
             document = new OpenApiStreamReader(new OpenApiReaderSettings
             {
                 RuleSet = ValidationRuleSet.GetDefaultRuleSet()
@@ -199,12 +279,33 @@ namespace Microsoft.OpenApi.Hidi
             var walker = new OpenApiWalker(statsVisitor);
             walker.Walk(document);
 
+            logger.LogTrace("Finished walking through the OpenApi document. Generating a statistics report..");
             Console.WriteLine(statsVisitor.GetStatisticsReport());
         }
 
-        private static OpenApiFormat GetOpenApiFormat(string openapi)
+        private static OpenApiFormat GetOpenApiFormat(string openapi, ILogger logger)
         {
+            logger.LogTrace("Getting the OpenApi format");
             return !openapi.StartsWith("http") && Path.GetExtension(openapi) == ".json" ? OpenApiFormat.Json : OpenApiFormat.Yaml;
+        }
+
+        private static ILogger ConfigureLoggerInstance(LogLevel loglevel)
+        {
+            // Configure logger options
+            #if DEBUG
+            loglevel = loglevel > LogLevel.Debug ? LogLevel.Debug : loglevel;
+            #endif
+
+            var logger = LoggerFactory.Create((builder) => {
+                builder
+                    .AddConsole()
+                #if DEBUG
+                    .AddDebug()
+                #endif
+                    .SetMinimumLevel(loglevel);
+            }).CreateLogger<OpenApiService>();
+
+            return logger;
         }
     }
 }

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -115,10 +115,10 @@ namespace Microsoft.OpenApi.Hidi
             textWriter.Flush();
         }
 
-        private static Stream GetStream(string openapi)
+        private static Stream GetStream(string input)
         {
             Stream stream;
-            if (openapi.StartsWith("http"))
+            if (input.StartsWith("http"))
             {
                 var httpClient = new HttpClient(new HttpClientHandler()
                 {
@@ -127,11 +127,11 @@ namespace Microsoft.OpenApi.Hidi
                 {
                     DefaultRequestVersion = HttpVersion.Version20
                 };
-                stream = httpClient.GetStreamAsync(openapi).Result;
+                stream = httpClient.GetStreamAsync(input).Result;
             }
             else
             {
-                var fileInput = new FileInfo(openapi);
+                var fileInput = new FileInfo(input);
                 stream = fileInput.OpenRead();
             }
 

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -25,11 +25,11 @@ namespace Microsoft.OpenApi.Hidi
             FileInfo output,
             OpenApiSpecVersion? version,
             OpenApiFormat? format,
-            string filterByOperationIds,
-            string filterByTags,
-            string filterByCollection,
+            string filterbyoperationids,
+            string filterbytags,
+            string filterbycollection,
             bool inline,
-            bool resolveExternal)
+            bool resolveexternal)
         {
             if (string.IsNullOrEmpty(openapi))
             {
@@ -47,7 +47,7 @@ namespace Microsoft.OpenApi.Hidi
             var stream = GetStream(openapi);
             var result = new OpenApiStreamReader(new OpenApiReaderSettings
             {
-                ReferenceResolution = resolveExternal ? ReferenceResolutionSetting.ResolveAllReferences : ReferenceResolutionSetting.ResolveLocalReferences,
+                ReferenceResolution = resolveexternal ? ReferenceResolutionSetting.ResolveAllReferences : ReferenceResolutionSetting.ResolveLocalReferences,
                 RuleSet = ValidationRuleSet.GetDefaultRuleSet()
             }
             ).ReadAsync(stream).GetAwaiter().GetResult();
@@ -56,24 +56,24 @@ namespace Microsoft.OpenApi.Hidi
             Func<string, OperationType?, OpenApiOperation, bool> predicate;
 
             // Check if filter options are provided, then execute
-            if (!string.IsNullOrEmpty(filterByOperationIds) && !string.IsNullOrEmpty(filterByTags))
+            if (!string.IsNullOrEmpty(filterbyoperationids) && !string.IsNullOrEmpty(filterbytags))
             {
                 throw new InvalidOperationException("Cannot filter by operationIds and tags at the same time.");
             }
-            if (!string.IsNullOrEmpty(filterByOperationIds))
+            if (!string.IsNullOrEmpty(filterbyoperationids))
             {
-                predicate = OpenApiFilterService.CreatePredicate(operationIds: filterByOperationIds);
+                predicate = OpenApiFilterService.CreatePredicate(operationIds: filterbyoperationids);
                 document = OpenApiFilterService.CreateFilteredDocument(document, predicate);
             }
-            if (!string.IsNullOrEmpty(filterByTags))
+            if (!string.IsNullOrEmpty(filterbytags))
             {
-                predicate = OpenApiFilterService.CreatePredicate(tags: filterByTags);
+                predicate = OpenApiFilterService.CreatePredicate(tags: filterbytags);
                 document = OpenApiFilterService.CreateFilteredDocument(document, predicate);
             }
 
-            if (!string.IsNullOrEmpty(filterByCollection))
+            if (!string.IsNullOrEmpty(filterbycollection))
             {
-                var fileStream = GetStream(filterByCollection);
+                var fileStream = GetStream(filterbycollection);
                 var requestUrls = ParseJsonCollectionFile(fileStream);
                 predicate = OpenApiFilterService.CreatePredicate(requestUrls: requestUrls, source:document);
                 document = OpenApiFilterService.CreateFilteredDocument(document, predicate);

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -21,10 +21,16 @@ namespace Microsoft.OpenApi.Hidi
             };
             validateCommand.Handler = CommandHandler.Create<string>(OpenApiService.ValidateOpenApiDocument);
 
+            var descriptionOption = new Option("--openapi", "Input OpenAPI description file path or URL", typeof(string));
+            descriptionOption.AddAlias("-d");
+
+            var outputOption = new Option("--output", "The output directory path for the generated file.", typeof(FileInfo), () => "./output", arity: ArgumentArity.ZeroOrOne);
+            outputOption.AddAlias("o");
+
             var transformCommand = new Command("transform")
             {
-                new Option("--input", "Input OpenAPI description file path or URL", typeof(string) ),
-                new Option("--output","Output OpenAPI description file", typeof(FileInfo), arity: ArgumentArity.ZeroOrOne),
+                descriptionOption,
+                outputOption,
                 new Option("--version", "OpenAPI specification version", typeof(OpenApiSpecVersion)),
                 new Option("--format", "File format",typeof(OpenApiFormat) ),
                 new Option("--inline", "Inline $ref instances", typeof(bool) ),

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -14,14 +14,8 @@ namespace Microsoft.OpenApi.Hidi
         {
             var rootCommand = new RootCommand() {
             };
-
-            var validateCommand = new Command("validate")
-            {
-                new Option("--input", "Input OpenAPI description file path or URL", typeof(string) )
-            };
-            validateCommand.Handler = CommandHandler.Create<string>(OpenApiService.ValidateOpenApiDocument);
-
-            // transform command options
+            
+            // command option parameters and aliases
             var descriptionOption = new Option("--openapi", "Input OpenAPI description file path or URL", typeof(string));
             descriptionOption.AddAlias("-d");
 
@@ -48,6 +42,12 @@ namespace Microsoft.OpenApi.Hidi
 ;
             var filterByCollectionOption = new Option("--filterByCollection", "Filters OpenApiDocument by Postman collection provided", typeof(string));
             filterByCollectionOption.AddAlias("-c");
+
+            var validateCommand = new Command("validate")
+            {
+                descriptionOption
+            };
+            validateCommand.Handler = CommandHandler.Create<string>(OpenApiService.ValidateOpenApiDocument);
 
             var transformCommand = new Command("transform")
             {

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -21,23 +21,45 @@ namespace Microsoft.OpenApi.Hidi
             };
             validateCommand.Handler = CommandHandler.Create<string>(OpenApiService.ValidateOpenApiDocument);
 
+            // transform command options
             var descriptionOption = new Option("--openapi", "Input OpenAPI description file path or URL", typeof(string));
             descriptionOption.AddAlias("-d");
 
             var outputOption = new Option("--output", "The output directory path for the generated file.", typeof(FileInfo), () => "./output", arity: ArgumentArity.ZeroOrOne);
-            outputOption.AddAlias("o");
+            outputOption.AddAlias("-o");
+
+            var versionOption = new Option("--version", "OpenAPI specification version", typeof(OpenApiSpecVersion));
+            versionOption.AddAlias("-v");
+
+            var formatOption = new Option("--format", "File format", typeof(OpenApiFormat));
+            formatOption.AddAlias("-f");
+;
+            var inlineOption = new Option("--inline", "Inline $ref instances", typeof(bool));
+            inlineOption.AddAlias("-i");
+;
+            var resolveExternalOption = new Option("--resolveExternal", "Resolve external $refs", typeof(bool));
+            resolveExternalOption.AddAlias("-ex");
+;
+            var filterByOperationIdsOption = new Option("--filterByOperationIds", "Filters OpenApiDocument by OperationId(s) provided", typeof(string));
+            filterByOperationIdsOption.AddAlias("-op");
+;
+            var filterByTagsOption = new Option("--filterByTags", "Filters OpenApiDocument by Tag(s) provided", typeof(string));
+            filterByTagsOption.AddAlias("-t");
+;
+            var filterByCollectionOption = new Option("--filterByCollection", "Filters OpenApiDocument by Postman collection provided", typeof(string));
+            filterByCollectionOption.AddAlias("-c");
 
             var transformCommand = new Command("transform")
             {
                 descriptionOption,
                 outputOption,
-                new Option("--version", "OpenAPI specification version", typeof(OpenApiSpecVersion)),
-                new Option("--format", "File format",typeof(OpenApiFormat) ),
-                new Option("--inline", "Inline $ref instances", typeof(bool) ),
-                new Option("--resolveExternal","Resolve external $refs", typeof(bool)),
-                new Option("--filterByOperationIds", "Filters OpenApiDocument by OperationId(s) provided", typeof(string)),
-                new Option("--filterByTags", "Filters OpenApiDocument by Tag(s) provided", typeof(string)),
-                new Option("--filterByCollection", "Filters OpenApiDocument by Postman collection provided", typeof(string))
+                versionOption,
+                formatOption,
+                inlineOption,
+                resolveExternalOption,
+                filterByOperationIdsOption,
+                filterByTagsOption,
+                filterByCollectionOption
             };
             transformCommand.Handler = CommandHandler.Create<string, FileInfo, OpenApiSpecVersion?, OpenApiFormat?, string, string, string, bool, bool>(
                 OpenApiService.ProcessOpenApiDocument);

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.OpenApi.Hidi
 {
@@ -27,7 +28,10 @@ namespace Microsoft.OpenApi.Hidi
 
             var formatOption = new Option("--format", "File format", typeof(OpenApiFormat));
             formatOption.AddAlias("-f");
-            
+
+            var logLevelOption = new Option("--loglevel", "The log level to use when logging messages to the main output.", typeof(LogLevel), () => LogLevel.Warning);
+            logLevelOption.AddAlias("-ll");
+
             var inlineOption = new Option("--inline", "Inline $ref instances", typeof(bool));
             inlineOption.AddAlias("-i");
 
@@ -45,9 +49,11 @@ namespace Microsoft.OpenApi.Hidi
 
             var validateCommand = new Command("validate")
             {
-                descriptionOption
+                descriptionOption,
+                logLevelOption
             };
-            validateCommand.Handler = CommandHandler.Create<string>(OpenApiService.ValidateOpenApiDocument);
+
+            validateCommand.Handler = CommandHandler.Create<string, LogLevel>(OpenApiService.ValidateOpenApiDocument);
 
             var transformCommand = new Command("transform")
             {
@@ -55,13 +61,15 @@ namespace Microsoft.OpenApi.Hidi
                 outputOption,
                 versionOption,
                 formatOption,
+                logLevelOption,
                 inlineOption,
                 resolveExternalOption,
                 filterByOperationIdsOption,
                 filterByTagsOption,
                 filterByCollectionOption
             };
-            transformCommand.Handler = CommandHandler.Create<string, FileInfo, OpenApiSpecVersion?, OpenApiFormat?, string, string, string, bool, bool>(
+
+            transformCommand.Handler = CommandHandler.Create<string, FileInfo, OpenApiSpecVersion?, OpenApiFormat?, LogLevel, string, string, string, bool, bool>(
                 OpenApiService.ProcessOpenApiDocument);
 
             rootCommand.Add(transformCommand);

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -31,16 +31,16 @@ namespace Microsoft.OpenApi.Hidi
             var inlineOption = new Option("--inline", "Inline $ref instances", typeof(bool));
             inlineOption.AddAlias("-i");
 ;
-            var resolveExternalOption = new Option("--resolveExternal", "Resolve external $refs", typeof(bool));
+            var resolveExternalOption = new Option("--resolve-external", "Resolve external $refs", typeof(bool));
             resolveExternalOption.AddAlias("-ex");
 ;
-            var filterByOperationIdsOption = new Option("--filterByOperationIds", "Filters OpenApiDocument by OperationId(s) provided", typeof(string));
+            var filterByOperationIdsOption = new Option("--filter-by-operationids", "Filters OpenApiDocument by OperationId(s) provided", typeof(string));
             filterByOperationIdsOption.AddAlias("-op");
 ;
-            var filterByTagsOption = new Option("--filterByTags", "Filters OpenApiDocument by Tag(s) provided", typeof(string));
+            var filterByTagsOption = new Option("--filter-by-tags", "Filters OpenApiDocument by Tag(s) provided", typeof(string));
             filterByTagsOption.AddAlias("-t");
 ;
-            var filterByCollectionOption = new Option("--filterByCollection", "Filters OpenApiDocument by Postman collection provided", typeof(string));
+            var filterByCollectionOption = new Option("--filter-by-collection", "Filters OpenApiDocument by Postman collection provided", typeof(string));
             filterByCollectionOption.AddAlias("-c");
 
             var validateCommand = new Command("validate")

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -27,19 +27,19 @@ namespace Microsoft.OpenApi.Hidi
 
             var formatOption = new Option("--format", "File format", typeof(OpenApiFormat));
             formatOption.AddAlias("-f");
-;
+            
             var inlineOption = new Option("--inline", "Inline $ref instances", typeof(bool));
             inlineOption.AddAlias("-i");
-;
+
             var resolveExternalOption = new Option("--resolve-external", "Resolve external $refs", typeof(bool));
             resolveExternalOption.AddAlias("-ex");
-;
+
             var filterByOperationIdsOption = new Option("--filter-by-operationids", "Filters OpenApiDocument by OperationId(s) provided", typeof(string));
             filterByOperationIdsOption.AddAlias("-op");
-;
+
             var filterByTagsOption = new Option("--filter-by-tags", "Filters OpenApiDocument by Tag(s) provided", typeof(string));
             filterByTagsOption.AddAlias("-t");
-;
+
             var filterByCollectionOption = new Option("--filter-by-collection", "Filters OpenApiDocument by Postman collection provided", typeof(string));
             filterByCollectionOption.AddAlias("-c");
 

--- a/src/Microsoft.OpenApi.Hidi/appsettings.json
+++ b/src/Microsoft.OpenApi.Hidi/appsettings.json
@@ -1,0 +1,7 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug"
+    }
+  }
+}

--- a/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
+++ b/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpYaml" Version="1.8.0" />
     <PackageReference Include="Verify" Version="14.14.1" />

--- a/test/Microsoft.OpenApi.Tests/Services/OpenApiFilterServiceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Services/OpenApiFilterServiceTests.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.IO;
+using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Hidi;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 using Microsoft.OpenApi.Tests.UtilityFiles;
+using Moq;
 using Xunit;
 
 namespace Microsoft.OpenApi.Tests.Services
@@ -14,10 +16,14 @@ namespace Microsoft.OpenApi.Tests.Services
     public class OpenApiFilterServiceTests
     {
         private readonly OpenApiDocument _openApiDocumentMock;
+        private readonly Mock<ILogger<OpenApiService>> _mockLogger;
+        private readonly ILogger<OpenApiService> _logger;
 
         public OpenApiFilterServiceTests()
         {
             _openApiDocumentMock = OpenApiDocumentMock.CreateOpenApiDocument();
+            _mockLogger = new Mock<ILogger<OpenApiService>>();
+            _logger = _mockLogger.Object;
         }
 
         [Theory]
@@ -53,7 +59,7 @@ namespace Microsoft.OpenApi.Tests.Services
             var stream = fileInput.OpenRead();
 
             // Act
-            var requestUrls = OpenApiService.ParseJsonCollectionFile(stream);
+            var requestUrls = OpenApiService.ParseJsonCollectionFile(stream, _logger);
             var predicate = OpenApiFilterService.CreatePredicate(requestUrls: requestUrls, source: _openApiDocumentMock);
             var subsetOpenApiDocument = OpenApiFilterService.CreateFilteredDocument(_openApiDocumentMock, predicate);
 
@@ -72,7 +78,7 @@ namespace Microsoft.OpenApi.Tests.Services
             var stream = fileInput.OpenRead();
 
             // Act
-            var requestUrls = OpenApiService.ParseJsonCollectionFile(stream);
+            var requestUrls = OpenApiService.ParseJsonCollectionFile(stream, _logger);
 
             // Assert
             var message = Assert.Throws<ArgumentException>(() =>


### PR DESCRIPTION
As per [Kiota's documentation](https://microsoft.github.io/kiota/using.html), this PR seeks to align the common parameters between Hidi and Kiota in order to reduce any disparity in the tools.
As of now, these parameters are:
-  `--openapi` in Kiota  vs `--input` in Hidi representing the path to the OpenAPI description/CSDL file used to generate the code files
-  `--output` in Kiota vs `--output` in Hidi representing the output directory path for the generated code files

This PR also seeks to add aliases to our existing parameters for simplicity
Fixes #662 