### PR TITLE
Convert csdl files to openapi

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.OData.Edm" Version="7.9.4" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.8" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
   </ItemGroup>
 

--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <PackAsTool>true</PackAsTool>
+    <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Microsoft/OpenAPI.NET</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -15,6 +16,7 @@
     <ToolCommandName>hidi</ToolCommandName>
     <PackageOutputPath>./../../artifacts</PackageOutputPath>
     <Version>0.5.0-preview4</Version>
+    <Description>OpenAPI.NET CLI tool for slicing OpenAPI documents</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>OpenAPI .NET</PackageTags>
     <RepositoryUrl>https://github.com/Microsoft/OpenAPI.NET</RepositoryUrl>

--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta2.21617.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.9.4" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.8" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -184,10 +184,10 @@ namespace Microsoft.OpenApi.Hidi
             return doc;
         }
 
-        private static Stream GetStream(string openapi)
+        private static Stream GetStream(string input)
         {
             Stream stream;
-            if (openapi.StartsWith("http"))
+            if (input.StartsWith("http"))
             {
                 var httpClient = new HttpClient(new HttpClientHandler()
                 {
@@ -196,11 +196,11 @@ namespace Microsoft.OpenApi.Hidi
                 {
                     DefaultRequestVersion = HttpVersion.Version20
                 };
-                stream = httpClient.GetStreamAsync(openapi).Result;
+                stream = httpClient.GetStreamAsync(input).Result;
             }
             else
             {
-                var fileInput = new FileInfo(openapi);
+                var fileInput = new FileInfo(input);
                 stream = fileInput.OpenRead();
             }
 

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -53,7 +53,7 @@ namespace Microsoft.OpenApi.Hidi
             
             OpenApiDocument document;
 
-            if (input.Contains(".xml"))
+            if (input.Contains(".xml") || input.Contains(".csdl"))
             {
                 document = ConvertCsdlToOpenApi(stream);
             }

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -356,10 +356,10 @@ namespace Microsoft.OpenApi.Hidi
             Console.WriteLine(statsVisitor.GetStatisticsReport());
         }
 
-        private static OpenApiFormat GetOpenApiFormat(string openapi, ILogger logger)
+        private static OpenApiFormat GetOpenApiFormat(string input, ILogger logger)
         {
             logger.LogTrace("Getting the OpenApi format");
-            return !openapi.StartsWith("http") && Path.GetExtension(openapi) == ".json" ? OpenApiFormat.Json : OpenApiFormat.Yaml;
+            return !input.StartsWith("http") && Path.GetExtension(input) == ".json" ? OpenApiFormat.Json : OpenApiFormat.Yaml;
         }
 
         private static ILogger ConfigureLoggerInstance(LogLevel loglevel)

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -46,6 +46,13 @@ namespace Microsoft.OpenApi.Hidi
             }
 
             var stream = GetStream(input);
+            OpenApiDocument document;
+
+            if (input.Contains("xml"))
+            {
+                document = ConvertCsdlToOpenApi(stream);
+            }
+           
             var result = new OpenApiStreamReader(new OpenApiReaderSettings
             {
                 ReferenceResolution = resolveExternal ? ReferenceResolutionSetting.ResolveAllReferences : ReferenceResolutionSetting.ResolveLocalReferences,
@@ -53,9 +60,8 @@ namespace Microsoft.OpenApi.Hidi
             }
             ).ReadAsync(stream).GetAwaiter().GetResult();
 
-            OpenApiDocument document;
             document = result.OpenApiDocument;
-
+            
             // Check if filter options are provided, then execute
             if (!string.IsNullOrEmpty(filterByOperationIds) && !string.IsNullOrEmpty(filterByTags))
             {

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -7,8 +7,12 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.OData.Edm.Csdl;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.OData;
 using Microsoft.OpenApi.Readers;
 using Microsoft.OpenApi.Services;
 using Microsoft.OpenApi.Validations;

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -83,21 +83,21 @@ namespace Microsoft.OpenApi.Hidi
             Stream stream;
             OpenApiDocument document;
             OpenApiFormat openApiFormat;
+            var stopwatch = new Stopwatch();
 
             if (!string.IsNullOrEmpty(csdl))
             {
                 // Default to yaml during csdl to OpenApi conversion
-                openApiFormat = format ?? GetOpenApiFormat(csdl);
+                openApiFormat = format ?? GetOpenApiFormat(csdl, logger);
 
-                stream = GetStream(csdl);
+                stream = await GetStream(csdl, logger);
                 document = ConvertCsdlToOpenApi(stream);
             }
             else
             {
-                stream = GetStream(openapi, logger);
+                stream = await GetStream(openapi, logger);
 
                 // Parsing OpenAPI file
-                var stopwatch = new Stopwatch();
                 stopwatch.Start();
                 logger.LogTrace("Parsing OpenApi file");
                 var result = new OpenApiStreamReader(new OpenApiReaderSettings
@@ -126,7 +126,7 @@ namespace Microsoft.OpenApi.Hidi
                     logger.LogTrace("{timestamp}ms: Parsed OpenApi successfully. {count} paths found.", stopwatch.ElapsedMilliseconds, document.Paths.Count);
                 }
 
-                openApiFormat = format ?? GetOpenApiFormat(openapi);
+                openApiFormat = format ?? GetOpenApiFormat(openapi, logger);
                 version ??= result.OpenApiDiagnostic.SpecificationVersion;
             }
 

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -9,7 +9,6 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OpenApi.Extensions;
@@ -49,21 +48,27 @@ namespace Microsoft.OpenApi.Hidi
             }
 
             var stream = GetStream(input);
+            
+            ReadResult result = null;
+            
             OpenApiDocument document;
 
-            if (input.Contains("xml"))
+            if (input.Contains(".xml"))
             {
                 document = ConvertCsdlToOpenApi(stream);
             }
-           
-            var result = new OpenApiStreamReader(new OpenApiReaderSettings
+            else
             {
-                ReferenceResolution = resolveExternal ? ReferenceResolutionSetting.ResolveAllReferences : ReferenceResolutionSetting.ResolveLocalReferences,
-                RuleSet = ValidationRuleSet.GetDefaultRuleSet()
-            }
-            ).ReadAsync(stream).GetAwaiter().GetResult();
+                result = new OpenApiStreamReader(new OpenApiReaderSettings
+                {
+                    ReferenceResolution = resolveExternal ? ReferenceResolutionSetting.ResolveAllReferences : ReferenceResolutionSetting.ResolveLocalReferences,
+                    RuleSet = ValidationRuleSet.GetDefaultRuleSet()
+                }
+                ).ReadAsync(stream).GetAwaiter().GetResult();
 
-            document = result.OpenApiDocument;
+                document = result.OpenApiDocument;
+            }
+            
             Func<string, OperationType?, OpenApiOperation, bool> predicate;
 
             // Check if filter options are provided, then execute

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -162,6 +162,11 @@ namespace Microsoft.OpenApi.Hidi
             return document;
         }
 
+        /// <summary>
+        /// Fixes the references in the resulting OpenApiDocument.
+        /// </summary>
+        /// <param name="document"> The converted OpenApiDocument.</param>
+        /// <returns> A valid OpenApiDocument instance.</returns>
         public static OpenApiDocument FixReferences(OpenApiDocument document)
         {
             // This method is only needed because the output of ConvertToOpenApi isn't quite a valid OpenApiDocument instance.

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -87,8 +87,9 @@ namespace Microsoft.OpenApi.Hidi
 
             if (!string.IsNullOrEmpty(csdl))
             {
-                // Default to yaml during csdl to OpenApi conversion
+                // Default to yaml and OpenApiVersion 3 during csdl to OpenApi conversion
                 openApiFormat = format ?? GetOpenApiFormat(csdl, logger);
+                version ??= OpenApiSpecVersion.OpenApi3_0;
 
                 stream = await GetStream(csdl, logger);
                 document = ConvertCsdlToOpenApi(stream);

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -19,7 +19,7 @@ namespace Microsoft.OpenApi.Hidi
             var descriptionOption = new Option<string>("--openapi", "Input OpenAPI description file path or URL");
             descriptionOption.AddAlias("-d");
 
-            var csdlOption = new Option("--csdl", "Input CSDL file path or URL", typeof(string));
+            var csdlOption = new Option<string>("--csdl", "Input CSDL file path or URL");
             csdlOption.AddAlias("-cs");
 
             var outputOption = new Option<FileInfo>("--output", () => new FileInfo("./output"), "The output directory path for the generated file.") { Arity = ArgumentArity.ZeroOrOne };
@@ -72,8 +72,8 @@ namespace Microsoft.OpenApi.Hidi
                 resolveExternalOption,
             };
 
-            transformCommand.SetHandler<string, FileInfo, OpenApiSpecVersion?, OpenApiFormat?, LogLevel, bool, bool, string, string, string> (
-                OpenApiService.ProcessOpenApiDocument, descriptionOption, outputOption, versionOption, formatOption, logLevelOption, inlineOption, resolveExternalOption, filterByOperationIdsOption, filterByTagsOption, filterByCollectionOption);
+            transformCommand.SetHandler<string, string, FileInfo, OpenApiSpecVersion?, OpenApiFormat?, LogLevel, bool, bool, string, string, string> (
+                OpenApiService.ProcessOpenApiDocument, descriptionOption, csdlOption, outputOption, versionOption, formatOption, logLevelOption, inlineOption, resolveExternalOption, filterByOperationIdsOption, filterByTagsOption, filterByCollectionOption);
 
             rootCommand.Add(transformCommand);
             rootCommand.Add(validateCommand);

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -19,6 +19,9 @@ namespace Microsoft.OpenApi.Hidi
             var descriptionOption = new Option("--openapi", "Input OpenAPI description file path or URL", typeof(string));
             descriptionOption.AddAlias("-d");
 
+            var csdlOption = new Option("--csdl", "Input CSDL file path or URL", typeof(string));
+            csdlOption.AddAlias("-cs");
+
             var outputOption = new Option("--output", "The output directory path for the generated file.", typeof(FileInfo), () => "./output", arity: ArgumentArity.ZeroOrOne);
             outputOption.AddAlias("-o");
 
@@ -52,6 +55,7 @@ namespace Microsoft.OpenApi.Hidi
             var transformCommand = new Command("transform")
             {
                 descriptionOption,
+                csdlOption,
                 outputOption,
                 versionOption,
                 formatOption,
@@ -61,7 +65,7 @@ namespace Microsoft.OpenApi.Hidi
                 filterByTagsOption,
                 filterByCollectionOption
             };
-            transformCommand.Handler = CommandHandler.Create<string, FileInfo, OpenApiSpecVersion?, OpenApiFormat?, string, string, string, bool, bool>(
+            transformCommand.Handler = CommandHandler.Create<string, string, FileInfo, OpenApiSpecVersion?, OpenApiFormat?, string, string, string, bool, bool>(
                 OpenApiService.ProcessOpenApiDocument);
 
             rootCommand.Add(transformCommand);

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.Hidi
 
             var transformCommand = new Command("transform")
             {
-                new Option("--input", "Input OpenAPI description file path or URL", typeof(string) ),
+                new Option("--input", "Input OpenAPI description, JSON or CSDL file path or URL", typeof(string) ),
                 new Option("--output","Output OpenAPI description file", typeof(FileInfo), arity: ArgumentArity.ZeroOrOne),
                 new Option("--version", "OpenAPI specification version", typeof(OpenApiSpecVersion)),
                 new Option("--format", "File format",typeof(OpenApiFormat) ),

--- a/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
+++ b/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
@@ -43,5 +43,8 @@
     <None Update="UtilityFiles\postmanCollection_ver2.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="UtilityFiles\Todo.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/test/Microsoft.OpenApi.Tests/Services/OpenApiCSDLConversionTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Services/OpenApiCSDLConversionTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.OpenApi.Hidi;
+using Microsoft.OpenApi.Services;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Services
+{
+    public class OpenApiCSDLConversionTests
+    {
+        [Fact]
+        public void ReturnConvertedCSDLFile()
+        {
+            // Arrange
+            var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "UtilityFiles\\Todo.xml");
+            var fileInput = new FileInfo(filePath);
+            var csdlStream = fileInput.OpenRead();
+
+            // Act
+            var openApiDoc = OpenApiService.ConvertCsdlToOpenApi(csdlStream);
+            var expectedPathCount = 5;
+
+            // Assert
+            Assert.NotNull(openApiDoc);
+            Assert.NotEmpty(openApiDoc.Paths);
+            Assert.Equal(openApiDoc.Paths.Count, expectedPathCount);
+        }
+        
+        [Theory]
+        [InlineData("Todos.Todo.UpdateTodo",null, 1)]
+        [InlineData("Todos.Todo.ListTodo",null, 1)]
+        [InlineData(null, "Todos.Todo", 4)]
+        public void ReturnFilteredOpenApiDocumentBasedOnOperationIdsAndInputCsdlDocument(string operationIds, string tags, int expectedPathCount)
+        {
+            // Arrange
+            var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "UtilityFiles\\Todo.xml");
+            var fileInput = new FileInfo(filePath);
+            var csdlStream = fileInput.OpenRead();
+
+            // Act
+            var openApiDoc = OpenApiService.ConvertCsdlToOpenApi(csdlStream);
+            var predicate = OpenApiFilterService.CreatePredicate(operationIds, tags);
+            var subsetOpenApiDocument = OpenApiFilterService.CreateFilteredDocument(openApiDoc, predicate);
+
+            // Assert
+            Assert.NotNull(subsetOpenApiDocument);
+            Assert.NotEmpty(subsetOpenApiDocument.Paths);
+            Assert.Equal(expectedPathCount, subsetOpenApiDocument.Paths.Count);
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Services/OpenApiServiceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Services/OpenApiServiceTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Microsoft.OpenApi.Tests.Services
 {
-    public class OpenApiCSDLConversionTests
+    public class OpenApiServiceTests
     {
         [Fact]
         public void ReturnConvertedCSDLFile()
@@ -33,7 +33,7 @@ namespace Microsoft.OpenApi.Tests.Services
         [InlineData("Todos.Todo.UpdateTodo",null, 1)]
         [InlineData("Todos.Todo.ListTodo",null, 1)]
         [InlineData(null, "Todos.Todo", 4)]
-        public void ReturnFilteredOpenApiDocumentBasedOnOperationIdsAndInputCsdlDocument(string operationIds, string tags, int expectedPathCount)
+        public void ReturnFilteredOpenApiDocBasedOnOperationIdsAndInputCsdlDocument(string operationIds, string tags, int expectedPathCount)
         {
             // Arrange
             var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "UtilityFiles\\Todo.xml");

--- a/test/Microsoft.OpenApi.Tests/UtilityFiles/Todo.xml
+++ b/test/Microsoft.OpenApi.Tests/UtilityFiles/Todo.xml
@@ -1,0 +1,21 @@
+﻿<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+    <edmx:DataServices>
+        <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="microsoft.graph" >
+
+            <EntityContainer Name="TodoService">
+                <EntitySet Name="Todos" EntityType="microsoft.graph.Todo">
+                </EntitySet>
+            </EntityContainer>
+
+            <EntityType Name="Todo" HasStream="true">
+                <Key>
+                    <PropertyRef Name="Id"/>
+                </Key>
+                <Property Name="Id" Type="Edm.String"/>
+                <Property Name="Logo" Type="Edm.Stream"/>
+                <Property Name="Description" Type="Edm.String"/>
+            </EntityType>
+
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
This feature enables consumption of CSDL files with the `.csdl` and `.xml` extensions as input in Hidi and therefore, slicing them based on the available parameters.

**Example**: `transform --input Files/Todo.xml --output Files/Todo-subset.yml --format yaml --version OpenApi3_0 --filterByOperationIds Todos.Todo.UpdateTodo`

Fixes #690 