### PR TITLE
Upgrades to System.Commandline beta2

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+      <LangVersion>9.0</LangVersion>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>hidi</ToolCommandName>
     <PackageOutputPath>./../../artifacts</PackageOutputPath>
@@ -14,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta2.21617.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -30,11 +30,12 @@ namespace Microsoft.OpenApi.Hidi
             OpenApiSpecVersion? version,
             OpenApiFormat? format,
             LogLevel loglevel,
+            bool inline,
+            bool resolveexternal,
             string filterbyoperationids,
             string filterbytags,
-            string filterbycollection,
-            bool inline,
-            bool resolveexternal)
+            string filterbycollection
+           )
         {
             var logger = ConfigureLoggerInstance(loglevel);
 

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -15,37 +14,37 @@ namespace Microsoft.OpenApi.Hidi
         {
             var rootCommand = new RootCommand() {
             };
-            
+
             // command option parameters and aliases
-            var descriptionOption = new Option("--openapi", "Input OpenAPI description file path or URL", typeof(string));
+            var descriptionOption = new Option<string>("--openapi", "Input OpenAPI description file path or URL");
             descriptionOption.AddAlias("-d");
 
-            var outputOption = new Option("--output", "The output directory path for the generated file.", typeof(FileInfo), () => "./output", arity: ArgumentArity.ZeroOrOne);
+            var outputOption = new Option<FileInfo>("--output", () => new FileInfo("./output"), "The output directory path for the generated file.") { Arity = ArgumentArity.ZeroOrOne };
             outputOption.AddAlias("-o");
 
-            var versionOption = new Option("--version", "OpenAPI specification version", typeof(OpenApiSpecVersion));
+            var versionOption = new Option<OpenApiSpecVersion?>("--version", "OpenAPI specification version");
             versionOption.AddAlias("-v");
 
-            var formatOption = new Option("--format", "File format", typeof(OpenApiFormat));
+            var formatOption = new Option<OpenApiFormat?>("--format", "File format");
             formatOption.AddAlias("-f");
 
-            var logLevelOption = new Option("--loglevel", "The log level to use when logging messages to the main output.", typeof(LogLevel), () => LogLevel.Warning);
+            var logLevelOption = new Option<LogLevel>("--loglevel", () => LogLevel.Warning, "The log level to use when logging messages to the main output.");
             logLevelOption.AddAlias("-ll");
 
-            var inlineOption = new Option("--inline", "Inline $ref instances", typeof(bool));
-            inlineOption.AddAlias("-i");
-
-            var resolveExternalOption = new Option("--resolve-external", "Resolve external $refs", typeof(bool));
-            resolveExternalOption.AddAlias("-ex");
-
-            var filterByOperationIdsOption = new Option("--filter-by-operationids", "Filters OpenApiDocument by OperationId(s) provided", typeof(string));
+            var filterByOperationIdsOption = new Option<string>("--filter-by-operationids", "Filters OpenApiDocument by OperationId(s) provided");
             filterByOperationIdsOption.AddAlias("-op");
 
-            var filterByTagsOption = new Option("--filter-by-tags", "Filters OpenApiDocument by Tag(s) provided", typeof(string));
+            var filterByTagsOption = new Option<string>("--filter-by-tags", "Filters OpenApiDocument by Tag(s) provided");
             filterByTagsOption.AddAlias("-t");
 
-            var filterByCollectionOption = new Option("--filter-by-collection", "Filters OpenApiDocument by Postman collection provided", typeof(string));
+            var filterByCollectionOption = new Option<string>("--filter-by-collection", "Filters OpenApiDocument by Postman collection provided");
             filterByCollectionOption.AddAlias("-c");
+
+            var inlineOption = new Option<bool>("--inline", "Inline $ref instances");
+            inlineOption.AddAlias("-i");
+
+            var resolveExternalOption = new Option<bool>("--resolve-external", "Resolve external $refs");
+            resolveExternalOption.AddAlias("-ex");
 
             var validateCommand = new Command("validate")
             {
@@ -53,7 +52,7 @@ namespace Microsoft.OpenApi.Hidi
                 logLevelOption
             };
 
-            validateCommand.Handler = CommandHandler.Create<string, LogLevel>(OpenApiService.ValidateOpenApiDocument);
+            validateCommand.SetHandler<string, LogLevel>(OpenApiService.ValidateOpenApiDocument, descriptionOption, logLevelOption);
 
             var transformCommand = new Command("transform")
             {
@@ -61,16 +60,16 @@ namespace Microsoft.OpenApi.Hidi
                 outputOption,
                 versionOption,
                 formatOption,
-                logLevelOption,
-                inlineOption,
-                resolveExternalOption,
+                logLevelOption,               
                 filterByOperationIdsOption,
                 filterByTagsOption,
-                filterByCollectionOption
+                filterByCollectionOption,
+                inlineOption,
+                resolveExternalOption,
             };
 
-            transformCommand.Handler = CommandHandler.Create<string, FileInfo, OpenApiSpecVersion?, OpenApiFormat?, LogLevel, string, string, string, bool, bool>(
-                OpenApiService.ProcessOpenApiDocument);
+            transformCommand.SetHandler<string, FileInfo, OpenApiSpecVersion?, OpenApiFormat?, LogLevel, bool, bool, string, string, string> (
+                OpenApiService.ProcessOpenApiDocument, descriptionOption, outputOption, versionOption, formatOption, logLevelOption, inlineOption, resolveExternalOption, filterByOperationIdsOption, filterByTagsOption, filterByCollectionOption);
 
             rootCommand.Add(transformCommand);
             rootCommand.Add(validateCommand);


### PR DESCRIPTION
This PR upgrades Hidi to use the [System.Commandline 2.0 Beta 2](https://github.com/dotnet/command-line-api/issues/1537) package and resolves the breaking changes
Fixes #709 