### PR TITLE
Fixed ValidateDocument method in hidi

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <PackAsTool>true</PackAsTool>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -251,13 +251,13 @@ namespace Microsoft.OpenApi.Hidi
             {
                 try
                 {
-                    using var httpClientHandler = new HttpClientHandler()
+                    var httpClientHandler = new HttpClientHandler()
                     {
                         SslProtocols = System.Security.Authentication.SslProtocols.Tls12,
                     };
                     using var httpClient = new HttpClient(httpClientHandler)
                     {
-                        DefaultRequestVersion = HttpVersion.Version20
+                      DefaultRequestVersion = HttpVersion.Version20
                     };
                     stream = await httpClient.GetStreamAsync(input);
                 }
@@ -323,7 +323,7 @@ namespace Microsoft.OpenApi.Hidi
             return requestUrls;
         }
 
-        internal static async void ValidateOpenApiDocument(string openapi, LogLevel loglevel)
+        internal static async Task ValidateOpenApiDocument(string openapi, LogLevel loglevel)
         {
             if (string.IsNullOrEmpty(openapi))
             {


### PR DESCRIPTION
Method returned void instead of Task and so would exit the app as soon as an async method was called.

Fixes #734 