### PR TITLE
updates pipeline definition to align with openapi.odata lib changes

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -19,7 +19,7 @@ pool:
 variables:
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
-  ProductBinPath: '$(Build.SourcesDirectory)\bin\$(BuildConfiguration)'
+  ProductBinPath: '$(Build.SourcesDirectory)\src\Microsoft.OpenApi\bin\$(BuildConfiguration)' 
 
 
 stages:

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -164,7 +164,7 @@ stages:
         inputs:
           command: pack
           projects: src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
-          arguments: '-o $(Build.ArtifactStagingDirectory)/Nugets --configuration $(BuildConfiguration) --no-build --include-symbols --include-source /p:SymbolPackageFormat=snupkg'
+          arguments: '-o $(Build.ArtifactStagingDirectory) --configuration $(BuildConfiguration) --no-build --include-symbols --include-source /p:SymbolPackageFormat=snupkg'
       
       # Pack
       - task: DotNetCoreCLI@2
@@ -172,7 +172,7 @@ stages:
         inputs:
           command: pack
           projects: src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
-          arguments: '-o $(Build.ArtifactStagingDirectory)/Nugets --configuration $(BuildConfiguration) --no-build --include-symbols --include-source /p:SymbolPackageFormat=snupkg'
+          arguments: '-o $(Build.ArtifactStagingDirectory) --configuration $(BuildConfiguration) --no-build --include-symbols --include-source /p:SymbolPackageFormat=snupkg'
       
       # Pack
       - task: DotNetCoreCLI@2
@@ -180,7 +180,7 @@ stages:
         inputs:
           command: pack
           projects: src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
-          arguments: '-o $(Build.ArtifactStagingDirectory)/Nugets --configuration $(BuildConfiguration) --no-build --include-symbols --include-source /p:SymbolPackageFormat=snupkg'
+          arguments: '-o $(Build.ArtifactStagingDirectory) --configuration $(BuildConfiguration) --no-build --include-symbols --include-source /p:SymbolPackageFormat=snupkg'
       
       - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
         displayName: 'ESRP CodeSigning Nuget Packages'
@@ -227,6 +227,13 @@ stages:
           projects: 'src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj'
           publishWebProjects: False
           zipAfterPublish: false 
+
+      - task: CopyFile@2
+        displayName: Prepare staging folder for upload
+        inputs:
+         targetFolder: $(Build.ArtifactStagingDirectory)/Nugets
+         sourceFolder: $(Build.ArtifactStagingDirectory)
+         content: '*.nupkg'
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact: Nugets'

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -16,151 +16,254 @@ pool:
   - msbuild
   - vstest
 
-steps:
-- task: UseDotNet@2
-  displayName: 'Use .NET Core sdk'
-  inputs:
-    packageType: 'sdk'
-    version: '6.0.x'
-    includePreviewVersions: true
+variables:
+  buildPlatform: 'Any CPU'
+  buildConfiguration: 'Release'
+  ProductBinPath: '$(Build.SourcesDirectory)\bin\$(BuildConfiguration)'
 
-- task: NuGetCommand@2
-  displayName: 'NuGet restore'
 
-- task: MSBuild@1
-  displayName: 'Build solution **/*.sln'
-  inputs:
-    configuration: Release
+stages:
 
-- task: VSTest@2
-  displayName: 'XUnit Tests'
-  inputs:
-    testAssemblyVer2: |
-     **\*.Tests.dll
+- stage: build
+  jobs:
+    - job: build
+      steps:
+      - task: UseDotNet@2
+        displayName: 'Use .NET 6'
+        inputs:
+          version: 6.x
 
-    vsTestVersion: 16.0
-    codeCoverageEnabled: true
+      - task: PoliCheck@1
+        displayName: 'Run PoliCheck "/src"'
+        inputs:
+          inputType: CmdLine
+          cmdLineArgs: '/F:$(Build.SourcesDirectory)/src /T:9 /Sev:"1|2" /PE:2 /O:poli_result_src.xml'
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'ESRP CodeSigning'
-  inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-    FolderPath: src
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [
-         {
-             "keyCode": "CP-230012",
-             "operationSetCode": "SigntoolSign",
-             "parameters": [
-             {
-                 "parameterName": "OpusName",
-                 "parameterValue": "Microsoft"
-             },
-             {
-                 "parameterName": "OpusInfo",
-                 "parameterValue": "http://www.microsoft.com"
-             },
-             {
-                 "parameterName": "FileDigest",
-                 "parameterValue": "/fd \"SHA256\""
-             },
-             {
-                 "parameterName": "PageHash",
-                 "parameterValue": "/NPH"
-             },
-             {
-                 "parameterName": "TimeStamp",
-                 "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-             }
-             ],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         },
-         {
-             "keyCode": "CP-230012",
-             "operationSetCode": "SigntoolVerify",
-             "parameters": [ ],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         }
-     ]
-    SessionTimeout: 20
+      - task: PoliCheck@1
+        displayName: 'Run PoliCheck "/test"'
+        inputs:
+          inputType: CmdLine
+          cmdLineArgs: '/F:$(Build.SourcesDirectory)/test /T:9 /Sev:"1|2" /PE:2 /O:poli_result_test.xml'
 
-- task: MSBuild@1
-  displayName: 'Pack OpenAPI'
-  inputs:
-    solution: src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
-    configuration: Release
-    msbuildArguments: '/t:pack /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)/Nugets /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
+      - task: PoliCheck@1
+        displayName: 'PoliCheck for /tool'
+        inputs:
+          inputType: CmdLine
+          cmdLineArgs: '/F:$(Build.SourcesDirectory)/tool /T:9 /Sev:"1|2" /PE:2 /O:poli_result_tool.xml'
+          
+      # Install the nuget tool.
+      - task: NuGetToolInstaller@0
+        displayName: 'Use NuGet >=5.2.0'
+        inputs:
+          versionSpec: '>=5.2.0'
+          checkLatest: true
 
-- task: MSBuild@1
-  displayName: 'Pack OpenAPI Readers'
-  inputs:
-    solution: src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
-    configuration: Release
-    msbuildArguments: '/t:pack /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)/Nugets /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
+      # Build the Product project
+      - task: DotNetCoreCLI@2
+        displayName: 'build'
+        inputs:
+          projects: '$(Build.SourcesDirectory)\Microsoft.OpenApi.sln'
+          arguments: '--configuration $(BuildConfiguration) --no-incremental'
 
-- task: MSBuild@1
-  displayName: 'Pack OpenApi Hidi'
-  inputs:
-    solution: src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
-    configuration: Release
-    msbuildArguments: '/t:pack /p:PackageOutputPath=$(Build.ArtifactStagingDirectory)/Nugets /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg'
+      # Run the Unit test
+      - task: DotNetCoreCLI@2
+        displayName: 'test'
+        inputs:
+          command: test
+          projects: '$(Build.SourcesDirectory)\Microsoft.OpenApi.sln'
+          arguments: '--configuration $(BuildConfiguration) --no-build'
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'ESRP CodeSigning Nuget Packages'
-  inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-    FolderPath: '$(Build.ArtifactStagingDirectory)'
-    Pattern: '*.nupkg'
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [
-         {
-             "keyCode": "CP-401405",
-             "operationSetCode": "NuGetSign",
-             "parameters": [ ],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         },
-         {
-             "keyCode": "CP-401405",
-             "operationSetCode": "NuGetVerify",
-             "parameters": [ ],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         }
-     ]
-    SessionTimeout: 20
+      # CredScan
+      - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+        displayName: 'Run CredScan - Src'
+        inputs:
+          toolMajorVersion: 'V2'
+          scanFolder: '$(Build.SourcesDirectory)\src'
+          debugMode: false
 
-- task: PowerShell@2
-  displayName: "Get Hidi's version-number from .csproj"
-  inputs:
-    targetType: 'inline'
-    script: |
-         $xml = [Xml] (Get-Content .\src\Microsoft.OpenApi.Hidi\Microsoft.OpenApi.Hidi.csproj)
-         $version = $xml.Project.PropertyGroup.Version
-         echo $version
-         echo "##vso[task.setvariable variable=version]$version"  
+      - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+        displayName: 'Run CredScan - Test'
+        inputs:
+          toolMajorVersion: 'V2'
+          scanFolder: '$(Build.SourcesDirectory)\test'
+          debugMode: false
 
-# publish hidi as an .exe
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'publish'
-    arguments: -c Release --runtime win-x64 /p:PublishSingleFile=true --self-contained --output $(Build.ArtifactStagingDirectory)/Microsoft.OpenApi.Hidi-v$(version) --no-dependencies
-    projects: 'src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj'
-    publishWebProjects: False
-    zipAfterPublish: false 
+      - task: AntiMalware@3
+        displayName: 'Run MpCmdRun.exe - ProductBinPath'
+        inputs:
+          FileDirPath: '$(ProductBinPath)'
+        enabled: false
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: Nugets'
-  inputs:
-    ArtifactName: Nugets
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/Nugets'
+      - task: BinSkim@3
+        displayName: 'Run BinSkim - Product Binaries'
+        inputs:
+          InputType: Basic
+          AnalyzeTarget: '$(ProductBinPath)\**\Microsoft.OpenApi.dll'
+          AnalyzeSymPath: '$(ProductBinPath)'
+          AnalyzeVerbose: true
+          AnalyzeHashes: true
+          AnalyzeEnvironment: true
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: Hidi'
-  inputs: 
-    ArtifactName: Microsoft.OpenApi.Hidi-v$(version)
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)/Microsoft.OpenApi.Hidi-v$(version)'
+      - task: PublishSecurityAnalysisLogs@2
+        displayName: 'Publish Security Analysis Logs'
+        inputs:
+          ArtifactName: SecurityLogs
+
+      - task: PostAnalysis@1
+        displayName: 'Post Analysis'
+        inputs:
+          BinSkim: true
+          CredScan: true
+          PoliCheck: true
+
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: 'ESRP CodeSigning'
+        inputs:
+          ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+          FolderPath: src
+          signConfigType: inlineSignParams
+          inlineOperation: |
+            [
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolSign",
+                    "parameters": [
+                    {
+                        "parameterName": "OpusName",
+                        "parameterValue": "Microsoft"
+                    },
+                    {
+                        "parameterName": "OpusInfo",
+                        "parameterValue": "http://www.microsoft.com"
+                    },
+                    {
+                        "parameterName": "FileDigest",
+                        "parameterValue": "/fd \"SHA256\""
+                    },
+                    {
+                        "parameterName": "PageHash",
+                        "parameterValue": "/NPH"
+                    },
+                    {
+                        "parameterName": "TimeStamp",
+                        "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                },
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolVerify",
+                    "parameters": [ ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                }
+            ]
+          SessionTimeout: 20
+      
+      # Pack
+      - task: DotNetCoreCLI@2
+        displayName: 'pack OpenAPI'
+        inputs:
+          command: pack
+          projects: src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+          arguments: '-o $(Build.ArtifactStagingDirectory)/Nugets --configuration $(BuildConfiguration) --no-build --include-symbols --include-source /p:SymbolPackageFormat=snupkg'
+      
+      # Pack
+      - task: DotNetCoreCLI@2
+        displayName: 'pack Readers'
+        inputs:
+          command: pack
+          projects: src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+          arguments: '-o $(Build.ArtifactStagingDirectory)/Nugets --configuration $(BuildConfiguration) --no-build --include-symbols --include-source /p:SymbolPackageFormat=snupkg'
+      
+      # Pack
+      - task: DotNetCoreCLI@2
+        displayName: 'pack Hidi'
+        inputs:
+          command: pack
+          projects: src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+          arguments: '-o $(Build.ArtifactStagingDirectory)/Nugets --configuration $(BuildConfiguration) --no-build --include-symbols --include-source /p:SymbolPackageFormat=snupkg'
+      
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: 'ESRP CodeSigning Nuget Packages'
+        inputs:
+          ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+          FolderPath: '$(Build.ArtifactStagingDirectory)'
+          Pattern: '*.nupkg'
+          signConfigType: inlineSignParams
+          inlineOperation: |
+            [
+                {
+                    "keyCode": "CP-401405",
+                    "operationSetCode": "NuGetSign",
+                    "parameters": [ ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                },
+                {
+                    "keyCode": "CP-401405",
+                    "operationSetCode": "NuGetVerify",
+                    "parameters": [ ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                }
+            ]
+          SessionTimeout: 20
+
+      - task: PowerShell@2
+        displayName: "Get Hidi's version-number from .csproj"
+        inputs:
+          targetType: 'inline'
+          script: |
+              $xml = [Xml] (Get-Content .\src\Microsoft.OpenApi.Hidi\Microsoft.OpenApi.Hidi.csproj)
+              $version = $xml.Project.PropertyGroup.Version
+              echo $version
+              echo "##vso[task.setvariable variable=version]$version"  
+
+      # publish hidi as an .exe
+      - task: DotNetCoreCLI@2
+        inputs:
+          command: 'publish'
+          arguments: -c Release --runtime win-x64 /p:PublishSingleFile=true --self-contained --output $(Build.ArtifactStagingDirectory)/Microsoft.OpenApi.Hidi-v$(version) --no-dependencies
+          projects: 'src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj'
+          publishWebProjects: False
+          zipAfterPublish: false 
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifact: Hidi'
+        inputs: 
+          ArtifactName: Microsoft.OpenApi.Hidi-v$(version)
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)/Microsoft.OpenApi.Hidi-v$(version)'
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifact: Nugets'
+        inputs:
+          ArtifactName: Nugets
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)/Nugets'
+
+- stage: deploy
+  condition: and(contains(variables['build.sourceBranch'], 'refs/heads/vnext'), succeeded())
+  dependsOn: build
+  jobs:
+    - deployment: deploy
+      environment: nuget-org
+      strategy:
+        runOnce:
+          deploy:
+            pool:
+              vmImage: ubuntu-latest
+            steps:
+            - task: DownloadPipelineArtifact@2
+              displayName: Download nupkg from artifacts
+              inputs:
+                artifact: Nugets
+                source: current
+            - task: NuGetCommand@2
+              displayName: 'NuGet push'
+              inputs:
+                command: push
+                packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.*.nupkg'
+                nuGetFeedType: external
+                publishFeedCredentials: 'OpenAPI Nuget Connection'

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -45,12 +45,6 @@ stages:
           inputType: CmdLine
           cmdLineArgs: '/F:$(Build.SourcesDirectory)/test /T:9 /Sev:"1|2" /PE:2 /O:poli_result_test.xml'
 
-      - task: PoliCheck@1
-        displayName: 'PoliCheck for /tool'
-        inputs:
-          inputType: CmdLine
-          cmdLineArgs: '/F:$(Build.SourcesDirectory)/tool /T:9 /Sev:"1|2" /PE:2 /O:poli_result_tool.xml'
-          
       # Install the nuget tool.
       - task: NuGetToolInstaller@0
         displayName: 'Use NuGet >=5.2.0'

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -223,7 +223,7 @@ stages:
         displayName: publish Hidi as executable
         inputs:
           command: 'publish'
-          arguments: -c Release --runtime win-x64 /p:PublishSingleFile=true --self-contained --output $(Build.ArtifactStagingDirectory)/Microsoft.OpenApi.Hidi-v$(hidiversion) --no-dependencies
+          arguments: -c Release --runtime win-x64 /p:PublishSingleFile=true --self-contained --output $(Build.ArtifactStagingDirectory)/Microsoft.OpenApi.Hidi-v$(hidiversion) -p:PublishTrimmed=true
           projects: 'src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj'
           publishWebProjects: False
           zipAfterPublish: false 

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -7,14 +7,16 @@ trigger:
   branches:
     include:
       - master
-pr: none
+      - vnext
+pr:
+  branches:
+    include:
+      - master
+      - vnext
 
 pool:
   name: Azure Pipelines
   vmImage: windows-latest
-  demands:
-  - msbuild
-  - vstest
 
 variables:
   buildPlatform: 'Any CPU'

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -228,7 +228,7 @@ stages:
           publishWebProjects: False
           zipAfterPublish: false 
 
-      - task: CopyFile@2
+      - task: CopyFiles@2
         displayName: Prepare staging folder for upload
         inputs:
          targetFolder: $(Build.ArtifactStagingDirectory)/Nugets

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -216,22 +216,17 @@ stages:
               $xml = [Xml] (Get-Content .\src\Microsoft.OpenApi.Hidi\Microsoft.OpenApi.Hidi.csproj)
               $version = $xml.Project.PropertyGroup.Version
               echo $version
-              echo "##vso[task.setvariable variable=version]$version"  
+              echo "##vso[task.setvariable variable=hidiversion]$version"  
 
       # publish hidi as an .exe
       - task: DotNetCoreCLI@2
+        displayName: publish Hidi as executable
         inputs:
           command: 'publish'
-          arguments: -c Release --runtime win-x64 /p:PublishSingleFile=true --self-contained --output $(Build.ArtifactStagingDirectory)/Microsoft.OpenApi.Hidi-v$(version) --no-dependencies
+          arguments: -c Release --runtime win-x64 /p:PublishSingleFile=true --self-contained --output $(Build.ArtifactStagingDirectory)/Microsoft.OpenApi.Hidi-v$(hidiversion) --no-dependencies
           projects: 'src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj'
           publishWebProjects: False
           zipAfterPublish: false 
-
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifact: Hidi'
-        inputs: 
-          ArtifactName: Microsoft.OpenApi.Hidi-v$(version)
-          PathtoPublish: '$(Build.ArtifactStagingDirectory)/Microsoft.OpenApi.Hidi-v$(version)'
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact: Nugets'
@@ -239,11 +234,96 @@ stages:
           ArtifactName: Nugets
           PathtoPublish: '$(Build.ArtifactStagingDirectory)/Nugets'
 
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifact: Hidi'
+        inputs: 
+          ArtifactName: Microsoft.OpenApi.Hidi-v$(hidiversion)
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)/Microsoft.OpenApi.Hidi-v$(hidiversion)'
+
 - stage: deploy
   condition: and(contains(variables['build.sourceBranch'], 'refs/heads/vnext'), succeeded())
   dependsOn: build
   jobs:
-    - deployment: deploy
+    - deployment: deploy_hidi
+      dependsOn: []
+      environment: nuget-org
+      strategy:
+        runOnce:
+          deploy:
+            pool:
+              vmImage: ubuntu-latest
+            steps:
+            - task: DownloadPipelineArtifact@2
+              displayName: Download nupkg from artifacts
+              inputs:
+                artifact: Nugets
+                source: current
+            # TODO update that script so it looks at the artifact name (name starts with) rather than a fixed index
+            - powershell: |
+                $url = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$env:SYSTEM_TEAMPROJECTID/_apis/build/builds/$env:BUILD_BUILDID/artifacts?api-version=4.1"
+                Write-Host "URL: $url"
+                $pipeline = Invoke-RestMethod -Uri $url -Headers @{
+                Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN"
+                }
+                Write-Host "artifactName:" ($artifactName = $Pipeline.value.name[1])   
+                #Set Variable $artifactName
+                Write-Host "##vso[task.setvariable variable=artifactName; isSecret=false; isOutput=true;]$artifactName"
+                displayName: 'Fetch Artifact Name'
+            - task: DownloadPipelineArtifact@2
+              displayName: Download hidi executable from artifacts
+              inputs:
+                artifact: $(artifactName)
+                source: current
+            - task: NuGetCommand@2
+              displayName: 'NuGet push'
+              inputs:
+                command: push
+                packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.Hidi.*.nupkg'
+                nuGetFeedType: external
+                publishFeedCredentials: 'OpenAPI Nuget Connection'
+            - task: GitHubRelease@1
+              displayName: 'GitHub release (create)'
+              inputs:
+                gitHubConnection: 'Github-MaggieKimani1'
+                tagSource: userSpecifiedTag
+                tag: '$(artifactName)'
+                title: '$(artifactName)'
+                releaseNotesSource: inline
+                assets: '$(System.DefaultWorkingDirectory)\**\*.exe'
+                changeLogType: issueBased
+    
+    - deployment: deploy_lib
+      dependsOn: []
+      environment: nuget-org
+      strategy:
+        runOnce:
+          deploy:
+            pool:
+              vmImage: ubuntu-latest
+            steps:
+            - task: DownloadPipelineArtifact@2
+              displayName: Download nupkg from artifacts
+              inputs:
+                artifact: Nugets
+                source: current
+            - powershell: |
+                $fileNames = "$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.Hidi.*.nupkg", "$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.Readers.*.nupkg", "$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.Workbench.*.nupkg"
+                foreach($fileName in $fileNames) {
+                  if(Test-Path $fileName) {
+                    rm $fileName -Verbose
+                  }
+                }
+              displayName: remove other nupkgs to avoid duplication
+            - task: NuGetCommand@2
+              displayName: 'NuGet push'
+              inputs:
+                command: push
+                packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.*.nupkg'
+                nuGetFeedType: external
+                publishFeedCredentials: 'OpenAPI Nuget Connection'
+
+    - deployment: deploy_readers
+      dependsOn: deploy_lib
       environment: nuget-org
       strategy:
         runOnce:
@@ -260,6 +340,6 @@ stages:
               displayName: 'NuGet push'
               inputs:
                 command: push
-                packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.*.nupkg'
+                packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.Readers.*.nupkg'
                 nuGetFeedType: external
                 publishFeedCredentials: 'OpenAPI Nuget Connection'


### PR DESCRIPTION
This PR pushes multiple improvements to the pipeline definition:

- Swaps ms build and vstest tasks by dotnet cli, to prepare an eventual transition to an ubuntu agent (performance) and for clarity
- Adds policheck, credscan, binskim, and antimalware scan tasks (compliance)
- Adds a deploy stage to avoid relying on the older release management, and use the same approbation rules defined in the environment across projects.

One thing I haven't included is the "has the version been bumped test" because I think further changes should be done to this pipeline:

- The deploy job should be splat into 3 jobs (deploy open API, deploy readers, deploy hidi) so each module can be deployed indenpendently from one another.
- Before each of those jobs, should be a reflective "check-openapi/reader/hidi version has been bumped" job that'd fail in case this was forgotten.

https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=68725&view=results