### PR TITLE
Use await keyword in our asynchronous operation to prevent deadlocks

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -101,12 +101,12 @@ namespace Microsoft.OpenApi.Hidi
                 // Parsing OpenAPI file
                 stopwatch.Start();
                 logger.LogTrace("Parsing OpenApi file");
-                var result = new OpenApiStreamReader(new OpenApiReaderSettings
+                var result = await new OpenApiStreamReader(new OpenApiReaderSettings
                 {
                     ReferenceResolution = resolveexternal ? ReferenceResolutionSetting.ResolveAllReferences : ReferenceResolutionSetting.ResolveLocalReferences,
                     RuleSet = ValidationRuleSet.GetDefaultRuleSet()
                 }
-                ).ReadAsync(stream).GetAwaiter().GetResult();
+                ).ReadAsync(stream);
 
                 document = result.OpenApiDocument;
                 stopwatch.Stop();


### PR DESCRIPTION
Fixes #775 