### PR TITLE
Better error handling

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -128,10 +128,13 @@ namespace Microsoft.OpenApi.Hidi
                 var context = result.OpenApiDiagnostic;
                 if (context.Errors.Count > 0)
                 {
+                    logger.LogTrace("{timestamp}ms: Parsed OpenAPI with errors. {count} paths found.", stopwatch.ElapsedMilliseconds, document.Paths.Count);
+
                     var errorReport = new StringBuilder();
 
                     foreach (var error in context.Errors)
                     {
+                        logger.LogError("OpenApi Parsing error: {message}", error.ToString());
                         errorReport.AppendLine(error.ToString());
                     }
                     logger.LogError($"{stopwatch.ElapsedMilliseconds}ms: OpenApi Parsing errors {string.Join(Environment.NewLine, context.Errors.Select(e => e.Message).ToArray())}");
@@ -282,9 +285,9 @@ namespace Microsoft.OpenApi.Hidi
                 catch (HttpRequestException ex)
                 {
 #if DEBUG
-                    logger.LogCritical(ex, $"Could not download the file at {input}, reason: {ex.Message}");
+                    logger.LogCritical(ex, "Could not download the file at {inputPath}, reason: {exMessage}", input, ex.Message);
 #else
-                    logger.LogCritical($"Could not download the file at {input}, reason: {ex.Message}", input, ex.Message);
+                    logger.LogCritical( "Could not download the file at {inputPath}, reason: {exMessage}", input, ex.Message);
 #endif
                     return null;
                 }
@@ -305,9 +308,9 @@ namespace Microsoft.OpenApi.Hidi
                     ex is NotSupportedException)
                 {
 #if DEBUG
-                    logger.LogCritical(ex, $"Could not open the file at {input}, reason: {ex.Message}");
+                    logger.LogCritical(ex, "Could not open the file at {inputPath}, reason: {exMessage}", input, ex.Message);
 #else
-                    logger.LogCritical($"Could not open the file at {input}, reason: {ex.Message}");
+                    logger.LogCritical("Could not open the file at {inputPath}, reason: {exMessage}", input, ex.Message);
 #endif
                     return null;
                 }

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -49,42 +49,18 @@ namespace Microsoft.OpenApi.Hidi
             {
                 if (string.IsNullOrEmpty(openapi) && string.IsNullOrEmpty(csdl))
                 {
-                    throw new ArgumentNullException("Please input a file path");
+                    throw new ArgumentException("Please input a file path");
                 }
-            }
-            catch (ArgumentNullException ex)
-            {
-#if DEBUG
-                logger.LogCritical(ex, ex.Message);
-#else
-                logger.LogCritical(ex.Message);
-#endif
-                return;
-            }
-            try
-            {
                 if(output == null)
                 {
-                    throw new ArgumentException(nameof(output));
+                    throw new ArgumentNullException(nameof(output));
                 }
-            }
-            catch (ArgumentException ex)
-            {
-#if DEBUG
-                logger.LogCritical(ex, ex.Message);
-#else
-                logger.LogCritical(ex.Message);
-#endif
-                return;
-            }
-            try
-            {
                 if (output.Exists)
                 {
                     throw new IOException($"The file {output} already exists. Please input a new file path.");
                 }
             }
-            catch (IOException ex)
+            catch (Exception ex)
             {
 #if DEBUG  
                 logger.LogCritical(ex, ex.Message);

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -353,7 +353,6 @@ namespace Microsoft.OpenApi.Hidi
                     foreach (var error in context.Errors)
                     {
                         logger.LogError("OpenApi Parsing error: {message}", error.ToString());
-                        Console.WriteLine(error.ToString());
                     }
                 }
 
@@ -362,7 +361,7 @@ namespace Microsoft.OpenApi.Hidi
                 walker.Walk(document);
 
                 logger.LogTrace("Finished walking through the OpenApi document. Generating a statistics report..");
-                Console.WriteLine(statsVisitor.GetStatisticsReport());
+                logger.LogInformation(statsVisitor.GetStatisticsReport());
             }
             catch(Exception ex)
             {
@@ -371,6 +370,7 @@ namespace Microsoft.OpenApi.Hidi
 #else
                 logger.LogCritical(ex.Message);
 #endif
+                return;
             }
 
         }

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -28,7 +28,7 @@ namespace Microsoft.OpenApi.Hidi
 {
     public class OpenApiService
     {
-        public static async Task ProcessOpenApiDocument(
+        public static async Task<int> ProcessOpenApiDocument(
             string openapi,
             string csdl,
             FileInfo output,
@@ -174,6 +174,8 @@ namespace Microsoft.OpenApi.Hidi
                 logger.LogTrace($"Finished serializing in {stopwatch.ElapsedMilliseconds}ms");
 
                 textWriter.Flush();
+
+                return 0;
             }
             catch (Exception ex)
             {
@@ -182,7 +184,7 @@ namespace Microsoft.OpenApi.Hidi
 #else
                 logger.LogCritical(ex.Message);
 #endif
-                return;
+                return 1;
             }            
         }
 
@@ -318,7 +320,7 @@ namespace Microsoft.OpenApi.Hidi
             return requestUrls;
         }
 
-        internal static async Task ValidateOpenApiDocument(string openapi, LogLevel loglevel, CancellationToken cancellationToken)
+        internal static async Task<int> ValidateOpenApiDocument(string openapi, LogLevel loglevel, CancellationToken cancellationToken)
         {
             var logger = ConfigureLoggerInstance(loglevel);
 
@@ -352,6 +354,8 @@ namespace Microsoft.OpenApi.Hidi
 
                 logger.LogTrace("Finished walking through the OpenApi document. Generating a statistics report..");
                 logger.LogInformation(statsVisitor.GetStatisticsReport());
+
+                return 0;
             }
             catch(Exception ex)
             {
@@ -360,7 +364,7 @@ namespace Microsoft.OpenApi.Hidi
 #else
                 logger.LogCritical(ex.Message);
 #endif
-                return;
+                return 1;
             }
 
         }

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -55,7 +56,7 @@ namespace Microsoft.OpenApi.Hidi
                 logLevelOption
             };
 
-            validateCommand.SetHandler<string, LogLevel>(OpenApiService.ValidateOpenApiDocument, descriptionOption, logLevelOption);
+            validateCommand.SetHandler<string, LogLevel, CancellationToken>(OpenApiService.ValidateOpenApiDocument, descriptionOption, logLevelOption);
 
             var transformCommand = new Command("transform")
             {
@@ -72,7 +73,7 @@ namespace Microsoft.OpenApi.Hidi
                 resolveExternalOption,
             };
 
-            transformCommand.SetHandler<string, string, FileInfo, OpenApiSpecVersion?, OpenApiFormat?, LogLevel, bool, bool, string, string, string> (
+            transformCommand.SetHandler<string, string, FileInfo, OpenApiSpecVersion?, OpenApiFormat?, LogLevel, bool, bool, string, string, string, CancellationToken> (
                 OpenApiService.ProcessOpenApiDocument, descriptionOption, csdlOption, outputOption, versionOption, formatOption, logLevelOption, inlineOption, resolveExternalOption, filterByOperationIdsOption, filterByTagsOption, filterByCollectionOption);
 
             rootCommand.Add(transformCommand);


### PR DESCRIPTION
Fixes #784
- Passes the cancellation token from the system.command line host to async APIs to avoid getting task cancelled exceptions when users press ctrl + c
- Formats the logging to use templates instead of doing string interpolation so logging APIs can do sampling and metrics