### PR TITLE
Add --clean-output parameter to allow overwriting existing files

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -31,6 +31,7 @@ namespace Microsoft.OpenApi.Hidi
             string openapi,
             string csdl,
             FileInfo output,
+            bool cleanoutput,
             OpenApiSpecVersion? version,
             OpenApiFormat? format,
             LogLevel loglevel,
@@ -69,6 +70,10 @@ namespace Microsoft.OpenApi.Hidi
             }
             try
             {
+                if (cleanoutput)
+                {
+                    output.Delete();
+                }
                 if (output.Exists)
                 {
                     throw new IOException("The file you're writing to already exists. Please input a new file path.");

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -56,7 +56,7 @@ namespace Microsoft.OpenApi.Hidi
                 {
                     throw new ArgumentNullException(nameof(output));
                 }
-                if (cleanoutput)
+                if (cleanoutput && output.Exists)
                 {
                     output.Delete();
                 }

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -25,6 +25,9 @@ namespace Microsoft.OpenApi.Hidi
             var outputOption = new Option<FileInfo>("--output", () => new FileInfo("./output"), "The output directory path for the generated file.") { Arity = ArgumentArity.ZeroOrOne };
             outputOption.AddAlias("-o");
 
+            var cleanOutputOption = new Option<bool>("--clean-output", "Overwrite an existing file");
+            cleanOutputOption.AddAlias("-co");
+
             var versionOption = new Option<OpenApiSpecVersion?>("--version", "OpenAPI specification version");
             versionOption.AddAlias("-v");
 
@@ -62,6 +65,7 @@ namespace Microsoft.OpenApi.Hidi
                 descriptionOption,
                 csdlOption,
                 outputOption,
+                cleanOutputOption,
                 versionOption,
                 formatOption,
                 logLevelOption,               
@@ -72,8 +76,8 @@ namespace Microsoft.OpenApi.Hidi
                 resolveExternalOption,
             };
 
-            transformCommand.SetHandler<string, string, FileInfo, OpenApiSpecVersion?, OpenApiFormat?, LogLevel, bool, bool, string, string, string> (
-                OpenApiService.ProcessOpenApiDocument, descriptionOption, csdlOption, outputOption, versionOption, formatOption, logLevelOption, inlineOption, resolveExternalOption, filterByOperationIdsOption, filterByTagsOption, filterByCollectionOption);
+            transformCommand.SetHandler<string, string, FileInfo, bool, OpenApiSpecVersion?, OpenApiFormat?, LogLevel, bool, bool, string, string, string> (
+                OpenApiService.ProcessOpenApiDocument, descriptionOption, csdlOption, outputOption, cleanOutputOption, versionOption, formatOption, logLevelOption, inlineOption, resolveExternalOption, filterByOperationIdsOption, filterByTagsOption, filterByCollectionOption);
 
             rootCommand.Add(transformCommand);
             rootCommand.Add(validateCommand);


### PR DESCRIPTION
Fixes #783 

Currently, when a user provides a file path that already exists in their local file system as output in Hidi, it returns an error and tells them to provide a new path. This has been simplified by allowing one to use `--clean-ouput` parameter abbreviated as `-co` when running the transform command which overwrites the existing file by deleting its contents and replacing it with the new file.