### PR TITLE
Fixed issues related to merge conflicts

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using System.CommandLine;
 using System.IO;
 using System.Threading;
@@ -11,7 +12,7 @@ namespace Microsoft.OpenApi.Hidi
 {
     static class Program
     {
-        static async Task<int> Main(string[] args)
+        static async Task Main(string[] args)
         {
             var rootCommand = new RootCommand() {
             };
@@ -32,7 +33,7 @@ namespace Microsoft.OpenApi.Hidi
             var formatOption = new Option<OpenApiFormat?>("--format", "File format");
             formatOption.AddAlias("-f");
 
-            var logLevelOption = new Option<LogLevel>("--loglevel", () => LogLevel.Warning, "The log level to use when logging messages to the main output.");
+            var logLevelOption = new Option<LogLevel>("--loglevel", () => LogLevel.Information, "The log level to use when logging messages to the main output.");
             logLevelOption.AddAlias("-ll");
 
             var filterByOperationIdsOption = new Option<string>("--filter-by-operationids", "Filters OpenApiDocument by OperationId(s) provided");
@@ -80,7 +81,10 @@ namespace Microsoft.OpenApi.Hidi
             rootCommand.Add(validateCommand);
 
             // Parse the incoming args and invoke the handler
-            return await rootCommand.InvokeAsync(args);
+            await rootCommand.InvokeAsync(args);
+
+            //// Wait for logger to write messages to the console before exiting
+            await Task.Delay(10);
         }
     }
 }

--- a/src/Microsoft.OpenApi.Hidi/appsettings.json
+++ b/src/Microsoft.OpenApi.Hidi/appsettings.json
@@ -1,7 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Debug"
-    }
-  }
-}


### PR DESCRIPTION
Some of the logic around default versions got broken during the merging to vnext.
Also, the mysteriously missing error messages was caused by a timing issue where the console application would shut down before the message got written to the console.  By adding a 10ms delay on shutdown, the console has time to write the message out.