### PR TITLE
Fixes failing script for Hidi exe

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -271,7 +271,7 @@ stages:
                 source: current
             - pwsh: |
                 $artifactName = Get-ChildItem -Path $(Pipeline.Workspace) -Filter Microsoft.OpenApi.Hidi-* -recurse | select -First 1
-                $artifactVersion= $artifactName -replace "Microsoft.OpenApi.Hidi-", ""                  
+                $artifactVersion= $artifactName -replace "Microsoft.OpenApi.Hidi-", ""
                 #Set Variable $artifactName and $artifactVersion
                 Write-Host "##vso[task.setvariable variable=artifactVersion; isSecret=false; isOutput=true]$artifactVersion"
                 Write-Host "##vso[task.setvariable variable=artifactName; isSecret=false; isOutput=true]$artifactName.FullName"


### PR DESCRIPTION
Fixes #729 

This PR:
- Updates the failing Powershell script that we use to extract package name and version from downloaded artifacts in the release stage to be passed as release title and tags in the .exe release task. 
- Updates the Github release task to fetch Hidi's .exe from the artifact directory and publish it as an asset

### Screenshot
![image](https://user-images.githubusercontent.com/36787645/158626871-6d77c912-b18d-4555-83f5-3823ca43dfbd.png)
