### PR TITLE
Added CSDL filter for entitysets and singletons

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/CsdlFilter.xslt
+++ b/src/Microsoft.OpenApi.Hidi/CsdlFilter.xslt
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:edm="http://docs.oasis-open.org/odata/ns/edm"
+    xmlns:msxsl="urn:schemas-microsoft-com:xslt" exclude-result-prefixes="msxsl"
+>
+    <xsl:output method="xml" indent="yes"/>
+
+    <xsl:param name="entitySetOrSingleton" select="'serviceappointments'"></xsl:param>
+    
+    <xsl:template match="edm:EntityContainer">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | edm:EntitySet[contains($entitySetOrSingleton,@Name)] | edm:Singleton[contains($entitySetOrSingleton,@Name)]"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -32,6 +32,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="CsdlFilter.xslt" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="CsdlFilter.xslt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -24,6 +24,10 @@ using Microsoft.OpenApi.Validations;
 using Microsoft.OpenApi.Writers;
 using static Microsoft.OpenApi.Hidi.OpenApiSpecVersionHelper;
 using System.Threading;
+using System.Xml.Xsl;
+using System.Xml;
+using System.Runtime.CompilerServices;
+using System.Reflection;
 
 namespace Microsoft.OpenApi.Hidi
 {
@@ -35,6 +39,7 @@ namespace Microsoft.OpenApi.Hidi
         public static async Task<int> TransformOpenApiDocument(
             string openapi,
             string csdl,
+            string csdlFilter,
             FileInfo output,
             bool cleanoutput,
             string? version,
@@ -85,6 +90,13 @@ namespace Microsoft.OpenApi.Hidi
                         openApiVersion = version != null ? TryParseOpenApiSpecVersion(version) : OpenApiSpecVersion.OpenApi3_0;
 
                         stream = await GetStream(csdl, logger, cancellationToken);
+
+                        if (!string.IsNullOrEmpty(csdlFilter))
+                        {
+                            XslCompiledTransform transform = GetFilterTransform();
+                            stream = ApplyFilter(csdl, csdlFilter, transform);
+                            stream.Position = 0;
+                        }
                         document = await ConvertCsdlToOpenApi(stream);
                         stopwatch.Stop();
                         logger.LogTrace("{timestamp}ms: Generated OpenAPI with {paths} paths.", stopwatch.ElapsedMilliseconds, document.Paths.Count);
@@ -210,6 +222,31 @@ namespace Microsoft.OpenApi.Hidi
             }            
         }
 
+        private static XslCompiledTransform GetFilterTransform()
+        {
+            XslCompiledTransform transform = new();
+            Assembly assembly = typeof(OpenApiService).GetTypeInfo().Assembly;
+            Stream xslt = assembly.GetManifestResourceStream("Microsoft.OpenApi.Hidi.CsdlFilter.xslt");
+            transform.Load(new XmlTextReader(new StreamReader(xslt)));
+            return transform;
+        }
+
+        private static Stream ApplyFilter(string csdl, string entitySetOrSingleton, XslCompiledTransform transform)
+        {
+            Stream stream;
+            StreamReader inputReader = new(csdl);
+            XmlReader inputXmlReader = XmlReader.Create(inputReader);
+            MemoryStream filteredStream = new();
+            StreamWriter writer = new(filteredStream);
+            XsltArgumentList args = new();
+            args.AddParam("entitySetOrSingleton", "", entitySetOrSingleton);
+            transform.Transform(inputXmlReader, args, writer);
+            stream = filteredStream;
+            return stream;
+        }
+
+
+
         /// <summary>
         /// Implementation of the validate command
         /// </summary>
@@ -306,8 +343,8 @@ namespace Microsoft.OpenApi.Hidi
                 EnableDiscriminatorValue = false,
                 EnableDerivedTypesReferencesForRequestBody = false,
                 EnableDerivedTypesReferencesForResponses = false,
-                ShowRootPath = true,
-                ShowLinks = true
+                ShowRootPath = false,
+                ShowLinks = false
             };
             OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
 

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -24,6 +24,9 @@ namespace Microsoft.OpenApi.Hidi
             var csdlOption = new Option<string>("--csdl", "Input CSDL file path or URL");
             csdlOption.AddAlias("-cs");
 
+            var csdlFilterOption = new Option<string>("--csdlFilter", "Name of EntitySet or Singleton to filter CSDL on");
+            csdlOption.AddAlias("-csf");
+
             var outputOption = new Option<FileInfo>("--output", () => new FileInfo("./output"), "The output directory path for the generated file.") { Arity = ArgumentArity.ZeroOrOne };
             outputOption.AddAlias("-o");
 
@@ -66,6 +69,7 @@ namespace Microsoft.OpenApi.Hidi
             {
                 descriptionOption,
                 csdlOption,
+                csdlFilterOption,
                 outputOption,
                 cleanOutputOption,
                 versionOption,
@@ -78,8 +82,8 @@ namespace Microsoft.OpenApi.Hidi
                 resolveExternalOption,
             };
 
-            transformCommand.SetHandler<string, string, FileInfo, bool, string?, OpenApiFormat?, LogLevel, bool, bool, string, string, string, CancellationToken> (
-                OpenApiService.TransformOpenApiDocument, descriptionOption, csdlOption, outputOption, cleanOutputOption, versionOption, formatOption, logLevelOption, inlineOption, resolveExternalOption, filterByOperationIdsOption, filterByTagsOption, filterByCollectionOption);
+            transformCommand.SetHandler<string, string, string, FileInfo, bool, string?, OpenApiFormat?, LogLevel, bool, bool, string, string, string, CancellationToken> (
+                OpenApiService.TransformOpenApiDocument, descriptionOption, csdlOption, csdlFilterOption, outputOption, cleanOutputOption, versionOption, formatOption, logLevelOption, inlineOption, resolveExternalOption, filterByOperationIdsOption, filterByTagsOption, filterByCollectionOption);
 
             rootCommand.Add(transformCommand);
             rootCommand.Add(validateCommand);

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -24,8 +24,8 @@ namespace Microsoft.OpenApi.Hidi
             var csdlOption = new Option<string>("--csdl", "Input CSDL file path or URL");
             csdlOption.AddAlias("-cs");
 
-            var csdlFilterOption = new Option<string>("--csdlFilter", "Name of EntitySet or Singleton to filter CSDL on");
-            csdlOption.AddAlias("-csf");
+            var csdlFilterOption = new Option<string>("--csdl-filter", "Comma delimited list of EntitySets or Singletons to filter CSDL on. e.g. tasks,accounts");
+            csdlFilterOption.AddAlias("-csf");
 
             var outputOption = new Option<FileInfo>("--output", () => new FileInfo("./output"), "The output directory path for the generated file.") { Arity = ArgumentArity.ZeroOrOne };
             outputOption.AddAlias("-o");
@@ -42,13 +42,13 @@ namespace Microsoft.OpenApi.Hidi
             var logLevelOption = new Option<LogLevel>("--loglevel", () => LogLevel.Information, "The log level to use when logging messages to the main output.");
             logLevelOption.AddAlias("-ll");
 
-            var filterByOperationIdsOption = new Option<string>("--filter-by-operationids", "Filters OpenApiDocument by OperationId(s) provided");
+            var filterByOperationIdsOption = new Option<string>("--filter-by-operationids", "Filters OpenApiDocument by comma delimited list of OperationId(s) provided");
             filterByOperationIdsOption.AddAlias("-op");
 
-            var filterByTagsOption = new Option<string>("--filter-by-tags", "Filters OpenApiDocument by Tag(s) provided");
+            var filterByTagsOption = new Option<string>("--filter-by-tags", "Filters OpenApiDocument by comma delimited list of Tag(s) provided. Also accepts a single regex.");
             filterByTagsOption.AddAlias("-t");
 
-            var filterByCollectionOption = new Option<string>("--filter-by-collection", "Filters OpenApiDocument by Postman collection provided");
+            var filterByCollectionOption = new Option<string>("--filter-by-collection", "Filters OpenApiDocument by Postman collection provided. Provide path to collection file.");
             filterByCollectionOption.AddAlias("-c");
 
             var inlineLocalOption = new Option<bool>("--inlineLocal", "Inline local $ref instances");

--- a/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
+++ b/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SharpYaml" Version="1.9.0" />
-    <PackageReference Include="Verify" Version="16.4.3" />
-    <PackageReference Include="Verify.Xunit" Version="16.4.3" />
+    <PackageReference Include="Verify" Version="16.4.4" />
+    <PackageReference Include="Verify.Xunit" Version="16.4.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Microsoft.OpenApi.Tests/Services/OpenApiServiceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Services/OpenApiServiceTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.OpenApi.Tests.Services
 
             // Act
             var openApiDoc = await OpenApiService.ConvertCsdlToOpenApi(csdlStream);
-            var expectedPathCount = 6;
+            var expectedPathCount = 5;
 
             // Assert
             Assert.NotNull(openApiDoc);


### PR DESCRIPTION
When working with large CSDL files, it can take a long time to generate the OpenAPI document.  For performance reasons this update adds a filter parameter so that a user can select a subset of the CSDL document.  This is done by providing a comma delimited list of EntitySet and Singleton names that appear in the EntityContainer.

```shell
hidi transform -cs dataverse.csdl --csdlFilter "appointments,opportunities" -o appointmentsAndOpportunities.yaml -ll trace
```