### PR TITLE
[bugfix] Resolve local file reference with Schema type properly

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
@@ -75,18 +75,6 @@ namespace Microsoft.OpenApi.Readers.V3
                 var segments = reference.Split('#');
                 if (segments.Length == 1)
                 {
-                    // Either this is an external reference as an entire file
-                    // or a simple string-style reference for tag and security scheme.
-                    if (type == null)
-                    {
-                        // "$ref": "Pet.json"
-                        return new OpenApiReference
-                        {
-                            Type = type,
-                            ExternalResource = segments[0]
-                        };
-                    }
-
                     if (type == ReferenceType.Tag || type == ReferenceType.SecurityScheme)
                     {
                         return new OpenApiReference
@@ -95,6 +83,14 @@ namespace Microsoft.OpenApi.Readers.V3
                             Id = reference
                         };
                     }
+
+                    // Either this is an external reference as an entire file
+                    // or a simple string-style reference for tag and security scheme.
+                    return new OpenApiReference
+                    {
+                        Type = type,
+                        ExternalResource = segments[0]
+                    };
                 }
                 else if (segments.Length == 2)
                 {

--- a/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/ConvertToOpenApiReferenceV3Tests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/ConvertToOpenApiReferenceV3Tests.cs
@@ -108,5 +108,21 @@ namespace Microsoft.OpenApi.Readers.Tests
             reference.ExternalResource.Should().BeNull();
             reference.Id.Should().Be(id);
         }
+
+        [Fact]
+        public void ParseLocalFileReference()
+        {
+            // Arrange
+            var versionService = new OpenApiV3VersionService(Diagnostic);
+            var referenceType = ReferenceType.Schema;
+            var input = $"../schemas/collection.json";
+
+            // Act
+            var reference = versionService.ConvertToOpenApiReference(input, referenceType);
+
+            // Assert
+            reference.Type.Should().Be(referenceType);
+            reference.ExternalResource.Should().Be(input);
+        }
     }
 }


### PR DESCRIPTION
Before the changes, if you pass `$ref: '../../smth'`, `ReferenceType` is found for the `OpenApiV3VersionService.ConvertToOpenApiReference()` call, and an error was thrown for every single openApiReference existing in the document (`The reference string '../schemas/api.json' has invalid format. [........]`)