### PR TITLE
Added support for Validation to produce warnings as well as errors

### DIFF
--- a/src/Microsoft.OpenApi.Readers/OpenApiDiagnostic.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiDiagnostic.cs
@@ -18,6 +18,11 @@ namespace Microsoft.OpenApi.Readers
         public IList<OpenApiError> Errors { get; set; } = new List<OpenApiError>();
 
         /// <summary>
+        /// List of all warnings
+        /// </summary>
+        public IList<OpenApiError> Warnings { get; set; } = new List<OpenApiError>();
+
+        /// <summary>
         /// Open API specification version of the document parsed.
         /// </summary>
         public OpenApiSpecVersion SpecificationVersion { get; set; }

--- a/src/Microsoft.OpenApi.Readers/OpenApiYamlDocumentReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiYamlDocumentReader.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Extensions;
@@ -12,6 +13,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.Interface;
 using Microsoft.OpenApi.Readers.Services;
 using Microsoft.OpenApi.Services;
+using Microsoft.OpenApi.Validations;
 using SharpYaml.Serialization;
 
 namespace Microsoft.OpenApi.Readers
@@ -68,11 +70,16 @@ namespace Microsoft.OpenApi.Readers
             // Validate the document
             if (_settings.RuleSet != null && _settings.RuleSet.Rules.Count > 0)
             {
-                var errors = document.Validate(_settings.RuleSet);
-                foreach (var item in errors)
+                var openApiErrors = document.Validate(_settings.RuleSet);
+                foreach (var item in openApiErrors.Where(e => e is OpenApiValidatorError))
                 {
                     diagnostic.Errors.Add(item);
                 }
+                foreach (var item in openApiErrors.Where(e => e is OpenApiValidatorWarning))
+                {
+                    diagnostic.Warnings.Add(item);
+                }
+
             }
 
             return document;

--- a/src/Microsoft.OpenApi/Extensions/OpenApiElementExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiElementExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
@@ -25,7 +26,7 @@ namespace Microsoft.OpenApi.Extensions
             var validator = new OpenApiValidator(ruleSet);
             var walker = new OpenApiWalker(validator);
             walker.Walk(element);
-            return validator.Errors;
+            return validator.Errors.Cast<OpenApiError>().Union(validator.Warnings);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/IValidationContext.cs
+++ b/src/Microsoft.OpenApi/Validations/IValidationContext.cs
@@ -15,6 +15,12 @@ namespace Microsoft.OpenApi.Validations
         void AddError(OpenApiValidatorError error);
 
         /// <summary>
+        /// Register a warning with the validation context.
+        /// </summary>
+        /// <param name="warning">Warning to register.</param>
+        void AddWarning(OpenApiValidatorWarning warning);
+
+        /// <summary>
         /// Allow Rule to indicate validation error occured at a deeper context level.  
         /// </summary>
         /// <param name="segment">Identifier for context</param>

--- a/src/Microsoft.OpenApi/Validations/OpenApiValidatiorWarning.cs
+++ b/src/Microsoft.OpenApi/Validations/OpenApiValidatiorWarning.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.OpenApi.Exceptions;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Validations
+{    
+    /// <summary>
+     /// Warnings detected when validating an OpenAPI Element
+     /// </summary>
+    public class OpenApiValidatorWarning : OpenApiError
+    {
+        /// <summary>
+        /// Initializes the <see cref="OpenApiError"/> class.
+        /// </summary>
+        public OpenApiValidatorWarning(string ruleName, string pointer, string message) : base(pointer, message)
+        {
+            RuleName = ruleName;
+        }
+
+        /// <summary>
+        /// Name of rule that detected the error.
+        /// </summary>
+        public string RuleName { get; set; }
+    }
+
+}

--- a/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
+++ b/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
@@ -17,6 +17,7 @@ namespace Microsoft.OpenApi.Validations
     {
         private readonly ValidationRuleSet _ruleSet;
         private readonly IList<OpenApiValidatorError> _errors = new List<OpenApiValidatorError>();
+        private readonly IList<OpenApiValidatorWarning> _warnings = new List<OpenApiValidatorWarning>();
 
         /// <summary>
         /// Create a vistor that will validate an OpenAPIDocument
@@ -39,6 +40,17 @@ namespace Microsoft.OpenApi.Validations
         }
 
         /// <summary>
+        /// Gets the validation warnings.
+        /// </summary>
+        public IEnumerable<OpenApiValidatorWarning> Warnings
+        {
+            get
+            {
+                return _warnings;
+            }
+        }
+
+        /// <summary>
         /// Register an error with the validation context.
         /// </summary>
         /// <param name="error">Error to register.</param>
@@ -52,6 +64,19 @@ namespace Microsoft.OpenApi.Validations
             _errors.Add(error);
         }
 
+        /// <summary>
+        /// Register an error with the validation context.
+        /// </summary>
+        /// <param name="warning">Error to register.</param>
+        public void AddWarning(OpenApiValidatorWarning warning)
+        {
+            if (warning == null)
+            {
+                throw Error.ArgumentNull(nameof(warning));
+            }
+
+            _warnings.Add(warning);
+        }
 
         /// <summary>
         /// Execute validation rules against an <see cref="OpenApiDocument"/>

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiHeaderRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiHeaderRules.cs
@@ -10,6 +10,7 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiHeader"/>.
     /// </summary>
+    //Removed from Default Rules as this is not a MUST in OpenAPI
     [OpenApiRule]
     public static class OpenApiHeaderRules
     {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiMediaTypeRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiMediaTypeRules.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// Future versions of the example parsers should not try an infer types.
     /// Example validation should be done as a separate post reading step so all schemas can be fully available.
     /// </remarks>
-    //[OpenApiRule]
+    [OpenApiRule]
     public static class OpenApiMediaTypeRules
     {
         /// <summary>

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiSchemaRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiSchemaRules.cs
@@ -11,6 +11,7 @@ namespace Microsoft.OpenApi.Validations.Rules
     /// <summary>
     /// The validation rules for <see cref="OpenApiSchema"/>.
     /// </summary>
+    
     [OpenApiRule]
     public static class OpenApiSchemaRules
     {

--- a/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
@@ -77,7 +77,7 @@ namespace Microsoft.OpenApi.Validations.Rules
                 // If value is not a string and also not an object, there is a data mismatch.
                 if (!(value is OpenApiObject))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                         ruleName,
                         DataTypeMismatchedErrorMessage);
                     return;
@@ -117,7 +117,7 @@ namespace Microsoft.OpenApi.Validations.Rules
                 // If value is not a string and also not an array, there is a data mismatch.
                 if (!(value is OpenApiArray))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                         ruleName,
                         DataTypeMismatchedErrorMessage);
                     return;
@@ -141,7 +141,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             {
                 if (!(value is OpenApiInteger))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                         ruleName,
                         DataTypeMismatchedErrorMessage);
                 }
@@ -153,7 +153,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             {
                 if (!(value is OpenApiLong))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                        ruleName,
                        DataTypeMismatchedErrorMessage);
                 }
@@ -165,7 +165,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             {
                 if (!(value is OpenApiInteger))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                         ruleName,
                         DataTypeMismatchedErrorMessage);
                 }
@@ -177,7 +177,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             {
                 if (!(value is OpenApiFloat))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                         ruleName,
                         DataTypeMismatchedErrorMessage);
                 }
@@ -189,7 +189,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             {
                 if (!(value is OpenApiDouble))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                         ruleName,
                         DataTypeMismatchedErrorMessage);
                 }
@@ -201,7 +201,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             {
                 if (!(value is OpenApiDouble))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                         ruleName,
                         DataTypeMismatchedErrorMessage);
                 }
@@ -213,7 +213,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             {
                 if (!(value is OpenApiByte))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                         ruleName,
                         DataTypeMismatchedErrorMessage);
                 }
@@ -225,7 +225,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             {
                 if (!(value is OpenApiDate))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                         ruleName,
                         DataTypeMismatchedErrorMessage);
                 }
@@ -237,7 +237,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             {
                 if (!(value is OpenApiDateTime))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                         ruleName,
                         DataTypeMismatchedErrorMessage);
                 }
@@ -249,7 +249,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             {
                 if (!(value is OpenApiPassword))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                         ruleName,
                         DataTypeMismatchedErrorMessage);
                 }
@@ -261,7 +261,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             {
                 if (!(value is OpenApiString))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                         ruleName,
                         DataTypeMismatchedErrorMessage);
                 }
@@ -273,7 +273,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             {
                 if (!(value is OpenApiBoolean))
                 {
-                    context.CreateError(
+                    context.CreateWarning(
                         ruleName,
                         DataTypeMismatchedErrorMessage);
                 }

--- a/src/Microsoft.OpenApi/Validations/ValidationExtensions.cs
+++ b/src/Microsoft.OpenApi/Validations/ValidationExtensions.cs
@@ -23,5 +23,15 @@ namespace Microsoft.OpenApi.Validations
             OpenApiValidatorError error = new OpenApiValidatorError(ruleName, context.PathString, message);
             context.AddError(error);
         }
+
+        /// <summary>
+        /// Helper method to simplify validation rules
+        /// </summary>
+        public static void CreateWarning(this IValidationContext context, string ruleName, string message)
+        {
+            OpenApiValidatorWarning warning = new OpenApiValidatorWarning(ruleName, context.PathString, message);
+            context.AddWarning(warning);
+        }
+
     }
 }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -1085,6 +1085,7 @@ namespace Microsoft.OpenApi.Validations
     {
         string PathString { get; }
         void AddError(Microsoft.OpenApi.Validations.OpenApiValidatorError error);
+        void AddWarning(Microsoft.OpenApi.Validations.OpenApiValidatorWarning warning);
         void Enter(string segment);
         void Exit();
     }
@@ -1092,7 +1093,9 @@ namespace Microsoft.OpenApi.Validations
     {
         public OpenApiValidator(Microsoft.OpenApi.Validations.ValidationRuleSet ruleSet) { }
         public System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Validations.OpenApiValidatorError> Errors { get; }
+        public System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Validations.OpenApiValidatorWarning> Warnings { get; }
         public void AddError(Microsoft.OpenApi.Validations.OpenApiValidatorError error) { }
+        public void AddWarning(Microsoft.OpenApi.Validations.OpenApiValidatorWarning warning) { }
         public override void Visit(Microsoft.OpenApi.Interfaces.IOpenApiExtensible item) { }
         public override void Visit(Microsoft.OpenApi.Interfaces.IOpenApiExtension item) { }
         public override void Visit(Microsoft.OpenApi.Models.OpenApiCallback item) { }
@@ -1119,9 +1122,15 @@ namespace Microsoft.OpenApi.Validations
         public OpenApiValidatorError(string ruleName, string pointer, string message) { }
         public string RuleName { get; set; }
     }
+    public class OpenApiValidatorWarning : Microsoft.OpenApi.Models.OpenApiError
+    {
+        public OpenApiValidatorWarning(string ruleName, string pointer, string message) { }
+        public string RuleName { get; set; }
+    }
     public static class ValidationContextExtensions
     {
         public static void CreateError(this Microsoft.OpenApi.Validations.IValidationContext context, string ruleName, string message) { }
+        public static void CreateWarning(this Microsoft.OpenApi.Validations.IValidationContext context, string ruleName, string message) { }
     }
     public abstract class ValidationRule
     {
@@ -1188,6 +1197,7 @@ namespace Microsoft.OpenApi.Validations.Rules
     {
         public static Microsoft.OpenApi.Validations.ValidationRule<Microsoft.OpenApi.Models.OpenApiLicense> LicenseRequiredFields { get; }
     }
+    [Microsoft.OpenApi.Validations.Rules.OpenApiRule]
     public static class OpenApiMediaTypeRules
     {
         public static Microsoft.OpenApi.Validations.ValidationRule<Microsoft.OpenApi.Models.OpenApiMediaType> MediaTypeMismatchedDataType { get; }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiHeaderValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiHeaderValidationTests.cs
@@ -38,15 +38,16 @@ namespace Microsoft.OpenApi.Validations.Tests
             walker.Walk(header);
 
             errors = validator.Errors;
-            bool result = !errors.Any();
+            var warnings = validator.Warnings;
+            bool result = !warnings.Any();
 
             // Assert
             result.Should().BeFalse();
-            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
                 RuleHelpers.DataTypeMismatchedErrorMessage
             });
-            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {
                 "#/example",
             });
@@ -56,7 +57,7 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateExamplesShouldNotHaveDataTypeMismatchForSimpleSchema()
         {
             // Arrange
-            IEnumerable<OpenApiError> errors;
+            IEnumerable<OpenApiError> warnings;
 
             var header = new OpenApiHeader()
             {
@@ -108,18 +109,18 @@ namespace Microsoft.OpenApi.Validations.Tests
             var walker = new OpenApiWalker(validator);
             walker.Walk(header);
 
-            errors = validator.Errors;
-            bool result = !errors.Any();
+            warnings = validator.Warnings;
+            bool result = !warnings.Any();
 
             // Assert
             result.Should().BeFalse();
-            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
                 RuleHelpers.DataTypeMismatchedErrorMessage,
                 RuleHelpers.DataTypeMismatchedErrorMessage,
                 RuleHelpers.DataTypeMismatchedErrorMessage,
             });
-            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {
                 // #enum/0 is not an error since the spec allows
                 // representing an object using a string.

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiMediaTypeValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiMediaTypeValidationTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateExampleShouldNotHaveDataTypeMismatchForSimpleSchema()
         {
             // Arrange
-            IEnumerable<OpenApiError> errors;
+            IEnumerable<OpenApiError> warnings;
             var mediaType = new OpenApiMediaType()
             {
                 Example = new OpenApiInteger(55),
@@ -33,21 +33,20 @@ namespace Microsoft.OpenApi.Validations.Tests
 
             // Act
             var ruleset = ValidationRuleSet.GetDefaultRuleSet();
-            ruleset.Add(OpenApiMediaTypeRules.MediaTypeMismatchedDataType);
             var validator = new OpenApiValidator(ruleset);
             var walker = new OpenApiWalker(validator);
             walker.Walk(mediaType);
 
-            errors = validator.Errors;
-            bool result = !errors.Any();
+            warnings = validator.Warnings;
+            bool result = !warnings.Any();
 
             // Assert
             result.Should().BeFalse();
-            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
                 RuleHelpers.DataTypeMismatchedErrorMessage
             });
-            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {
                 "#/example",
             });
@@ -57,7 +56,7 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateExamplesShouldNotHaveDataTypeMismatchForSimpleSchema()
         {
             // Arrange
-            IEnumerable<OpenApiError> errors;
+            IEnumerable<OpenApiError> warnings;
 
             var mediaType = new OpenApiMediaType()
             {
@@ -105,23 +104,22 @@ namespace Microsoft.OpenApi.Validations.Tests
 
             // Act
             var ruleset = ValidationRuleSet.GetDefaultRuleSet();
-            ruleset.Add(OpenApiMediaTypeRules.MediaTypeMismatchedDataType);
             var validator = new OpenApiValidator(ruleset);
             var walker = new OpenApiWalker(validator);
             walker.Walk(mediaType);
 
-            errors = validator.Errors;
-            bool result = !errors.Any();
+            warnings = validator.Warnings;
+            bool result = !warnings.Any();
 
             // Assert
             result.Should().BeFalse();
-            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
                 RuleHelpers.DataTypeMismatchedErrorMessage,
                 RuleHelpers.DataTypeMismatchedErrorMessage,
                 RuleHelpers.DataTypeMismatchedErrorMessage,
             });
-            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {
                 // #enum/0 is not an error since the spec allows
                 // representing an object using a string.

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiParameterValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiParameterValidationTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateExampleShouldNotHaveDataTypeMismatchForSimpleSchema()
         {
             // Arrange
-            IEnumerable<OpenApiError> errors;
+            IEnumerable<OpenApiError> warnings;
             var parameter = new OpenApiParameter()
             {
                 Name = "parameter1",
@@ -84,16 +84,16 @@ namespace Microsoft.OpenApi.Validations.Tests
             var walker = new OpenApiWalker(validator);
             walker.Walk(parameter);
 
-            errors = validator.Errors;
-            bool result = !errors.Any();
+            warnings = validator.Warnings;
+            bool result = !warnings.Any();
 
             // Assert
             result.Should().BeFalse();
-            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
                 RuleHelpers.DataTypeMismatchedErrorMessage
             });
-            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {
                 "#/{parameter1}/example",
             });
@@ -103,7 +103,7 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateExamplesShouldNotHaveDataTypeMismatchForSimpleSchema()
         {
             // Arrange
-            IEnumerable<OpenApiError> errors;
+            IEnumerable<OpenApiError> warnings;
 
             var parameter = new OpenApiParameter()
             {
@@ -158,18 +158,18 @@ namespace Microsoft.OpenApi.Validations.Tests
             var walker = new OpenApiWalker(validator);
             walker.Walk(parameter);
 
-            errors = validator.Errors;
-            bool result = !errors.Any();
+            warnings = validator.Warnings;
+            bool result = !warnings.Any();
 
             // Assert
             result.Should().BeFalse();
-            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
                 RuleHelpers.DataTypeMismatchedErrorMessage,
                 RuleHelpers.DataTypeMismatchedErrorMessage,
                 RuleHelpers.DataTypeMismatchedErrorMessage,
             });
-            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {
                 // #enum/0 is not an error since the spec allows
                 // representing an object using a string.

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiSchemaValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiSchemaValidationTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateDefaultShouldNotHaveDataTypeMismatchForSimpleSchema()
         {
             // Arrange
-            IEnumerable<OpenApiError> errors;
+            IEnumerable<OpenApiError> warnings;
             var schema = new OpenApiSchema()
             {
                 Default = new OpenApiInteger(55),
@@ -33,16 +33,16 @@ namespace Microsoft.OpenApi.Validations.Tests
             var walker = new OpenApiWalker(validator);
             walker.Walk(schema);
 
-            errors = validator.Errors;
-            bool result = !errors.Any();
+            warnings = validator.Warnings;
+            bool result = !warnings.Any();
 
             // Assert
             result.Should().BeFalse();
-            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
                 RuleHelpers.DataTypeMismatchedErrorMessage
             });
-            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {
                 "#/default",
             });
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateExampleAndDefaultShouldNotHaveDataTypeMismatchForSimpleSchema()
         {
             // Arrange
-            IEnumerable<OpenApiError> errors;
+            IEnumerable<OpenApiError> warnings;
             var schema = new OpenApiSchema()
             {
                 Example = new OpenApiLong(55),
@@ -65,17 +65,17 @@ namespace Microsoft.OpenApi.Validations.Tests
             var walker = new OpenApiWalker(validator);
             walker.Walk(schema);
 
-            errors = validator.Errors;
-            bool result = !errors.Any();
+            warnings = validator.Warnings;
+            bool result = !warnings.Any();
 
             // Assert
             result.Should().BeFalse();
-            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
                 RuleHelpers.DataTypeMismatchedErrorMessage,
                 RuleHelpers.DataTypeMismatchedErrorMessage
             });
-            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {
                 "#/default",
                 "#/example",
@@ -86,7 +86,7 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateEnumShouldNotHaveDataTypeMismatchForSimpleSchema()
         {
             // Arrange
-            IEnumerable<OpenApiError> errors;
+            IEnumerable<OpenApiError> warnings;
             var schema = new OpenApiSchema()
             {
                 Enum =
@@ -120,18 +120,18 @@ namespace Microsoft.OpenApi.Validations.Tests
             var walker = new OpenApiWalker(validator);
             walker.Walk(schema);
 
-            errors = validator.Errors;
-            bool result = !errors.Any();
+            warnings = validator.Warnings;
+            bool result = !warnings.Any();
 
             // Assert
             result.Should().BeFalse();
-            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
                 RuleHelpers.DataTypeMismatchedErrorMessage,
                 RuleHelpers.DataTypeMismatchedErrorMessage,
                 RuleHelpers.DataTypeMismatchedErrorMessage,
             });
-            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {
                 // #enum/0 is not an error since the spec allows
                 // representing an object using a string.
@@ -145,7 +145,7 @@ namespace Microsoft.OpenApi.Validations.Tests
         public void ValidateDefaultShouldNotHaveDataTypeMismatchForComplexSchema()
         {
             // Arrange
-            IEnumerable<OpenApiError> errors;
+            IEnumerable<OpenApiError> warnings;
             var schema = new OpenApiSchema()
             {
                 Type = "object",
@@ -210,12 +210,12 @@ namespace Microsoft.OpenApi.Validations.Tests
             var walker = new OpenApiWalker(validator);
             walker.Walk(schema);
 
-            errors = validator.Errors;
-            bool result = !errors.Any();
+            warnings = validator.Warnings;
+            bool result = !warnings.Any();
 
             // Assert
             result.Should().BeFalse();
-            errors.Select(e => e.Message).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Message).Should().BeEquivalentTo(new[]
             {
                 RuleHelpers.DataTypeMismatchedErrorMessage,
                 RuleHelpers.DataTypeMismatchedErrorMessage,
@@ -223,7 +223,7 @@ namespace Microsoft.OpenApi.Validations.Tests
                 RuleHelpers.DataTypeMismatchedErrorMessage,
                 RuleHelpers.DataTypeMismatchedErrorMessage,
             });
-            errors.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
+            warnings.Select(e => e.Pointer).Should().BeEquivalentTo(new[]
             {
                 "#/default/property1/0",
                 "#/default/property1/2",

--- a/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.NotEmpty(rules);
 
             // Update the number if you add new default rule(s).
-            Assert.Equal(21, rules.Count);
+            Assert.Equal(22, rules.Count);
         }
     }
 }


### PR DESCRIPTION
Previously, OpenApiValidator only had the ability to report issues as Errors.  This PR adds a Warnings property and allows validation rules to create warnings instead of errors.  

All of the DataTypeMismatch rules have been updated to create Warnings instead of Errors.  

OpenApiDiagnostic that is returned when parsing an OpenAPI document now has a list of Errors and a list of Warnings.