### PR TITLE
Add --terse-output Commandline parameter for producing JSON in terse format

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -44,6 +44,7 @@ namespace Microsoft.OpenApi.Hidi
             bool cleanoutput,
             string? version,
             OpenApiFormat? format,
+            bool terseOutput,
             LogLevel loglevel,
             bool inlineLocal,
             bool inlineExternal,
@@ -188,11 +189,13 @@ namespace Microsoft.OpenApi.Hidi
                     using var outputStream = output?.Create();
                     var textWriter = outputStream != null ? new StreamWriter(outputStream) : Console.Out;
 
-                    var settings = new OpenApiWriterSettings()
+                    var settings = new OpenApiWriterSettings();
+                    if (terseOutput)
                     {
-                        InlineLocalReferences = inlineLocal,
-                        InlineExternalReferences = inlineExternal
-                    };
+                        settings.Terse = terseOutput;
+                    }
+                    settings.InlineLocalReferences = inlineLocal;
+                    settings.InlineExternalReferences = inlineExternal;
 
                     IOpenApiWriter writer = openApiFormat switch
                     {

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -189,17 +189,15 @@ namespace Microsoft.OpenApi.Hidi
                     using var outputStream = output?.Create();
                     var textWriter = outputStream != null ? new StreamWriter(outputStream) : Console.Out;
 
-                    var settings = new OpenApiWriterSettings();
-                    if (terseOutput)
+                    var settings = new OpenApiWriterSettings()
                     {
-                        settings.Terse = terseOutput;
-                    }
-                    settings.InlineLocalReferences = inlineLocal;
-                    settings.InlineExternalReferences = inlineExternal;
+                        InlineLocalReferences = inlineLocal,
+                        InlineExternalReferences = inlineExternal
+                    };
 
                     IOpenApiWriter writer = openApiFormat switch
                     {
-                        OpenApiFormat.Json => new OpenApiJsonWriter(textWriter, settings),
+                        OpenApiFormat.Json => terseOutput ? new OpenApiJsonWriter(textWriter, settings, terseOutput) : new OpenApiJsonWriter(textWriter, settings, false),
                         OpenApiFormat.Yaml => new OpenApiYamlWriter(textWriter, settings),
                         _ => throw new ArgumentException("Unknown format"),
                     };

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -39,6 +39,9 @@ namespace Microsoft.OpenApi.Hidi
             var formatOption = new Option<OpenApiFormat?>("--format", "File format");
             formatOption.AddAlias("-f");
 
+            var terseOutputOption = new Option<bool>("--terseOutput", "Produce terse json output");
+            terseOutputOption.AddAlias("-to");
+
             var logLevelOption = new Option<LogLevel>("--loglevel", () => LogLevel.Information, "The log level to use when logging messages to the main output.");
             logLevelOption.AddAlias("-ll");
 
@@ -74,6 +77,7 @@ namespace Microsoft.OpenApi.Hidi
                 cleanOutputOption,
                 versionOption,
                 formatOption,
+                terseOutputOption,
                 logLevelOption,               
                 filterByOperationIdsOption,
                 filterByTagsOption,
@@ -82,8 +86,8 @@ namespace Microsoft.OpenApi.Hidi
                 inlineExternalOption
             };
 
-            transformCommand.SetHandler<string, string, string, FileInfo, bool, string?, OpenApiFormat?, LogLevel, bool, bool, string, string, string, CancellationToken> (
-                OpenApiService.TransformOpenApiDocument, descriptionOption, csdlOption, csdlFilterOption, outputOption, cleanOutputOption, versionOption, formatOption, logLevelOption, inlineLocalOption, inlineExternalOption, filterByOperationIdsOption, filterByTagsOption, filterByCollectionOption);
+            transformCommand.SetHandler<string, string, string, FileInfo, bool, string?, OpenApiFormat?, bool, LogLevel, bool, bool, string, string, string, CancellationToken> (
+                OpenApiService.TransformOpenApiDocument, descriptionOption, csdlOption, csdlFilterOption, outputOption, cleanOutputOption, versionOption, formatOption, terseOutputOption, logLevelOption, inlineLocalOption, inlineExternalOption, filterByOperationIdsOption, filterByTagsOption, filterByCollectionOption);
 
             rootCommand.Add(transformCommand);
             rootCommand.Add(validateCommand);

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -39,7 +39,7 @@ namespace Microsoft.OpenApi.Hidi
             var formatOption = new Option<OpenApiFormat?>("--format", "File format");
             formatOption.AddAlias("-f");
 
-            var terseOutputOption = new Option<bool>("--terseOutput", "Produce terse json output");
+            var terseOutputOption = new Option<bool>("--terse-output", "Produce terse json output");
             terseOutputOption.AddAlias("-to");
 
             var logLevelOption = new Option<LogLevel>("--loglevel", () => LogLevel.Information, "The log level to use when logging messages to the main output.");

--- a/src/Microsoft.OpenApi/Extensions/OpenApiSerializableExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiSerializableExtensions.cs
@@ -83,20 +83,14 @@ namespace Microsoft.OpenApi.Extensions
                 throw Error.ArgumentNull(nameof(stream));
             }
 
-            IOpenApiWriter writer;
             var streamWriter = new FormattingStreamWriter(stream, CultureInfo.InvariantCulture);
-            switch (format)
-            {
-                case OpenApiFormat.Json:
-                    writer = new OpenApiJsonWriter(streamWriter,settings);
-                    break;
-                case OpenApiFormat.Yaml:
-                    writer = new OpenApiYamlWriter(streamWriter, settings);
-                    break;
-                default:
-                    throw new OpenApiException(string.Format(SRResource.OpenApiFormatNotSupported, format));
-            }
 
+            IOpenApiWriter writer = format switch
+            {
+                OpenApiFormat.Json => new OpenApiJsonWriter(streamWriter, settings, false),
+                OpenApiFormat.Yaml => new OpenApiYamlWriter(streamWriter, settings),
+                _ => throw new OpenApiException(string.Format(SRResource.OpenApiFormatNotSupported, format)),
+            };
             element.Serialize(writer, specVersion);
         }
 

--- a/src/Microsoft.OpenApi/Writers/OpenApiJsonWriter.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiJsonWriter.cs
@@ -33,12 +33,10 @@ namespace Microsoft.OpenApi.Writers
         /// </summary>
         /// <param name="textWriter">The text writer.</param>
         /// <param name="settings">Settings for controlling how the OpenAPI document will be written out.</param>
-        public OpenApiJsonWriter(TextWriter textWriter, OpenApiWriterSettings settings) : base(textWriter, settings)
+        /// <param name="terseOutput"> Setting for allowing the JSON emitted to be in terse format.</param>
+        public OpenApiJsonWriter(TextWriter textWriter, OpenApiWriterSettings settings, bool terseOutput = false) : base(textWriter, settings)
         {
-            if (settings != null)
-            {
-                _produceTerseOutput = settings.Terse;
-            }
+            _produceTerseOutput = terseOutput;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Writers/OpenApiJsonWriter.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiJsonWriter.cs
@@ -35,6 +35,7 @@ namespace Microsoft.OpenApi.Writers
         /// <param name="settings">Settings for controlling how the OpenAPI document will be written out.</param>
         public OpenApiJsonWriter(TextWriter textWriter, OpenApiWriterSettings settings) : base(textWriter, settings)
         {
+            _produceTerseOutput = settings.Terse;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Writers/OpenApiJsonWriter.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiJsonWriter.cs
@@ -35,7 +35,10 @@ namespace Microsoft.OpenApi.Writers
         /// <param name="settings">Settings for controlling how the OpenAPI document will be written out.</param>
         public OpenApiJsonWriter(TextWriter textWriter, OpenApiWriterSettings settings) : base(textWriter, settings)
         {
-            _produceTerseOutput = settings.Terse;
+            if (settings != null)
+            {
+                _produceTerseOutput = settings.Terse;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterSettings.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterSettings.cs
@@ -69,12 +69,6 @@ namespace Microsoft.OpenApi.Writers
         /// </summary>
         public bool InlineExternalReferences { get; set; } = false;
 
-        /// <summary>
-        /// Indicates whether or not the produced document will be written in a compact or pretty fashion.
-        /// </summary>
-        public bool Terse { get; set; } = false;
-
-
         internal bool ShouldInlineReference(OpenApiReference reference)
         {
             return (reference.IsLocal && InlineLocalReferences)

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterSettings.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterSettings.cs
@@ -69,6 +69,11 @@ namespace Microsoft.OpenApi.Writers
         /// </summary>
         public bool InlineExternalReferences { get; set; } = false;
 
+        /// <summary>
+        /// Indicates whether or not the produced document will be written in a compact or pretty fashion.
+        /// </summary>
+        public bool Terse { get; set; } = false;
+
 
         internal bool ShouldInlineReference(OpenApiReference reference)
         {

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -1297,7 +1297,7 @@ namespace Microsoft.OpenApi.Writers
     public class OpenApiJsonWriterSettings : Microsoft.OpenApi.Writers.OpenApiWriterSettings
     {
         public OpenApiJsonWriterSettings() { }
-        public bool Terse { get; set; }
+        public new bool Terse { get; set; }
     }
     public static class OpenApiWriterAnyExtensions
     {
@@ -1379,6 +1379,7 @@ namespace Microsoft.OpenApi.Writers
         public bool InlineLocalReferences { get; set; }
         [System.Obsolete("Use InlineLocalReference and InlineExternalReference settings instead")]
         public Microsoft.OpenApi.Writers.ReferenceInlineSetting ReferenceInline { get; set; }
+        public bool Terse { get; set; }
     }
     public class OpenApiYamlWriter : Microsoft.OpenApi.Writers.OpenApiWriterBase
     {

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -1281,7 +1281,7 @@ namespace Microsoft.OpenApi.Writers
     {
         public OpenApiJsonWriter(System.IO.TextWriter textWriter) { }
         public OpenApiJsonWriter(System.IO.TextWriter textWriter, Microsoft.OpenApi.Writers.OpenApiJsonWriterSettings settings) { }
-        public OpenApiJsonWriter(System.IO.TextWriter textWriter, Microsoft.OpenApi.Writers.OpenApiWriterSettings settings) { }
+        public OpenApiJsonWriter(System.IO.TextWriter textWriter, Microsoft.OpenApi.Writers.OpenApiWriterSettings settings, bool terseOutput = false) { }
         protected override int BaseIndentation { get; }
         public override void WriteEndArray() { }
         public override void WriteEndObject() { }
@@ -1297,7 +1297,7 @@ namespace Microsoft.OpenApi.Writers
     public class OpenApiJsonWriterSettings : Microsoft.OpenApi.Writers.OpenApiWriterSettings
     {
         public OpenApiJsonWriterSettings() { }
-        public new bool Terse { get; set; }
+        public bool Terse { get; set; }
     }
     public static class OpenApiWriterAnyExtensions
     {
@@ -1379,7 +1379,6 @@ namespace Microsoft.OpenApi.Writers
         public bool InlineLocalReferences { get; set; }
         [System.Obsolete("Use InlineLocalReference and InlineExternalReference settings instead")]
         public Microsoft.OpenApi.Writers.ReferenceInlineSetting ReferenceInline { get; set; }
-        public bool Terse { get; set; }
     }
     public class OpenApiYamlWriter : Microsoft.OpenApi.Writers.OpenApiWriterBase
     {


### PR DESCRIPTION
Fixes #829 
Adds a --terse-ouput parameter, abbreviated as -to in Hidi to emit terse JSON output.

#### Usage:
`transform -d C:\pestore.yaml -f json -o C:\pestore.json -co -to`