### PR TITLE
Add OpenApiContact for ReadFragment

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiV2VersionService.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiV2VersionService.cs
@@ -34,6 +34,7 @@ namespace Microsoft.OpenApi.Readers.V2
         private IDictionary<Type, Func<ParseNode, object>> _loaders = new Dictionary<Type, Func<ParseNode, object>>
         {
             [typeof(IOpenApiAny)] = OpenApiV2Deserializer.LoadAny,
+            [typeof(OpenApiContact)] = OpenApiV2Deserializer.LoadContact,
             [typeof(OpenApiExternalDocs)] = OpenApiV2Deserializer.LoadExternalDocs,
             [typeof(OpenApiHeader)] = OpenApiV2Deserializer.LoadHeader,
             [typeof(OpenApiInfo)] = OpenApiV2Deserializer.LoadInfo,

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
@@ -35,6 +35,7 @@ namespace Microsoft.OpenApi.Readers.V3
             [typeof(IOpenApiAny)] = OpenApiV3Deserializer.LoadAny,
             [typeof(OpenApiCallback)] = OpenApiV3Deserializer.LoadCallback,
             [typeof(OpenApiComponents)] = OpenApiV3Deserializer.LoadComponents,
+            [typeof(OpenApiContact)] = OpenApiV3Deserializer.LoadContact,
             [typeof(OpenApiEncoding)] = OpenApiV3Deserializer.LoadEncoding,
             [typeof(OpenApiExample)] = OpenApiV3Deserializer.LoadExample,
             [typeof(OpenApiExternalDocs)] = OpenApiV3Deserializer.LoadExternalDocs,

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiContactTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiContactTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using FluentAssertions;
+using Microsoft.OpenApi.Models;
+using System;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.V2Tests
+{
+    public class OpenApiContactTests
+    {
+        [Fact]
+        public void ParseStringContactFragmentShouldSucceed()
+        {
+            var input = @"
+{
+  ""name"": ""API Support"",
+  ""url"": ""http://www.swagger.io/support"",
+  ""email"": ""support@swagger.io""
+}
+";
+            var reader = new OpenApiStringReader();
+            var diagnostic = new OpenApiDiagnostic();
+
+            // Act
+            var contact = reader.ReadFragment<OpenApiContact>(input, OpenApiSpecVersion.OpenApi2_0, out diagnostic);
+
+            // Assert
+            diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());
+
+            contact.Should().BeEquivalentTo(
+                new OpenApiContact
+                {
+                    Email = "support@swagger.io",
+                    Name = "API Support",
+                    Url = new Uri("http://www.swagger.io/support")
+                });
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiContactTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiContactTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using FluentAssertions;
+using Microsoft.OpenApi.Models;
+using System;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.V3Tests
+{
+    public class OpenApiContactTests
+    {
+        [Fact]
+        public void ParseStringContactFragmentShouldSucceed()
+        {
+            var input = @"
+{
+  ""name"": ""API Support"",
+  ""url"": ""http://www.swagger.io/support"",
+  ""email"": ""support@swagger.io""
+}
+";
+            var reader = new OpenApiStringReader();
+            var diagnostic = new OpenApiDiagnostic();
+
+            // Act
+            var contact = reader.ReadFragment<OpenApiContact>(input, OpenApiSpecVersion.OpenApi3_0, out diagnostic);
+
+            // Assert
+            diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());
+
+            contact.Should().BeEquivalentTo(
+                new OpenApiContact
+                {
+                    Email = "support@swagger.io",
+                    Name = "API Support",
+                    Url = new Uri("http://www.swagger.io/support")
+                });
+        }
+    }
+}


### PR DESCRIPTION
Currently, `OpenApiStringReader.ReadFragment<OpenApiContact>()` throws the following exception:
```
System.Collections.Generic.KeyNotFoundException : The given key 'Microsoft.OpenApi.Models.OpenApiContact'
was not present in the dictionary.
```

This is because `OpenApiV2/V3VersionService._loaders` does not have the entry of `[typeof(OpenApiContact)]`.