### PR TITLE
Bumps conversion lib version and Hidi version

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -15,7 +15,7 @@
     <PackageId>Microsoft.OpenApi.Hidi</PackageId>
     <ToolCommandName>hidi</ToolCommandName>
     <PackageOutputPath>./../../artifacts</PackageOutputPath>
-    <Version>1.0.0-preview4</Version>
+    <Version>1.0.0-preview5</Version>
     <Description>OpenAPI.NET CLI tool for slicing OpenAPI documents</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>OpenAPI .NET</PackageTags>
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.11.0" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.10" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.11-preview2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates the `Microsoft.OpenApi.OData` lib version from `1.0.10` to `1.0.11-preview2`
Bumps up Hidi release version to `1.0.0-preview5`