### PR TITLE
Add support for request body path parameters in v2

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiPathItemDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiPathItemDeserializer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiPathItemDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiPathItemDeserializer.cs
@@ -69,16 +69,13 @@ namespace Microsoft.OpenApi.Readers.V2
                 var requestBody = CreateRequestBody(node.Context, bodyParameter);
                 foreach(var opPair in pathItem.Operations)
                 {
-                    if (opPair.Value.RequestBody == null)
+                    switch (opPair.Key)
                     {
-                        switch (opPair.Key)
-                        {
-                            case OperationType.Post:
-                            case OperationType.Put:
-                            case OperationType.Patch:
-                                opPair.Value.RequestBody = requestBody;
-                                break;
-                        }
+                        case OperationType.Post:
+                        case OperationType.Put:
+                        case OperationType.Patch:
+                            opPair.Value.RequestBody = requestBody;
+                            break;
                     }
                 }
             }

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiPathItemDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiPathItemDeserializer.cs
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.Readers.V2
             if (bodyParameter != null)
             {
                 var requestBody = CreateRequestBody(node.Context, bodyParameter);
-                foreach(var opPair in pathItem.Operations)
+                foreach(var opPair in pathItem.Operations.Where(x => x.Value.RequestBody is null))
                 {
                     switch (opPair.Key)
                     {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiPathItemDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiPathItemDeserializer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.OpenApi.Readers.V2
                 if (formParameters != null)
                 {
                     var requestBody = CreateFormBody(node.Context, formParameters);
-                    foreach (var opPair in pathItem.Operations)
+                    foreach (var opPair in pathItem.Operations.Where(x => x.Value.RequestBody is null))
                     {
                         if (opPair.Value.RequestBody == null)
                         {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiPathItemDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiPathItemDeserializer.cs
@@ -90,16 +90,13 @@ namespace Microsoft.OpenApi.Readers.V2
                     var requestBody = CreateFormBody(node.Context, formParameters);
                     foreach (var opPair in pathItem.Operations.Where(x => x.Value.RequestBody is null))
                     {
-                        if (opPair.Value.RequestBody == null)
+                        switch (opPair.Key)
                         {
-                            switch (opPair.Key)
-                            {
-                                case OperationType.Post:
-                                case OperationType.Put:
-                                case OperationType.Patch:
-                                    opPair.Value.RequestBody = requestBody;
-                                    break;
-                            }
+                            case OperationType.Post:
+                            case OperationType.Put:
+                            case OperationType.Patch:
+                                opPair.Value.RequestBody = requestBody;
+                                break;
                         }
                     }
                 }

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -14,6 +14,7 @@
     </PropertyGroup>
     <ItemGroup>
       <None Remove="V2Tests\Samples\ComponentRootReference.json" />
+      <None Remove="V2Tests\Samples\OpenApiPathItem\pathItemWithFormDataPathParameter.yaml" />
       <None Remove="V3Tests\Samples\OpenApiWorkspace\TodoComponents.yaml" />
       <None Remove="V3Tests\Samples\OpenApiWorkspace\TodoMain.yaml" />
     </ItemGroup>
@@ -83,6 +84,9 @@
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
       <EmbeddedResource Include="V2Tests\Samples\OpenApiParameter\queryParameter.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiPathItem\pathItemWithFormDataPathParameter.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
       <EmbeddedResource Include="V2Tests\Samples\OpenApiPathItem\basicPathItemWithFormData.yaml">

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -14,6 +14,7 @@
     </PropertyGroup>
     <ItemGroup>
       <None Remove="V2Tests\Samples\ComponentRootReference.json" />
+      <None Remove="V2Tests\Samples\OpenApiPathItem\pathItemWithBodyPathParameter.yaml" />
       <None Remove="V2Tests\Samples\OpenApiPathItem\pathItemWithFormDataPathParameter.yaml" />
       <None Remove="V3Tests\Samples\OpenApiWorkspace\TodoComponents.yaml" />
       <None Remove="V3Tests\Samples\OpenApiWorkspace\TodoMain.yaml" />
@@ -87,6 +88,9 @@
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
       <EmbeddedResource Include="V2Tests\Samples\OpenApiPathItem\pathItemWithFormDataPathParameter.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V2Tests\Samples\OpenApiPathItem\pathItemWithBodyPathParameter.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
       <EmbeddedResource Include="V2Tests\Samples\OpenApiPathItem\basicPathItemWithFormData.yaml">

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiPathItemTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiPathItemTests.cs
@@ -275,7 +275,29 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
 
             // Assert
             // FormData parameters at in the path level are pushed into Operation request bodies.
-            Assert.True(pathItem.Operations.All(o => o.Value.RequestBody != null));
+            Assert.True(pathItem.Operations[OperationType.Put].RequestBody != null);
+            Assert.True(pathItem.Operations[OperationType.Post].RequestBody != null);
+            Assert.Equal(2, pathItem.Operations.Count(o => o.Value.RequestBody != null));
         }
+        [Fact]
+        public void ParsePathItemBodyDataPathParameterShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "pathItemWithBodyPathParameter.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var pathItem = OpenApiV2Deserializer.LoadPathItem(node);
+
+            // Assert
+            // FormData parameters at in the path level are pushed into Operation request bodies.
+            Assert.True(pathItem.Operations[OperationType.Put].RequestBody != null);
+            Assert.True(pathItem.Operations[OperationType.Post].RequestBody != null);
+            Assert.Equal(2, pathItem.Operations.Count(o => o.Value.RequestBody != null));
+        }
+
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiPathItemTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiPathItemTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using FluentAssertions;
 using Microsoft.OpenApi.Extensions;
@@ -253,10 +254,28 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             }
 
             // Act
-            var operation = OpenApiV2Deserializer.LoadPathItem(node);
+            var pathItem = OpenApiV2Deserializer.LoadPathItem(node);
 
             // Assert
-            operation.Should().BeEquivalentTo(_basicPathItemWithFormData);
+            pathItem.Should().BeEquivalentTo(_basicPathItemWithFormData);
+        }
+
+        [Fact]
+        public void ParsePathItemWithFormDataPathParameterShouldSucceed()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "pathItemWithFormDataPathParameter.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var pathItem = OpenApiV2Deserializer.LoadPathItem(node);
+
+            // Assert
+            // FormData parameters at in the path level are pushed into Operation request bodies.
+            Assert.True(pathItem.Operations.All(o => o.Value.RequestBody != null));
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiPathItem/pathItemWithBodyPathParameter.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiPathItem/pathItemWithBodyPathParameter.yaml
@@ -1,0 +1,31 @@
+﻿put:
+    summary: Puts a pet in the store with form data
+    description: ""
+    responses:
+        '200':
+          description: Pet updated.
+        '405':
+          description: Invalid input
+post:
+    summary: Posts a pet in the store with form data
+    description: ""
+    responses:
+        '200':
+        description: Pet updated.
+parameters:
+  - name: petId
+    in: path
+    description: ID of pet that needs to be updated
+    required: true
+    schema: 
+    type: string
+  - name: name
+    in: body
+    description: Updated pet body
+    required: true
+    type: object
+    properties:
+      name: 
+        type: string
+      status: 
+        type: string

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiPathItem/pathItemWithFormDataPathParameter.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiPathItem/pathItemWithFormDataPathParameter.yaml
@@ -1,0 +1,41 @@
+﻿put:
+    summary: Puts a pet in the store with form data
+    description: ""
+    responses:
+        '200':
+          description: Pet updated.
+        '405':
+          description: Invalid input
+    x-http-tests: 
+    - parameterValues:
+        petId: 10
+        name: Milo
+        status: Happy
+        expectedRequest: 
+        href: /pathitem-form-parameter/10
+        headers:
+            Content-Type: multipart/form-data 
+        content: name=Milo&status=Happy
+post:
+    summary: Posts a pet in the store with form data
+    description: ""
+    responses:
+        '200':
+        description: Pet updated.
+parameters:
+  - name: petId
+    in: path
+    description: ID of pet that needs to be updated
+    required: true
+    schema: 
+    type: string
+  - name: name
+    in: formData
+    description: Updated name of the pet
+    required: true
+    type: string
+  - name: status
+    in: formData
+    description: Updated status of the pet
+    required: false
+    type: string


### PR DESCRIPTION
see #885 

- [x] Added support for reading parameters "in: body"
- [x] Added support for reading parameters "in: formdata"
