### PR TITLE
Fixes missing path parameters

### DIFF
--- a/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiFilterServiceTests.cs
+++ b/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiFilterServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -134,6 +134,23 @@ namespace Microsoft.OpenApi.Tests.Services
 
             var message2 = Assert.Throws<InvalidOperationException>(() => OpenApiFilterService.CreatePredicate("users.user.ListUser", "users.user")).Message;
             Assert.Equal("Cannot specify both operationIds and tags at the same time.", message2);
+        }
+
+        [Theory]
+        [InlineData("reports.getTeamsUserActivityUserDetail-a3f1", null)]
+        [InlineData(null, "reports.Functions")]
+        public void ReturnsPathParametersOnSlicingBasedOnOperationIdsOrTags(string operationIds, string tags)
+        {
+            // Act
+            var predicate = OpenApiFilterService.CreatePredicate(operationIds, tags);
+            var subsetOpenApiDocument = OpenApiFilterService.CreateFilteredDocument(_openApiDocumentMock, predicate);
+
+            // Assert
+            foreach (var pathItem in subsetOpenApiDocument.Paths)
+            {
+                Assert.True(pathItem.Value.Parameters.Any());
+                Assert.Equal(1, pathItem.Value.Parameters.Count);
+            }
         }
     }
 }

--- a/Microsoft.OpenApi.Hidi.Tests/UtilityFiles/OpenApiDocumentMock.cs
+++ b/Microsoft.OpenApi.Hidi.Tests/UtilityFiles/OpenApiDocumentMock.cs
@@ -116,6 +116,21 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                     }
                                 }
                             }
+                        },
+                        Parameters = new List<OpenApiParameter>
+                        {
+                            {
+                                new OpenApiParameter()
+                                {
+                                    Name = "period",
+                                    In = ParameterLocation.Path,
+                                    Required = true,
+                                    Schema = new OpenApiSchema()
+                                    {
+                                        Type = "string"
+                                    }
+                                }
+                            }
                         }
                     },
                     ["/reports/microsoft.graph.getTeamsUserActivityUserDetail(date={date})"] = new OpenApiPathItem()
@@ -175,7 +190,20 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                     }
                                 }
                             }
-                        }
+                        },
+                        Parameters = new List<OpenApiParameter>
+                        {
+                            new OpenApiParameter
+                            {
+                                Name = "period",
+                                In = ParameterLocation.Path,
+                                Required = true,
+                                Schema = new OpenApiSchema()
+                                {
+                                    Type = "string"
+                                }
+                            }
+                        }                                    
                     },
                     ["/users"] = new OpenApiPathItem()
                     {

--- a/src/Microsoft.OpenApi/Services/OpenApiFilterService.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiFilterService.cs
@@ -164,6 +164,14 @@ namespace Microsoft.OpenApi.Services
                 if (result.CurrentKeys.Operation != null)
                 {
                     pathItem.Operations.Add((OperationType)result.CurrentKeys.Operation, result.Operation);
+
+                    if (result.Parameters?.Any() ?? false)
+                    {
+                        foreach (var parameter in result.Parameters)
+                        {
+                            pathItem.Parameters.Add(parameter);
+                        }
+                    }
                 }
             }
 

--- a/src/Microsoft.OpenApi/Services/OperationSearch.cs
+++ b/src/Microsoft.OpenApi/Services/OperationSearch.cs
@@ -31,18 +31,25 @@ namespace Microsoft.OpenApi.Services
         }
 
         /// <summary>
-        /// Visits <see cref="OpenApiOperation"/>.
+        /// Visits <see cref="OpenApiPathItem"/>
         /// </summary>
-        /// <param name="operation">The target <see cref="OpenApiOperation"/>.</param>
-        public override void Visit(OpenApiOperation operation)
+        /// <param name="pathItem"> The target <see cref="OpenApiPathItem"/>.</param>
+        public override void Visit(OpenApiPathItem pathItem)
         {
-            if (_predicate(CurrentKeys.Path, CurrentKeys.Operation, operation))
+            foreach (var item in pathItem.Operations)
             {
-                _searchResults.Add(new SearchResult()
+                var operation = item.Value;
+                var operationType = item.Key;
+
+                if (_predicate(CurrentKeys.Path, CurrentKeys.Operation, operation))
                 {
-                    Operation = operation,
-                    CurrentKeys = CopyCurrentKeys(CurrentKeys)
-                });
+                    _searchResults.Add(new SearchResult()
+                    {
+                        Operation = operation,
+                        Parameters = pathItem.Parameters,
+                        CurrentKeys = CopyCurrentKeys(CurrentKeys, operationType)
+                    });
+                }
             }
         }
 
@@ -65,12 +72,12 @@ namespace Microsoft.OpenApi.Services
             base.Visit(parameters);
         }
 
-        private static CurrentKeys CopyCurrentKeys(CurrentKeys currentKeys)
+        private static CurrentKeys CopyCurrentKeys(CurrentKeys currentKeys, OperationType operationType)
         {
             return new CurrentKeys
             {
                 Path = currentKeys.Path,
-                Operation = currentKeys.Operation
+                Operation = operationType
             };
         }
     }

--- a/src/Microsoft.OpenApi/Services/SearchResult.cs
+++ b/src/Microsoft.OpenApi/Services/SearchResult.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Services
@@ -19,5 +20,11 @@ namespace Microsoft.OpenApi.Services
         /// An Operation object.
         /// </summary>
         public OpenApiOperation Operation { get; set; }
+
+        /// <summary>
+        /// Parameters object
+        /// </summary>
+        public IList<OpenApiParameter> Parameters { get; set; }
+
     }
 }


### PR DESCRIPTION
This PR updates the slicing logic to retrieve missing path parameters during slicing of OpenAPI documents from the `OpenApiPathItem` object when the setting `DeclarePathParametersOnPathItem` is set to true.
Fixes #834 