### PR TITLE
Fix anyOf and oneOf v2 serialization

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiOperationDeserializer.cs
@@ -60,7 +60,7 @@ namespace Microsoft.OpenApi.Readers.V2
                     "consumes", (o, n) => {
                         var consumes = n.CreateSimpleList(s => s.GetScalarValue());
                         if (consumes.Count > 0) {
-                        n.Context.SetTempStorage(TempStorageKeys.OperationConsumes,consumes);
+                            n.Context.SetTempStorage(TempStorageKeys.OperationConsumes,consumes);
                         }
                     }
                 },

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiV2VersionService.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiV2VersionService.cs
@@ -107,30 +107,6 @@ namespace Microsoft.OpenApi.Readers.V2
             }
         }
 
-        private static string GetReferenceTypeV2Name(ReferenceType referenceType)
-        {
-            switch (referenceType)
-            {
-                case ReferenceType.Schema:
-                    return "definitions";
-
-                case ReferenceType.Parameter:
-                    return "parameters";
-
-                case ReferenceType.Response:
-                    return "responses";
-
-                case ReferenceType.Tag:
-                    return "tags";
-
-                case ReferenceType.SecurityScheme:
-                    return "securityDefinitions";
-
-                default:
-                    throw new ArgumentException();
-            }
-        }
-
         private static ReferenceType GetReferenceTypeV2FromName(string referenceType)
         {
             switch (referenceType)

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -700,12 +700,12 @@ namespace Microsoft.OpenApi.Models
             if (AllOf == null || AllOf.Count == 0)
             {
                 // anyOf (Not Supported in V2)  - Write the first schema only as an allOf.
-                writer.WriteOptionalCollection(OpenApiConstants.AllOf, AnyOf.Take(1), (w, s) => s.SerializeAsV2(w));
+                writer.WriteOptionalCollection(OpenApiConstants.AllOf, AnyOf?.Take(1), (w, s) => s.SerializeAsV2(w));
 
                 if (AnyOf == null || AnyOf.Count == 0)
                 {
                     // oneOf (Not Supported in V2) - Write the first schema only as an allOf.
-                    writer.WriteOptionalCollection(OpenApiConstants.AllOf, OneOf.Take(1), (w, s) => s.SerializeAsV2(w));
+                    writer.WriteOptionalCollection(OpenApiConstants.AllOf, OneOf?.Take(1), (w, s) => s.SerializeAsV2(w));
                 }
             }
 


### PR DESCRIPTION
Fixes #850 

When converting a schema to Open API v2, which contains either `oneOf` or `anyOf`, we add them as `allOf` if an `allOf` doesn't already exist, since both are not supported in v2.

The existing implementation failed to check if `anyOf` or `oneOf` existed before attempting to add `allOf`. This PR adds the check. 
