### PR TITLE
Fixes Missing Release Notes

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -266,14 +266,6 @@ stages:
                 echo "$artifactName"
                 echo "$artifactVersion"
               displayName: 'Fetch Artifact Name'
-
-            - task: NuGetCommand@2
-              displayName: 'NuGet push'
-              inputs:
-                command: push
-                packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.Hidi.*.nupkg'
-                nuGetFeedType: external
-                publishFeedCredentials: 'OpenAPI Nuget Connection'
             - task: GitHubRelease@1
               displayName: 'GitHub release (edit)'
               inputs:
@@ -285,6 +277,13 @@ stages:
                 releaseNotesSource: inline
                 assets: '$(Pipeline.Workspace)\**\*.exe'
                 changeLogType: issueBased
+            - task: NuGetCommand@2
+              displayName: 'NuGet push'
+              inputs:
+                command: push
+                packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.Hidi.*.nupkg'
+                nuGetFeedType: external
+                publishFeedCredentials: 'OpenAPI Nuget Connection'
     
     - deployment: deploy_lib
       dependsOn: []

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -266,8 +266,16 @@ stages:
                 echo "$artifactName"
                 echo "$artifactVersion"
               displayName: 'Fetch Artifact Name'
+            - task: NuGetCommand@2
+              displayName: 'NuGet push'
+              inputs:
+                command: push
+                packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.Hidi.*.nupkg'
+                nuGetFeedType: external
+                publishFeedCredentials: 'OpenAPI Nuget Connection'
             - task: GitHubRelease@1
               displayName: 'GitHub release (edit)'
+              condition: succeededOrFailed()
               inputs:
                 gitHubConnection: 'Github-MaggieKimani1'
                 action: edit
@@ -277,13 +285,6 @@ stages:
                 releaseNotesSource: inline
                 assets: '$(Pipeline.Workspace)\**\*.exe'
                 changeLogType: issueBased
-            - task: NuGetCommand@2
-              displayName: 'NuGet push'
-              inputs:
-                command: push
-                packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.Hidi.*.nupkg'
-                nuGetFeedType: external
-                publishFeedCredentials: 'OpenAPI Nuget Connection'
     
     - deployment: deploy_lib
       dependsOn: []


### PR DESCRIPTION
This PR updates the Github release task by adding a condition `succeededOrFailed()` to ensure the task runs even if the preceding step fails.
Fixes #964