### PR TITLE
Appends `format` property value to root schema if contained in `anyOf`, `oneOf` or `allOf` when serializing as v2

### DIFF
--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -11,7 +11,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi</Title>
         <PackageId>Microsoft.OpenApi</PackageId>
-        <Version>1.4.0</Version>
+        <Version>1.4.1</Version>
         <Description>.NET models with JSON and YAML writers for OpenAPI specification</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -566,10 +566,13 @@ namespace Microsoft.OpenApi.Models
             writer.WriteProperty(OpenApiConstants.Type, Type);
 
             // format
-            Format ??= AllOf?.FirstOrDefault(static x => x.Format != null)?.Format ??
+            if (string.IsNullOrEmpty(Format))
+            {
+                Format = AllOf?.FirstOrDefault(static x => x.Format != null)?.Format ??
                     AnyOf?.FirstOrDefault(static x => x.Format != null)?.Format ??
                     OneOf?.FirstOrDefault(static x => x.Format != null)?.Format;
-
+            }
+            
             writer.WriteProperty(OpenApiConstants.Format, Format);
 
             // items
@@ -634,9 +637,12 @@ namespace Microsoft.OpenApi.Models
             }
 
             // format
-            Format ??= AllOf?.FirstOrDefault(static x => x.Format != null)?.Format ??
+            if (string.IsNullOrEmpty(Format))
+            {
+                Format = AllOf?.FirstOrDefault(static x => x.Format != null)?.Format ??
                     AnyOf?.FirstOrDefault(static x => x.Format != null)?.Format ??
                     OneOf?.FirstOrDefault(static x => x.Format != null)?.Format;
+            }
 
             writer.WriteProperty(OpenApiConstants.Format, Format);
 

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
@@ -566,6 +566,10 @@ namespace Microsoft.OpenApi.Models
             writer.WriteProperty(OpenApiConstants.Type, Type);
 
             // format
+            Format ??= AllOf?.FirstOrDefault(static x => x.Format != null)?.Format ??
+                    AnyOf?.FirstOrDefault(static x => x.Format != null)?.Format ??
+                    OneOf?.FirstOrDefault(static x => x.Format != null)?.Format;
+
             writer.WriteProperty(OpenApiConstants.Format, Format);
 
             // items

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -568,9 +568,9 @@ namespace Microsoft.OpenApi.Models
             // format
             if (string.IsNullOrEmpty(Format))
             {
-                Format = AllOf?.FirstOrDefault(static x => x.Format != null)?.Format ??
-                    AnyOf?.FirstOrDefault(static x => x.Format != null)?.Format ??
-                    OneOf?.FirstOrDefault(static x => x.Format != null)?.Format;
+                Format = AllOf?.FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format ??
+                    AnyOf?.FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format ??
+                    OneOf?.FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format;
             }
             
             writer.WriteProperty(OpenApiConstants.Format, Format);
@@ -639,9 +639,9 @@ namespace Microsoft.OpenApi.Models
             // format
             if (string.IsNullOrEmpty(Format))
             {
-                Format = AllOf?.FirstOrDefault(static x => x.Format != null)?.Format ??
-                    AnyOf?.FirstOrDefault(static x => x.Format != null)?.Format ??
-                    OneOf?.FirstOrDefault(static x => x.Format != null)?.Format;
+                Format = AllOf?.FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format ??
+                    AnyOf?.FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format ??
+                    OneOf?.FirstOrDefault(static x => !string.IsNullOrEmpty(x.Format))?.Format;
             }
 
             writer.WriteProperty(OpenApiConstants.Format, Format);

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
@@ -50,7 +50,12 @@ namespace Microsoft.OpenApi.Tests.Models
             Schema = new OpenApiSchema
             {
                 Title = "title2",
-                Description = "description2"
+                Description = "description2",
+                OneOf = new List<OpenApiSchema>
+                {
+                    new OpenApiSchema { Type = "number", Format = "double" },
+                    new OpenApiSchema { Type = "string" }                        
+                }
             },
             Examples = new Dictionary<string, OpenApiExample>
             {
@@ -234,6 +239,15 @@ namespace Microsoft.OpenApi.Tests.Models
   ""explode"": true,
   ""schema"": {
     ""title"": ""title2"",
+    ""oneOf"": [
+      {
+        ""type"": ""number"",
+        ""format"": ""double""
+      },
+      {
+        ""type"": ""string""
+      }
+    ],
     ""description"": ""description2""
   },
   ""examples"": {
@@ -246,6 +260,27 @@ namespace Microsoft.OpenApi.Tests.Models
 
             // Act
             var actual = AdvancedPathParameterWithSchema.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeAdvancedParameterAsV2JsonWorks()
+        {
+            // Arrange
+            var expected = @"{
+  ""in"": ""path"",
+  ""name"": ""name1"",
+  ""description"": ""description1"",
+  ""required"": true,
+  ""format"": ""double""
+}";
+
+            // Act
+            var actual = AdvancedPathParameterWithSchema.SerializeAsJson(OpenApiSpecVersion.OpenApi2_0);
 
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET/issues/992

This PR:
- Retrieves the `format` property value from the child schemas of `anyOf`, `oneOf` or `allOf` and appends this to the root schema when serializing as v2 (when writing items as properties). 
- Updates test to validate the above.