### PR TITLE
Ensures `Paths` are copied in the copy constructor

### DIFF
--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -11,7 +11,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi</Title>
         <PackageId>Microsoft.OpenApi</PackageId>
-        <Version>1.4.1</Version>
+        <Version>1.4.2</Version>
         <Description>.NET models with JSON and YAML writers for OpenAPI specification</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -83,7 +83,7 @@ namespace Microsoft.OpenApi.Models
             Workspace = document?.Workspace != null ? new(document?.Workspace) : null;
             Info = document?.Info != null ? new(document?.Info) : null;
             Servers = document?.Servers != null ? new List<OpenApiServer>(document.Servers) : null;
-            Paths = document?.Paths;
+            Paths = document?.Paths != null ? new(document?.Paths) : null;
             Components = document?.Components != null ? new(document?.Components) : null;
             SecurityRequirements = document?.SecurityRequirements != null ? new List<OpenApiSecurityRequirement>(document.SecurityRequirements) : null;
             Tags = document?.Tags != null ? new List<OpenApiTag>(document.Tags) : null;

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -83,7 +83,7 @@ namespace Microsoft.OpenApi.Models
             Workspace = document?.Workspace != null ? new(document?.Workspace) : null;
             Info = document?.Info != null ? new(document?.Info) : null;
             Servers = document?.Servers != null ? new List<OpenApiServer>(document.Servers) : null;
-            if (document.Paths != null)
+            if (document?.Paths != null)
             {
                 Paths = new();
                 Paths = document.Paths;

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -83,11 +83,7 @@ namespace Microsoft.OpenApi.Models
             Workspace = document?.Workspace != null ? new(document?.Workspace) : null;
             Info = document?.Info != null ? new(document?.Info) : null;
             Servers = document?.Servers != null ? new List<OpenApiServer>(document.Servers) : null;
-            if (document?.Paths != null)
-            {
-                Paths = new();
-                Paths = document.Paths;
-            }
+            Paths = document?.Paths;
             Components = document?.Components != null ? new(document?.Components) : null;
             SecurityRequirements = document?.SecurityRequirements != null ? new List<OpenApiSecurityRequirement>(document.SecurityRequirements) : null;
             Tags = document?.Tags != null ? new List<OpenApiTag>(document.Tags) : null;

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
 using System;
@@ -83,7 +83,11 @@ namespace Microsoft.OpenApi.Models
             Workspace = document?.Workspace != null ? new(document?.Workspace) : null;
             Info = document?.Info != null ? new(document?.Info) : null;
             Servers = document?.Servers != null ? new List<OpenApiServer>(document.Servers) : null;
-            Paths = document?.Paths != null ? new(document?.Paths) : null;
+            if (document.Paths != null)
+            {
+                Paths = new();
+                Paths = document.Paths;
+            }
             Components = document?.Components != null ? new(document?.Components) : null;
             SecurityRequirements = document?.SecurityRequirements != null ? new List<OpenApiSecurityRequirement>(document.SecurityRequirements) : null;
             Tags = document?.Tags != null ? new List<OpenApiTag>(document.Tags) : null;

--- a/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
 
@@ -17,6 +16,23 @@ namespace Microsoft.OpenApi.Models
         IOpenApiExtensible
         where T : IOpenApiSerializable
     {
+        /// <summary>
+        /// Parameterless constructor
+        /// </summary>
+        protected OpenApiExtensibleDictionary() { }
+
+        /// <summary>
+        /// Initializes a copy of <see cref="OpenApiExtensibleDictionary{T}"/> class.
+        /// </summary>
+        /// <param name="dictionary">The generic dictionary.</param>
+        /// <param name="extensions">The dictionary of <see cref="IOpenApiExtension"/>.</param>
+        protected OpenApiExtensibleDictionary(
+            Dictionary<string, T> dictionary = null,
+            IDictionary<string, IOpenApiExtension> extensions = null) : base (dictionary)
+        {
+            Extensions = extensions != null ? new Dictionary<string, IOpenApiExtension>(extensions) : null;
+        }       
+
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiPaths.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiPaths.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Initializes a copy of <see cref="OpenApiPaths"/> object
         /// </summary>
-        public OpenApiPaths(OpenApiPaths paths) {}
-
+        /// <param name="paths">The <see cref="OpenApiPaths"/>.</param>
+        public OpenApiPaths(OpenApiPaths paths) : base(dictionary: paths) {}
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
@@ -1342,5 +1342,19 @@ paths: { }";
 
             return openApiDoc;
         }
+
+        [Fact]
+        public void CopyConstructorForAdvancedDocumentWorks()
+        {
+            // Arrange & Act
+            var doc = new OpenApiDocument(AdvancedDocument);
+
+            // Assert
+            Assert.NotNull(doc.Info);
+            Assert.NotNull(doc.Servers);
+            Assert.NotNull(doc.Paths);
+            Assert.Equal(2, doc.Paths.Count);
+            Assert.NotNull(doc.Components);
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -581,6 +581,7 @@ namespace Microsoft.OpenApi.Models
         where T : Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
         protected OpenApiExtensibleDictionary() { }
+        protected OpenApiExtensibleDictionary(System.Collections.Generic.Dictionary<string, T> dictionary = null, System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> extensions = null) { }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; set; }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET/issues/1007

This PR:
- Ensures `Paths` are copied in the copy constructor of `OpenApiDocument`.
- Adds test to validate the above.