### PR TITLE
fix: invariant culture for version field

### DIFF
--- a/src/Microsoft.OpenApi/Writers/SpecialCharacterStringExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/SpecialCharacterStringExtensions.cs
@@ -192,7 +192,7 @@ namespace Microsoft.OpenApi.Writers
             if (decimal.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out var _) ||
                 IsHexadecimalNotation(input) ||
                 bool.TryParse(input, out var _) ||
-                DateTime.TryParse(input, out var _))
+                DateTime.TryParse(input, CultureInfo.InvariantCulture, DateTimeStyles.None, out var _))
             {
                 return $"'{input}'";
             }

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterSpecialCharacterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterSpecialCharacterTests.cs
@@ -148,5 +148,26 @@ namespace Microsoft.OpenApi.Tests.Writers
             // Assert
             actual.Should().Be(expected);
         }
+
+        [Theory]
+        [InlineData("1.8.0", " '1.8.0'", "en-US")]
+        [InlineData("1.8.0", " '1.8.0'", "en-GB")]
+        [InlineData("1.13.0", " '1.13.0'", "en-US")]
+        [InlineData("1.13.0", " '1.13.0'", "en-GB")]
+        public void WriteStringAsYamlDoesNotDependOnSystemCulture(string input, string expected, string culture)
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(culture);
+            
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiYamlWriter(outputStringWriter);
+            
+            // Act
+            writer.WriteValue(input);
+            var actual = outputStringWriter.GetStringBuilder().ToString();
+
+            // Assert
+            actual.Should().Be(expected);
+        }
     }
 }


### PR DESCRIPTION
Writing version field depends on current system culture 
`version: '1.13.0'` for `en-US`
`version: 1.13.0` for `en-GB`

existing workaround:
set `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT` environment variable 
https://learn.microsoft.com/en-us/dotnet/core/runtime-config/globalization#invariant-mode