### PR TITLE
- bumps minor for hidi

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -15,7 +15,7 @@
     <PackageId>Microsoft.OpenApi.Hidi</PackageId>
     <ToolCommandName>hidi</ToolCommandName>
     <PackageOutputPath>./../../artifacts</PackageOutputPath>
-    <Version>1.0.0-preview10</Version>
+    <Version>1.1.0-preview1</Version>
     <Description>OpenAPI.NET CLI tool for slicing OpenAPI documents</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>OpenAPI .NET</PackageTags>


### PR DESCRIPTION
bumps minor for hidi since the preview10 label is not considered a newer version than preview9 by nuget. https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=86423&view=logs&j=aa033440-3a4f-5530-5739-e7066bf05a26&t=384f8f03-5b5b-582f-91ea-efd11deadcd6