### PR TITLE
Copy OpenApiResponses object from source OpenApiOperation

### DIFF
--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -11,7 +11,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi</Title>
         <PackageId>Microsoft.OpenApi</PackageId>
-        <Version>1.4.2</Version>
+        <Version>1.4.3</Version>
         <Description>.NET models with JSON and YAML writers for OpenAPI specification</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/src/Microsoft.OpenApi/Models/OpenApiResponses.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponses.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Initializes a copy of <see cref="OpenApiResponses"/> object
         /// </summary>
-        public OpenApiResponses(OpenApiResponses openApiResponses) { }
-
+        /// <param name="openApiResponses">The <see cref="OpenApiResponses"/></param>
+        public OpenApiResponses(OpenApiResponses openApiResponses) : base(dictionary: openApiResponses) {}
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiOperationTests.cs
@@ -787,5 +787,16 @@ namespace Microsoft.OpenApi.Tests.Models
             expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
+
+        [Fact]
+        public void EnsureOpenApiOperationCopyConstructorCopiesResponsesObject()
+        {
+            // Arrange and act
+            var operation = new OpenApiOperation(_operationWithBody);
+
+            // Assert
+            Assert.NotNull(operation.Responses);
+            Assert.Equal(2, operation.Responses.Count);
+        }
     }
 }


### PR DESCRIPTION
Fixes #995 
This PR:
- Ensures `Responses` are copied over in the `OpenApiOperation` copy constructor
- Adds a test case for validation 
- Bumps up lib version 