### PR TITLE
Adds a summary property in the info object

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiV2Deserializer.cs
@@ -113,8 +113,6 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 try
                 {
-                    var newProperty = new List<IOpenApiAny>();
-
                     mapNode.Context.StartObject(anyMapFieldName);
 
                     foreach (var propertyMapElement in anyMapFieldMap[anyMapFieldName].PropertyMapGetter(domainObject))

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiInfoDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiInfoDeserializer.cs
@@ -69,10 +69,7 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiInfo LoadInfo(ParseNode node)
         {
             var mapNode = node.CheckMapNode("Info");
-
             var info = new OpenApiInfo();
-            var required = new List<string> { "title", "version" };
-
             ParseMap(mapNode, info, InfoFixedFields, InfoPatternFields);
 
             return info;

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiInfoDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiInfoDeserializer.cs
@@ -30,6 +30,12 @@ namespace Microsoft.OpenApi.Readers.V3
                 }
             },
             {
+                "summary", (o, n) =>
+                {
+                    o.Summary = n.GetScalarValue();
+                }
+            },
+            {
                 "description", (o, n) =>
                 {
                     o.Description = n.GetScalarValue();

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiResponseDeserializer.cs
@@ -58,7 +58,6 @@ namespace Microsoft.OpenApi.Readers.V3
                 return mapNode.GetReferencedObject<OpenApiResponse>(ReferenceType.Response, pointer);
             }
 
-            var requiredFields = new List<string> { "description" };
             var response = new OpenApiResponse();
             ParseMap(mapNode, response, _responseFixedFields, _responsePatternFields);
 

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiV3Deserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiV3Deserializer.cs
@@ -108,9 +108,7 @@ namespace Microsoft.OpenApi.Readers.V3
             foreach (var anyMapFieldName in anyMapFieldMap.Keys.ToList())
             {
                 try
-                {
-                    var newProperty = new List<IOpenApiAny>();
-
+                {                   
                     mapNode.Context.StartObject(anyMapFieldName);
 
                     foreach (var propertyMapElement in anyMapFieldMap[anyMapFieldName].PropertyMapGetter(domainObject))

--- a/src/Microsoft.OpenApi/Models/OpenApiInfo.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiInfo.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
 
@@ -20,10 +19,15 @@ namespace Microsoft.OpenApi.Models
         public string Title { get; set; }
 
         /// <summary>
+        /// A short summary of the API.
+        /// </summary>
+        public string Summary { get; set; }
+        
+        /// <summary>
         /// A short description of the application.
         /// </summary>
         public string Description { get; set; }
-
+        
         /// <summary>
         /// REQUIRED. The version of the OpenAPI document.
         /// </summary>
@@ -60,6 +64,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiInfo(OpenApiInfo info)
         {
             Title = info?.Title ?? Title;
+            Summary = info?.Summary ?? Summary;
             Description = info?.Description ?? Description;
             Version = info?.Version ?? Version;
             TermsOfService = info?.TermsOfService ?? TermsOfService;
@@ -83,6 +88,9 @@ namespace Microsoft.OpenApi.Models
             // title
             writer.WriteProperty(OpenApiConstants.Title, Title);
 
+            // summary
+            writer.WriteProperty(OpenApiConstants.Summary, Summary);
+            
             // description
             writer.WriteProperty(OpenApiConstants.Description, Description);
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiInfoTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiInfoTests.cs
@@ -41,6 +41,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                     new OpenApiInfo
                     {
                         Title = "Advanced Info",
+                        Summary = "Sample Summary",
                         Description = "Sample Description",
                         Version = "1.0.0",
                         TermsOfService = new Uri("http://example.org/termsOfService"),
@@ -101,6 +102,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                     new OpenApiInfo
                     {
                         Title = "Basic Info",
+                        Summary = "Sample Summary",
                         Description = "Sample Description",
                         Version = "1.0.1",
                         TermsOfService = new Uri("http://swagger.io/terms/"),

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiInfo/advancedInfo.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiInfo/advancedInfo.yaml
@@ -1,5 +1,6 @@
 ﻿title: Advanced Info
 version: 1.0.0
+summary: Sample Summary
 description: Sample Description
 termsOfService: http://example.org/termsOfService
 contact: 

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiInfo/basicInfo.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiInfo/basicInfo.yaml
@@ -1,5 +1,6 @@
 {
   "title": "Basic Info",
+  "summary": "Sample Summary",
   "description": "Sample Description",
   "termsOfService": "http://swagger.io/terms/",
   "contact": {

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiInfoTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiInfoTests.cs
@@ -8,6 +8,7 @@ using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using SharpYaml;
 using Xunit;
 
 namespace Microsoft.OpenApi.Tests.Models
@@ -27,6 +28,14 @@ namespace Microsoft.OpenApi.Tests.Models
             {
                 {"x-updated", new OpenApiString("metadata")}
             }
+        };
+
+        public static OpenApiInfo InfoWithSummary = new()
+        {
+            Title = "Sample Pet Store App",
+            Summary = "This is a sample server for a pet store.",
+            Description = "This is a sample server for a pet store.",
+            Version = "1.1.1",
         };
 
         public static OpenApiInfo BasicInfo = new OpenApiInfo
@@ -101,6 +110,7 @@ version: '1.0'"
                     specVersion,
                     @"{
   ""title"": ""Sample Pet Store App"",
+  ""summary"": ""This is a sample server for a pet store."",
   ""description"": ""This is a sample server for a pet store."",
   ""termsOfService"": ""http://example.com/terms/"",
   ""contact"": {
@@ -194,6 +204,44 @@ version: '2017-03-01'";
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializeInfoObjectWithSummaryAsV3YamlWorks()
+        {
+            // Arrange
+            var expected = @"title: Sample Pet Store App
+summary: This is a sample server for a pet store.
+description: This is a sample server for a pet store.
+version: '1.1.1'";
+
+            // Act
+            var actual = InfoWithSummary.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_0);
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void SerializeInfoObjectWithSummaryAsV3JsonWorks()
+        {
+            // Arrange
+            var expected = @"{
+  ""title"": ""Sample Pet Store App"",
+  ""summary"": ""This is a sample server for a pet store."",
+  ""description"": ""This is a sample server for a pet store."",
+  ""version"": ""1.1.1""
+}";
+            
+            // Act
+            var actual = InfoWithSummary.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            Assert.Equal(expected, actual);
         }
     }
 }


### PR DESCRIPTION
This PR:
- Adds a Summary field to the OpenApiInfo object as per the [OpenAPI 3.1 spec](https://spec.openapis.org/oas/v3.1.0#info-object).
- Adds tests for validation