### PR TITLE
Add license SPDX identifier

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiLicenseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiLicenseDeserializer.cs
@@ -23,6 +23,12 @@ namespace Microsoft.OpenApi.Readers.V3
                 }
             },
             {
+                "identifier", (o, n) =>
+                {
+                    o.Identifier = n.GetScalarValue();
+                }
+            },
+            {
                 "url", (o, n) =>
                 {
                     o.Url = new Uri(n.GetScalarValue(), UriKind.RelativeOrAbsolute);

--- a/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
@@ -121,6 +121,11 @@ namespace Microsoft.OpenApi.Models
         public const string Name = "name";
 
         /// <summary>
+        /// Field: Identifier
+        /// </summary>
+        public const string Identifier = "identifier";
+
+        /// <summary>
         /// Field: Namespace
         /// </summary>
         public const string Namespace = "namespace";

--- a/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
@@ -20,6 +20,11 @@ namespace Microsoft.OpenApi.Models
         public string Name { get; set; }
 
         /// <summary>
+        /// An SPDX license expression for the API. The identifier field is mutually exclusive of the url field.
+        /// </summary>
+        public string Identifier { get; set; }
+
+        /// <summary>
         /// The URL pointing to the contact information. MUST be in the format of a URL.
         /// </summary>
         public Uri Url { get; set; }
@@ -40,6 +45,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiLicense(OpenApiLicense license)
         {
             Name = license?.Name ?? Name;
+            Identifier = license?.Identifier ?? Identifier;
             Url = license?.Url != null ? new Uri(license.Url.OriginalString) : null;
             Extensions = license?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(license.Extensions) : null;
         }
@@ -71,6 +77,9 @@ namespace Microsoft.OpenApi.Models
 
             // name
             writer.WriteProperty(OpenApiConstants.Name, Name);
+
+            // identifier
+            writer.WriteProperty(OpenApiConstants.Identifier, Identifier);
 
             // url
             writer.WriteProperty(OpenApiConstants.Url, Url?.OriginalString);

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net6.0</TargetFrameworks>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -162,6 +162,9 @@
       <EmbeddedResource Include="V3Tests\Samples\OpenApiExample\explicitString.yaml" />
       <EmbeddedResource Include="V3Tests\Samples\OpenApiResponse\responseWithHeaderReference.yaml" />
       <EmbeddedResource Include="V3Tests\Samples\OpenApiInfo\basicInfo.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiLicense\licenseWithSpdxIdentifier.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
       <EmbeddedResource Include="V3Tests\Samples\OpenApiInfo\minimalInfo.yaml">

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiLicenseTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiLicenseTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. 
+
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.ParseNodes;
+using Microsoft.OpenApi.Readers.V3;
+using SharpYaml.Serialization;
+using System.IO;
+using Xunit;
+using System.Linq;
+using FluentAssertions;
+
+namespace Microsoft.OpenApi.Readers.Tests.V3Tests
+{
+
+    public class OpenApiLicenseTests
+    {
+        private const string SampleFolderPath = "V3Tests/Samples/OpenApiLicense/";
+
+        [Fact]
+        public void ParseLicenseWithSpdxIdentifierShouldSucceed()
+        {
+            using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "licenseWithSpdxIdentifier.yaml"));
+            var yamlStream = new YamlStream();
+            yamlStream.Load(new StreamReader(stream));
+            var yamlNode = yamlStream.Documents.First().RootNode;
+
+            var diagnostic = new OpenApiDiagnostic();
+            var context = new ParsingContext(diagnostic);
+
+            var node = new MapNode(context, (YamlMappingNode)yamlNode);
+
+            // Act
+            var license = OpenApiV3Deserializer.LoadLicense(node);
+
+            // Assert
+            license.Should().BeEquivalentTo(
+                new OpenApiLicense
+                {
+                    Name = "Apache 2.0",
+                    Identifier = "Apache-2.0"
+                });
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiLicense/licenseWithSpdxIdentifier.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiLicense/licenseWithSpdxIdentifier.yaml
@@ -1,0 +1,2 @@
+﻿name: Apache 2.0
+identifier: Apache-2.0

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiLicenseTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiLicenseTests.cs
@@ -30,6 +30,12 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
+        public static OpenApiLicense LicenseWithIdentifier = new OpenApiLicense
+        {
+            Name = "Apache 2.0",
+            Identifier = "Apache-2.0"
+        };
+
         [Theory]
         [InlineData(OpenApiSpecVersion.OpenApi3_0)]
         [InlineData(OpenApiSpecVersion.OpenApi2_0)]
@@ -122,6 +128,37 @@ x-copyright: Abc";
             // Assert
             Assert.NotEqual(AdvanceLicense.Name, licenseCopy.Name);
             Assert.NotEqual(AdvanceLicense.Url, licenseCopy.Url);
+        }
+
+        [Fact]
+        public void SerializeLicenseWithIdentifierAsJsonWorks()
+        {
+            // Arrange
+            var expected =
+                @"{
+  ""name"": ""Apache 2.0"",
+  ""identifier"": ""Apache-2.0""
+}";
+
+            // Act
+            var actual = LicenseWithIdentifier.SerializeAsJson(OpenApiSpecVersion.OpenApi3_0);
+
+            // Assert
+            Assert.Equal(expected.MakeLineBreaksEnvironmentNeutral(), actual.MakeLineBreaksEnvironmentNeutral());
+        }
+        
+        [Fact]
+        public void SerializeLicenseWithIdentifierAsYamlWorks()
+        {
+            // Arrange
+            var expected = @"name: Apache 2.0
+identifier: Apache-2.0";
+
+            // Act
+            var actual = LicenseWithIdentifier.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_0);
+
+            // Assert
+            Assert.Equal(expected.MakeLineBreaksEnvironmentNeutral(), actual.MakeLineBreaksEnvironmentNeutral());
         }
     }
 }


### PR DESCRIPTION
Adds a license identifier field in the license object for the [SPDX license expression](https://spec.openapis.org/oas/v3.1.0#license-object) for an API.