### PR TITLE
Upgrades conversion lib. version

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -15,7 +15,7 @@
     <PackageId>Microsoft.OpenApi.Hidi</PackageId>
     <ToolCommandName>hidi</ToolCommandName>
     <PackageOutputPath>./../../artifacts</PackageOutputPath>
-    <Version>1.1.0-preview2</Version>
+    <Version>1.1.0-preview3</Version>
     <Description>OpenAPI.NET CLI tool for slicing OpenAPI documents</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>OpenAPI .NET</PackageTags>
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.12.4" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.2.0-preview4" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.2.0-preview5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR:
- Upgrades the conversion lib. version. This is to capture the fix https://github.com/microsoft/OpenAPI.NET.OData/pull/299
- Bumps up Hidi version