### PR TITLE
Remove return statement to eliminate NullReference exception

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
@@ -105,7 +105,6 @@ namespace Microsoft.OpenApi.Readers.V3
                         catch (OpenApiException ex)
                         {
                             Diagnostic.Errors.Add(new OpenApiError(ex));
-                            return null;
                         }
                     }
                     // Where fragments point into a non-OpenAPI document, the id will be the complete fragment identifier


### PR DESCRIPTION
Returning a null value once an exception is caught and added to the diagnostics object raises a `NullReferenceException` as the new `schema.Reference` object created during schema deserialization is assigned a null value when trying to convert the schema into an `OpenApiReference` object as shown [in this snippet](https://github.com/microsoft/OpenAPI.NET/blob/996dff454259178fb0d40e74a8c2741b3b7b9ab4/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs#L279-L288).           
Meanwhile, there's an actual reference object considering a reference pointer is found in the schema. This means that the value of the '$ref' passed is either unsupported or incorrect.

Fixes #1045