### PR TITLE
Add summary and description to OpenApiReference object

### DIFF
--- a/src/Microsoft.OpenApi.Readers/Interface/IOpenApiVersionService.cs
+++ b/src/Microsoft.OpenApi.Readers/Interface/IOpenApiVersionService.cs
@@ -19,8 +19,10 @@ namespace Microsoft.OpenApi.Readers.Interface
         /// </summary>
         /// <param name="reference">The reference string.</param>
         /// <param name="type">The type of the reference.</param>
+        /// <param name="summary">The summary of the reference.</param>
+        /// <param name="description">A reference description</param>
         /// <returns>The <see cref="OpenApiReference"/> object or null.</returns>
-        OpenApiReference ConvertToOpenApiReference(string reference, ReferenceType? type);
+        OpenApiReference ConvertToOpenApiReference(string reference, ReferenceType? type, string summary = null, string description = null);
 
         /// <summary>
         /// Loads an OpenAPI Element from a document fragment
@@ -36,5 +38,13 @@ namespace Microsoft.OpenApi.Readers.Interface
         /// <param name="rootNode">RootNode containing the information to be converted into an OpenAPI Document</param>
         /// <returns>Instance of OpenApiDocument populated with data from rootNode</returns>
         OpenApiDocument LoadDocument(RootNode rootNode);
+
+        /// <summary>
+        /// Gets the description and summary scalar values in a reference object for V3.1 support
+        /// </summary>
+        /// <param name="mapNode">A YamlMappingNode.</param>
+        /// <param name="scalarValue">The scalar value we're parsing.</param>
+        /// <returns>The resulting node value.</returns>
+        string GetReferenceScalarValues(MapNode mapNode, string scalarValue);
     }
 }

--- a/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+++ b/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0</TargetFrameworks>
+        <LangVersion>9.0</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
         <PackageProjectUrl>https://github.com/Microsoft/OpenAPI.NET</PackageProjectUrl>

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/MapNode.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/MapNode.cs
@@ -181,13 +181,13 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             return x.Serialize(_node);
         }
 
-        public T GetReferencedObject<T>(ReferenceType referenceType, string referenceId)
+        public T GetReferencedObject<T>(ReferenceType referenceType, string referenceId, string summary = null, string description = null)
             where T : IOpenApiReferenceable, new()
         {
             return new T()
             {
                 UnresolvedReference = true,
-                Reference = Context.VersionService.ConvertToOpenApiReference(referenceId, referenceType)
+                Reference = Context.VersionService.ConvertToOpenApiReference(referenceId, referenceType, summary, description)
             };
         }
 

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiV2VersionService.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiV2VersionService.cs
@@ -225,7 +225,7 @@ namespace Microsoft.OpenApi.Readers.V2
         /// <inheritdoc />
         public string GetReferenceScalarValues(MapNode mapNode, string scalarValue)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiV2VersionService.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiV2VersionService.cs
@@ -134,7 +134,7 @@ namespace Microsoft.OpenApi.Readers.V2
         /// <summary>
         /// Parse the string to a <see cref="OpenApiReference"/> object.
         /// </summary>
-        public OpenApiReference ConvertToOpenApiReference(string reference, ReferenceType? type)
+        public OpenApiReference ConvertToOpenApiReference(string reference, ReferenceType? type, string summary = null, string description = null)
         {
             if (!string.IsNullOrWhiteSpace(reference))
             {
@@ -220,6 +220,12 @@ namespace Microsoft.OpenApi.Readers.V2
         public T LoadElement<T>(ParseNode node) where T : IOpenApiElement
         {
             return (T)_loaders[typeof(T)](node);
+        }
+
+        /// <inheritdoc />
+        public string GetReferenceScalarValues(MapNode mapNode, string scalarValue)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiExampleDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiExampleDeserializer.cs
@@ -52,17 +52,12 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiExample LoadExample(ParseNode node)
         {
             var mapNode = node.CheckMapNode("example");
-            string description = null;
-            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
             if (pointer != null)
             {
-                if (mapNode.Count() > 1)
-                {
-                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
-                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
-                }
+                var description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                var summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);                
                 
                 return mapNode.GetReferencedObject<OpenApiExample>(ReferenceType.Example, pointer, summary, description);
             }

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiExampleDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiExampleDeserializer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Linq;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
@@ -51,11 +52,19 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiExample LoadExample(ParseNode node)
         {
             var mapNode = node.CheckMapNode("example");
+            string description = null;
+            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
             if (pointer != null)
             {
-                return mapNode.GetReferencedObject<OpenApiExample>(ReferenceType.Example, pointer);
+                if (mapNode.Count() > 1)
+                {
+                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                }
+                
+                return mapNode.GetReferencedObject<OpenApiExample>(ReferenceType.Example, pointer, summary, description);
             }
 
             var example = new OpenApiExample();

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiHeaderDeserializer.cs
@@ -86,17 +86,13 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiHeader LoadHeader(ParseNode node)
         {
             var mapNode = node.CheckMapNode("header");
-            string description = null;
-            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
             if (pointer != null)
             {
-                if (mapNode.Count() > 1)
-                {
-                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
-                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
-                }
+                var description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                var summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                
                 return mapNode.GetReferencedObject<OpenApiHeader>(ReferenceType.Header, pointer, summary, description);
             }
 

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiHeaderDeserializer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Linq;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
@@ -85,11 +86,18 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiHeader LoadHeader(ParseNode node)
         {
             var mapNode = node.CheckMapNode("header");
+            string description = null;
+            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
             if (pointer != null)
             {
-                return mapNode.GetReferencedObject<OpenApiHeader>(ReferenceType.Header, pointer);
+                if (mapNode.Count() > 1)
+                {
+                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                }
+                return mapNode.GetReferencedObject<OpenApiHeader>(ReferenceType.Header, pointer, summary, description);
             }
 
             var header = new OpenApiHeader();

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiLinkDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiLinkDeserializer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Linq;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
@@ -57,11 +58,18 @@ namespace Microsoft.OpenApi.Readers.V3
         {
             var mapNode = node.CheckMapNode("link");
             var link = new OpenApiLink();
+            string description = null;
+            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
             if (pointer != null)
             {
-                return mapNode.GetReferencedObject<OpenApiLink>(ReferenceType.Link, pointer);
+                if (mapNode.Count() > 1)
+                {
+                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                }
+                return mapNode.GetReferencedObject<OpenApiLink>(ReferenceType.Link, pointer, summary, description);
             }
 
             ParseMap(mapNode, link, _linkFixedFields, _linkPatternFields);

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiLinkDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiLinkDeserializer.cs
@@ -58,17 +58,13 @@ namespace Microsoft.OpenApi.Readers.V3
         {
             var mapNode = node.CheckMapNode("link");
             var link = new OpenApiLink();
-            string description = null;
-            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
             if (pointer != null)
             {
-                if (mapNode.Count() > 1)
-                {
-                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
-                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
-                }
+                var description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                var summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                
                 return mapNode.GetReferencedObject<OpenApiLink>(ReferenceType.Link, pointer, summary, description);
             }
 

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiParameterDeserializer.cs
@@ -142,17 +142,13 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiParameter LoadParameter(ParseNode node)
         {
             var mapNode = node.CheckMapNode("parameter");
-            string description = null;
-            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
             if (pointer != null)
             {
-                if (mapNode.Count() > 1)
-                {
-                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
-                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
-                }
+                var description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                var summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                
                 return mapNode.GetReferencedObject<OpenApiParameter>(ReferenceType.Parameter, pointer, summary, description);
             }
 

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiParameterDeserializer.cs
@@ -142,11 +142,18 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiParameter LoadParameter(ParseNode node)
         {
             var mapNode = node.CheckMapNode("parameter");
+            string description = null;
+            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
             if (pointer != null)
             {
-                return mapNode.GetReferencedObject<OpenApiParameter>(ReferenceType.Parameter, pointer);
+                if (mapNode.Count() > 1)
+                {
+                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                }
+                return mapNode.GetReferencedObject<OpenApiParameter>(ReferenceType.Parameter, pointer, summary, description);
             }
 
             var parameter = new OpenApiParameter();

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiPathItemDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiPathItemDeserializer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Linq;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
@@ -55,15 +56,22 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiPathItem LoadPathItem(ParseNode node)
         {
             var mapNode = node.CheckMapNode("PathItem");
+            string description = null;
+            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
 
             if (pointer != null)
             {
+                if (mapNode.Count() > 1)
+                {
+                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                }
                 return new OpenApiPathItem()
                 {
                     UnresolvedReference = true,
-                    Reference = node.Context.VersionService.ConvertToOpenApiReference(pointer, ReferenceType.PathItem)
+                    Reference = node.Context.VersionService.ConvertToOpenApiReference(pointer, ReferenceType.PathItem, summary, description)
                 };
             }
 

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiPathItemDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiPathItemDeserializer.cs
@@ -56,18 +56,14 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiPathItem LoadPathItem(ParseNode node)
         {
             var mapNode = node.CheckMapNode("PathItem");
-            string description = null;
-            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
 
             if (pointer != null)
             {
-                if (mapNode.Count() > 1)
-                {
-                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
-                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
-                }
+                var description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                var summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                
                 return new OpenApiPathItem()
                 {
                     UnresolvedReference = true,

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiRequestBodyDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiRequestBodyDeserializer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Linq;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
@@ -45,11 +46,18 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiRequestBody LoadRequestBody(ParseNode node)
         {
             var mapNode = node.CheckMapNode("requestBody");
+            string description = null;
+            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
             if (pointer != null)
             {
-                return mapNode.GetReferencedObject<OpenApiRequestBody>(ReferenceType.RequestBody, pointer);
+                if (mapNode.Count() > 1)
+                {
+                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                }
+                return mapNode.GetReferencedObject<OpenApiRequestBody>(ReferenceType.RequestBody, pointer, summary, description);
             }
 
             var requestBody = new OpenApiRequestBody();

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiRequestBodyDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiRequestBodyDeserializer.cs
@@ -46,17 +46,13 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiRequestBody LoadRequestBody(ParseNode node)
         {
             var mapNode = node.CheckMapNode("requestBody");
-            string description = null;
-            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
             if (pointer != null)
             {
-                if (mapNode.Count() > 1)
-                {
-                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
-                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
-                }
+                var description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                var summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                
                 return mapNode.GetReferencedObject<OpenApiRequestBody>(ReferenceType.RequestBody, pointer, summary, description);
             }
 

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiResponseDeserializer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
@@ -51,11 +52,18 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiResponse LoadResponse(ParseNode node)
         {
             var mapNode = node.CheckMapNode("response");
+            string description = null;
+            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
             if (pointer != null)
             {
-                return mapNode.GetReferencedObject<OpenApiResponse>(ReferenceType.Response, pointer);
+                if (mapNode.Count() > 1)
+                {
+                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                }
+                return mapNode.GetReferencedObject<OpenApiResponse>(ReferenceType.Response, pointer, summary, description);
             }
 
             var response = new OpenApiResponse();

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiResponseDeserializer.cs
@@ -52,17 +52,14 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiResponse LoadResponse(ParseNode node)
         {
             var mapNode = node.CheckMapNode("response");
-            string description = null;
-            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
             if (pointer != null)
             {
-                if (mapNode.Count() > 1)
-                {
-                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
-                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
-                }
+
+                var description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                var summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                
                 return mapNode.GetReferencedObject<OpenApiResponse>(ReferenceType.Response, pointer, summary, description);
             }
 

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -276,17 +276,12 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiSchema LoadSchema(ParseNode node)
         {
             var mapNode = node.CheckMapNode(OpenApiConstants.Schema);
-            string description = null;
-            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
             if (pointer != null)
-            {
-                if(mapNode.Count() > 1)
-                {                    
-                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
-                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
-                }
+            {                   
+                var description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                var summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
 
                 return new OpenApiSchema
                 {
@@ -294,7 +289,7 @@ namespace Microsoft.OpenApi.Readers.V3
                     Reference = node.Context.VersionService.ConvertToOpenApiReference(pointer, ReferenceType.Schema, summary, description)
                 };
             }
-
+            
             var schema = new OpenApiSchema();
 
             foreach (var propertyNode in mapNode)

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -7,6 +7,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 
 namespace Microsoft.OpenApi.Readers.V3
 {
@@ -275,15 +276,22 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiSchema LoadSchema(ParseNode node)
         {
             var mapNode = node.CheckMapNode(OpenApiConstants.Schema);
+            string description = null;
+            string summary = null;
 
             var pointer = mapNode.GetReferencePointer();
-
             if (pointer != null)
             {
-                return new OpenApiSchema()
+                if(mapNode.Count() > 1)
+                {                    
+                    description = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Description);
+                    summary = node.Context.VersionService.GetReferenceScalarValues(mapNode, OpenApiConstants.Summary);
+                }
+
+                return new OpenApiSchema
                 {
                     UnresolvedReference = true,
-                    Reference = node.Context.VersionService.ConvertToOpenApiReference(pointer, ReferenceType.Schema)
+                    Reference = node.Context.VersionService.ConvertToOpenApiReference(pointer, ReferenceType.Schema, summary, description)
                 };
             }
 

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
@@ -166,10 +166,17 @@ namespace Microsoft.OpenApi.Readers.V3
         /// <inheritdoc />
         public string GetReferenceScalarValues(MapNode mapNode, string scalarValue)
         {
-            var valueNode = mapNode.Where(x => x.Name.Equals(scalarValue))
+            var filteredList = mapNode.Where(x => x.Name != "$ref");
+
+            if (filteredList.Any())
+            {
+                var valueNode = mapNode.Where(x => x.Name.Equals(scalarValue))
                 .Select(static x => x.Value).OfType<ValueNode>().FirstOrDefault();
 
-            return valueNode.GetScalarValue();
+                return valueNode.GetScalarValue();
+            }
+
+            return null;
         }
 
         private OpenApiReference ParseLocalReference(string localReference, string summary = null, string description = null)

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Extensions;
@@ -67,9 +68,13 @@ namespace Microsoft.OpenApi.Readers.V3
         /// </summary>
         /// <param name="reference">The URL of the reference</param>
         /// <param name="type">The type of object refefenced based on the context of the reference</param>
+        /// <param name="summary">The summary of the reference</param>
+        /// <param name="description">A reference description</param>
         public OpenApiReference ConvertToOpenApiReference(
             string reference,
-            ReferenceType? type)
+            ReferenceType? type,
+            string summary = null,
+            string description = null)
         {
             if (!string.IsNullOrWhiteSpace(reference))
             {
@@ -80,6 +85,8 @@ namespace Microsoft.OpenApi.Readers.V3
                     {
                         return new OpenApiReference
                         {
+                            Summary = summary,
+                            Description = description,
                             Type = type,
                             Id = reference
                         };
@@ -89,6 +96,8 @@ namespace Microsoft.OpenApi.Readers.V3
                     // or a simple string-style reference for tag and security scheme.
                     return new OpenApiReference
                     {
+                        Summary = summary,
+                        Description = description,
                         Type = type,
                         ExternalResource = segments[0]
                     };
@@ -100,7 +109,7 @@ namespace Microsoft.OpenApi.Readers.V3
                         // "$ref": "#/components/schemas/Pet"
                         try
                         {
-                            return ParseLocalReference(segments[1]);
+                            return ParseLocalReference(segments[1], summary, description);
                         }
                         catch (OpenApiException ex)
                         {
@@ -131,6 +140,8 @@ namespace Microsoft.OpenApi.Readers.V3
 
                     return new OpenApiReference
                     {
+                        Summary = summary,
+                        Description = description,
                         ExternalResource = segments[0],
                         Type = type,
                         Id = id
@@ -151,7 +162,17 @@ namespace Microsoft.OpenApi.Readers.V3
             return (T)_loaders[typeof(T)](node);
         }
 
-        private OpenApiReference ParseLocalReference(string localReference)
+
+        /// <inheritdoc />
+        public string GetReferenceScalarValues(MapNode mapNode, string scalarValue)
+        {
+            var valueNode = mapNode.Where(x => x.Name.Equals(scalarValue))
+                .Select(x => x.Value as ValueNode).FirstOrDefault();
+
+            return valueNode.GetScalarValue();
+        }
+
+        private OpenApiReference ParseLocalReference(string localReference, string summary = null, string description = null)
         {
             if (string.IsNullOrWhiteSpace(localReference))
             {
@@ -170,7 +191,16 @@ namespace Microsoft.OpenApi.Readers.V3
                     {
                         refId = "/" + segments[3];
                     };
-                    return new OpenApiReference { Type = referenceType, Id = refId };
+
+                    var parsedReference = new OpenApiReference
+                    {
+                        Summary = summary,
+                        Description = description,
+                        Type = referenceType,
+                        Id = refId
+                    };
+                    
+                    return parsedReference;
                 }
             }
 

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
@@ -167,7 +167,7 @@ namespace Microsoft.OpenApi.Readers.V3
         public string GetReferenceScalarValues(MapNode mapNode, string scalarValue)
         {
             var valueNode = mapNode.Where(x => x.Name.Equals(scalarValue))
-                .Select(x => x.Value as ValueNode).FirstOrDefault();
+                .Select(static x => x.Value).OfType<ValueNode>().FirstOrDefault();
 
             return valueNode.GetScalarValue();
         }

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiV3VersionService.cs
@@ -166,9 +166,7 @@ namespace Microsoft.OpenApi.Readers.V3
         /// <inheritdoc />
         public string GetReferenceScalarValues(MapNode mapNode, string scalarValue)
         {
-            var filteredList = mapNode.Where(x => x.Name != "$ref");
-
-            if (filteredList.Any())
+            if (mapNode.Any(static x => !"$ref".Equals(x.Name, StringComparison.OrdinalIgnoreCase)))
             {
                 var valueNode = mapNode.Where(x => x.Name.Equals(scalarValue))
                 .Select(static x => x.Value).OfType<ValueNode>().FirstOrDefault();

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -504,31 +504,51 @@ namespace Microsoft.OpenApi.Models
                 switch (reference.Type)
                 {
                     case ReferenceType.Schema:
-                        return this.Components.Schemas[reference.Id];
+                        var resolvedSchema = this.Components.Schemas[reference.Id];
+                        resolvedSchema.Description = reference.Description != null ? reference.Description : resolvedSchema.Description;
+                        return resolvedSchema;
                         
                     case ReferenceType.PathItem:
-                        return this.Components.PathItems[reference.Id];
+                        var resolvedPathItem = this.Components.PathItems[reference.Id];
+                        resolvedPathItem.Description = reference.Description != null ? reference.Description : resolvedPathItem.Description;
+                        resolvedPathItem.Summary = reference.Summary != null ? reference.Summary : resolvedPathItem.Summary;
+                        return resolvedPathItem;
                         
                     case ReferenceType.Response:
-                        return this.Components.Responses[reference.Id];
+                        var resolvedResponse = this.Components.Responses[reference.Id];
+                        resolvedResponse.Description = reference.Description != null ? reference.Description : resolvedResponse.Description;
+                        return resolvedResponse;
 
                     case ReferenceType.Parameter:
-                        return this.Components.Parameters[reference.Id];
+                        var resolvedParameter = this.Components.Parameters[reference.Id];
+                        resolvedParameter.Description = reference.Description != null ? reference.Description : resolvedParameter.Description;
+                        return resolvedParameter;
 
                     case ReferenceType.Example:
-                        return this.Components.Examples[reference.Id];
+                        var resolvedExample = this.Components.Examples[reference.Id];
+                        resolvedExample.Summary = reference.Summary != null ? reference.Summary : resolvedExample.Summary;
+                        resolvedExample.Description = reference.Description != null ? reference.Description : resolvedExample.Description;
+                        return resolvedExample;
 
                     case ReferenceType.RequestBody:
-                        return this.Components.RequestBodies[reference.Id];
-
+                        var resolvedRequestBody = this.Components.RequestBodies[reference.Id];
+                        resolvedRequestBody.Description = reference.Description != null ? reference.Description : resolvedRequestBody.Description;
+                        return resolvedRequestBody;
+                        
                     case ReferenceType.Header:
-                        return this.Components.Headers[reference.Id];
-
+                        var resolvedHeader = this.Components.Headers[reference.Id];
+                        resolvedHeader.Description = reference.Description != null ? reference.Description : resolvedHeader.Description;
+                        return resolvedHeader;
+                        
                     case ReferenceType.SecurityScheme:
-                        return this.Components.SecuritySchemes[reference.Id];
-
+                        var resolvedSecurityScheme = this.Components.SecuritySchemes[reference.Id];
+                        resolvedSecurityScheme.Description = reference.Description != null ? reference.Description : resolvedSecurityScheme.Description;
+                        return resolvedSecurityScheme;
+                        
                     case ReferenceType.Link:
-                        return this.Components.Links[reference.Id];
+                        var resolvedLink = this.Components.Links[reference.Id];
+                        resolvedLink.Description = reference.Description != null ? reference.Description : resolvedLink.Description;
+                        return resolvedLink;
 
                     case ReferenceType.Callback:
                         return this.Components.Callbacks[reference.Id];

--- a/src/Microsoft.OpenApi/Models/OpenApiReference.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiReference.cs
@@ -13,6 +13,16 @@ namespace Microsoft.OpenApi.Models
     public class OpenApiReference : IOpenApiSerializable
     {
         /// <summary>
+        /// A short summary of the Reference
+        /// </summary>
+        public string Summary { get; set; }
+
+        /// <summary>
+        /// A short description of the reference
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
         /// External resource in the reference.
         /// It maybe:
         /// 1. a absolute/relative file path, for example:  ../commons/pet.json
@@ -122,6 +132,8 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         public OpenApiReference(OpenApiReference reference)
         {
+            Summary = reference?.Summary;
+            Description = reference?.Description;
             ExternalResource = reference?.ExternalResource;
             Type = reference?.Type;
             Id = reference?.Id;
@@ -153,6 +165,12 @@ namespace Microsoft.OpenApi.Models
             }
 
             writer.WriteStartObject();
+            
+            // summary
+            writer.WriteProperty(OpenApiConstants.Summary, Summary);
+            
+            // description
+            writer.WriteProperty(OpenApiConstants.Description, Description);
 
             // $ref
             writer.WriteProperty(OpenApiConstants.DollarRef, ReferenceV3);

--- a/src/Microsoft.OpenApi/Models/OpenApiReference.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiReference.cs
@@ -13,12 +13,15 @@ namespace Microsoft.OpenApi.Models
     public class OpenApiReference : IOpenApiSerializable
     {
         /// <summary>
-        /// A short summary of the Reference
+        /// A short summary which by default SHOULD override that of the referenced component.
+        /// If the referenced object-type does not allow a summary field, then this field has no effect.
         /// </summary>
         public string Summary { get; set; }
 
         /// <summary>
-        /// A short description of the reference
+        /// A description which by default SHOULD override that of the referenced component.
+        /// CommonMark syntax MAY be used for rich text representation.
+        /// If the referenced object-type does not allow a description field, then this field has no effect.
         /// </summary>
         public string Description { get; set; }
 

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -128,6 +128,9 @@
       <EmbeddedResource Include="V3Tests\Samples\OpenApiDocument\documentWithReusablePaths.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiDocument\documentWithSummaryAndDescriptionInReference.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
       <EmbeddedResource Include="V3Tests\Samples\OpenApiDiscriminator\basicDiscriminator.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiDocument/documentWithSummaryAndDescriptionInReference.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiDocument/documentWithSummaryAndDescriptionInReference.yaml
@@ -1,0 +1,46 @@
+﻿openapi: '3.1.0'
+info:
+  version: '1.0.0'
+  title: Swagger Petstore (Simple)
+paths:
+  /pets:
+    get:
+      description: Returns all pets from the system that the user has access to
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+                schema:
+                  "$ref": '#/components/schemas/pet'
+                  summary: A pet
+                  description: A pet in a petstore
+components:
+  headers:
+    X-Test:
+      description: Test
+      schema:
+        type: string
+  responses:
+    Test:
+      description: Test Repsonse
+      headers:
+        X-Test:
+          $ref: '#/components/headers/X-Test'
+          summary: X-Test header
+          description: A referenced X-Test header
+  schemas:
+    pet:
+      description: A referenced pet in a petstore
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+          name:
+            type: string
+            tag:
+              type: string

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiInfoTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiInfoTests.cs
@@ -110,7 +110,6 @@ version: '1.0'"
                     specVersion,
                     @"{
   ""title"": ""Sample Pet Store App"",
-  ""summary"": ""This is a sample server for a pet store."",
   ""description"": ""This is a sample server for a pet store."",
   ""termsOfService"": ""http://example.com/terms/"",
   ""contact"": {

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -1,7 +1,7 @@
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Microsoft/OpenAPI.NET")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Microsoft.OpenApi.Readers.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100957cb48387b2a5f54f5ce39255f18f26d32a39990db27cf48737afc6bc62759ba996b8a2bfb675d4e39f3d06ecb55a178b1b4031dcb2a767e29977d88cce864a0d16bfc1b3bebb0edf9fe285f10fffc0a85f93d664fa05af07faa3aad2e545182dbf787e3fd32b56aca95df1a3c4e75dec164a3f1a4c653d971b01ffc39eb3c4")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Microsoft.OpenApi.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100957cb48387b2a5f54f5ce39255f18f26d32a39990db27cf48737afc6bc62759ba996b8a2bfb675d4e39f3d06ecb55a178b1b4031dcb2a767e29977d88cce864a0d16bfc1b3bebb0edf9fe285f10fffc0a85f93d664fa05af07faa3aad2e545182dbf787e3fd32b56aca95df1a3c4e75dec164a3f1a4c653d971b01ffc39eb3c4")]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Microsoft.OpenApi.Any
 {
     public enum AnyType
@@ -424,6 +424,7 @@ namespace Microsoft.OpenApi.Models
         public const string Head = "head";
         public const string Headers = "headers";
         public const string Host = "host";
+        public const string Identifier = "identifier";
         public const string Implicit = "implicit";
         public const string In = "in";
         public const string Info = "info";
@@ -644,6 +645,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiLicense() { }
         public OpenApiLicense(Microsoft.OpenApi.Models.OpenApiLicense license) { }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; set; }
+        public string Identifier { get; set; }
         public string Name { get; set; }
         public System.Uri Url { get; set; }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -780,6 +782,7 @@ namespace Microsoft.OpenApi.Models
     {
         public OpenApiReference() { }
         public OpenApiReference(Microsoft.OpenApi.Models.OpenApiReference reference) { }
+        public string Description { get; set; }
         public string ExternalResource { get; set; }
         public Microsoft.OpenApi.Models.OpenApiDocument HostDocument { get; set; }
         public string Id { get; set; }
@@ -787,6 +790,7 @@ namespace Microsoft.OpenApi.Models
         public bool IsLocal { get; }
         public string ReferenceV2 { get; }
         public string ReferenceV3 { get; }
+        public string Summary { get; set; }
         public Microsoft.OpenApi.Models.ReferenceType? Type { get; set; }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }


### PR DESCRIPTION
- Adds `summary` and `description` fields to the Reference object whose values by default SHOULD override those of the referenced component.
- Adds test to validate this.