### PR TITLE
Fix check Extensions object for null to avoid null reference exception

### DIFF
--- a/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
@@ -274,7 +274,7 @@ namespace Microsoft.OpenApi.Services
 
             _visitor.Visit(openApiExtensible);
 
-            if (openApiExtensible != null)
+            if (openApiExtensible.Extensions != null)
             {
                 foreach (var item in openApiExtensible.Extensions)
                 {


### PR DESCRIPTION
using Microsoft.OpenApi.OData package it generates OpenApi document with OpenApiComponents.Extensions == null and usage of OpenApiWalker triggers an exception