### PR TITLE
Enable termination of Hidi processes through pressing the breaking key combinations

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Handlers/TransformCommandHandler.cs
+++ b/src/Microsoft.OpenApi.Hidi/Handlers/TransformCommandHandler.cs
@@ -51,7 +51,6 @@ namespace Microsoft.OpenApi.Hidi.Handlers
             string filterbytags = context.ParseResult.GetValueForOption(FilterByTagsOption);
             string filterbycollection = context.ParseResult.GetValueForOption(FilterByCollectionOption);
 
-            var console = context.Console;
             CancellationToken cancellationToken = (CancellationToken)context.BindingContext.GetService(typeof(CancellationToken));
 
             using var loggerFactory = Logger.ConfigureLogger(logLevel);

--- a/src/Microsoft.OpenApi.Hidi/Handlers/TransformCommandHandler.cs
+++ b/src/Microsoft.OpenApi.Hidi/Handlers/TransformCommandHandler.cs
@@ -50,6 +50,8 @@ namespace Microsoft.OpenApi.Hidi.Handlers
             string filterbyoperationids = context.ParseResult.GetValueForOption(FilterByOperationIdsOption);
             string filterbytags = context.ParseResult.GetValueForOption(FilterByTagsOption);
             string filterbycollection = context.ParseResult.GetValueForOption(FilterByCollectionOption);
+
+            var console = context.Console;
             CancellationToken cancellationToken = (CancellationToken)context.BindingContext.GetService(typeof(CancellationToken));
 
             using var loggerFactory = Logger.ConfigureLogger(logLevel);

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -102,7 +102,7 @@ namespace Microsoft.OpenApi.Hidi
                             stream.Position = 0;
                         }
 
-                        document = await ConvertCsdlToOpenApi(stream, cancellationToken, settingsFile);
+                        document = await ConvertCsdlToOpenApi(stream, settingsFile, cancellationToken);
                         stopwatch.Stop();
                         logger.LogTrace("{timestamp}ms: Generated OpenAPI with {paths} paths.", stopwatch.ElapsedMilliseconds, document.Paths.Count);
                     }
@@ -328,7 +328,7 @@ namespace Microsoft.OpenApi.Hidi
         /// </summary>
         /// <param name="csdl">The CSDL stream.</param>
         /// <returns>An OpenAPI document.</returns>
-        public static async Task<OpenApiDocument> ConvertCsdlToOpenApi(Stream csdl, CancellationToken token, string settingsFile = null)
+        public static async Task<OpenApiDocument> ConvertCsdlToOpenApi(Stream csdl, string settingsFile = null, CancellationToken token = default)
         {
             using var reader = new StreamReader(csdl);
             var csdlText = await reader.ReadToEndAsync(token);

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -102,7 +102,7 @@ namespace Microsoft.OpenApi.Hidi
                             stream.Position = 0;
                         }
 
-                        document = await ConvertCsdlToOpenApi(stream, settingsFile);
+                        document = await ConvertCsdlToOpenApi(stream, cancellationToken, settingsFile);
                         stopwatch.Stop();
                         logger.LogTrace("{timestamp}ms: Generated OpenAPI with {paths} paths.", stopwatch.ElapsedMilliseconds, document.Paths.Count);
                     }
@@ -216,6 +216,10 @@ namespace Microsoft.OpenApi.Hidi
                     textWriter.Flush();
                 }
             }
+            catch(TaskCanceledException)
+            {
+                Console.Error.WriteLine("CTRL+C pressed, aborting the operation.");
+            }            
             catch (Exception ex)
             {
                 throw new InvalidOperationException($"Could not transform the document, reason: {ex.Message}", ex);
@@ -324,12 +328,12 @@ namespace Microsoft.OpenApi.Hidi
         /// </summary>
         /// <param name="csdl">The CSDL stream.</param>
         /// <returns>An OpenAPI document.</returns>
-        public static async Task<OpenApiDocument> ConvertCsdlToOpenApi(Stream csdl, string settingsFile = null)
+        public static async Task<OpenApiDocument> ConvertCsdlToOpenApi(Stream csdl, CancellationToken token, string settingsFile = null)
         {
             using var reader = new StreamReader(csdl);
-            var csdlText = await reader.ReadToEndAsync();
+            var csdlText = await reader.ReadToEndAsync(token);
             var edmModel = CsdlReader.Parse(XElement.Parse(csdlText).CreateReader());
-            
+
             var config = GetConfiguration(settingsFile);
             var settings = new OpenApiConvertSettings()
             {
@@ -353,9 +357,8 @@ namespace Microsoft.OpenApi.Hidi
                 EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty = true
             };
             config.GetSection("OpenApiConvertSettings").Bind(settings);
-            
-            OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
 
+            OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
             document = FixReferences(document);
 
             return document;

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -16,12 +16,8 @@ namespace Microsoft.OpenApi.Hidi
     static class Program
     {
         static async Task Main(string[] args)
-        {
-            // subscribe to CancelKeyPress event to listen for termination requests from users through Ctrl+C or Ctrl+Break keys
-            Console.CancelKeyPress += new ConsoleCancelEventHandler(Console_CancelKeyPressEvent);
-
-            var rootCommand = new RootCommand() {
-            };
+        {            
+            var rootCommand = new RootCommand() {};
 
             // command option parameters and aliases
             var descriptionOption = new Option<string>("--openapi", "Input OpenAPI description file path or URL");
@@ -121,36 +117,12 @@ namespace Microsoft.OpenApi.Hidi
 
             rootCommand.Add(transformCommand);
             rootCommand.Add(validateCommand);
-
+            
             // Parse the incoming args and invoke the handler
             await rootCommand.InvokeAsync(args);
 
             //// Wait for logger to write messages to the console before exiting
             await Task.Delay(10);
-        }
-
-        /// <summary>
-        /// This event is raised when the user presses either of the two breaking key combinations: Ctrl+C or Ctrl+Break keys.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="eventArgs"></param>
-        private static void Console_CancelKeyPressEvent(object sender, ConsoleCancelEventArgs eventArgs)
-        {
-            if ((eventArgs.SpecialKey == ConsoleSpecialKey.ControlC) || (eventArgs.SpecialKey == ConsoleSpecialKey.ControlBreak))
-            {
-                Console.WriteLine("CTRL+C pressed, aborting current process...");
-                Thread.Sleep(5000);
-                
-                if (Process.GetCurrentProcess().HasExited)
-                {
-                    Console.WriteLine("Process has already exited.");
-                }
-                else
-                {
-                    Console.WriteLine("Process has not exited, attempting to kill process...");
-                    Process.GetCurrentProcess().Kill();                    
-                }
-            }
         }        
     }
 }

--- a/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
+++ b/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OpenApi.Tests.Services
             var csdlStream = fileInput.OpenRead();
 
             // Act
-            var openApiDoc = await OpenApiService.ConvertCsdlToOpenApi(csdlStream);
+            var openApiDoc = await OpenApiService.ConvertCsdlToOpenApi(csdlStream, CancellationToken.None);
             var expectedPathCount = 5;
 
             // Assert
@@ -39,9 +39,9 @@ namespace Microsoft.OpenApi.Tests.Services
             var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "UtilityFiles\\Todo.xml");
             var fileInput = new FileInfo(filePath);
             var csdlStream = fileInput.OpenRead();
-
+            
             // Act
-            var openApiDoc = await OpenApiService.ConvertCsdlToOpenApi(csdlStream);
+            var openApiDoc = await OpenApiService.ConvertCsdlToOpenApi(csdlStream, CancellationToken.None);
             var predicate = OpenApiFilterService.CreatePredicate(operationIds, tags);
             var subsetOpenApiDocument = OpenApiFilterService.CreateFilteredDocument(openApiDoc, predicate);
 

--- a/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
+++ b/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OpenApi.Tests.Services
             var csdlStream = fileInput.OpenRead();
 
             // Act
-            var openApiDoc = await OpenApiService.ConvertCsdlToOpenApi(csdlStream, CancellationToken.None);
+            var openApiDoc = await OpenApiService.ConvertCsdlToOpenApi(csdlStream);
             var expectedPathCount = 5;
 
             // Assert
@@ -41,7 +41,7 @@ namespace Microsoft.OpenApi.Tests.Services
             var csdlStream = fileInput.OpenRead();
             
             // Act
-            var openApiDoc = await OpenApiService.ConvertCsdlToOpenApi(csdlStream, CancellationToken.None);
+            var openApiDoc = await OpenApiService.ConvertCsdlToOpenApi(csdlStream);
             var predicate = OpenApiFilterService.CreatePredicate(operationIds, tags);
             var subsetOpenApiDocument = OpenApiFilterService.CreateFilteredDocument(openApiDoc, predicate);
 


### PR DESCRIPTION
Adds logic to enable process termination by getting an `IConsole` instance which enables us to listen for the breaking combination `CTRL+C` and using a `CancellationToken` to register cancellation and abort the process.
Fixes #884 
Reference: https://github.com/dotnet/command-line-api/issues/1750#issuecomment-1146502468