### PR TITLE
Fix hidi validator error when loading unix paths

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -287,7 +287,7 @@ namespace Microsoft.OpenApi.Hidi
                 {
                     RuleSet = ValidationRuleSet.GetDefaultRuleSet(),
                     LoadExternalRefs = inlineExternal,
-                    BaseUrl = openApiFile.StartsWith("http") ? new Uri(openApiFile) : new Uri("file:" + new FileInfo(openApiFile).DirectoryName + "\\")
+                    BaseUrl = openApiFile.StartsWith("http") ? new Uri(openApiFile) : new Uri("file:" + new FileInfo(openApiFile).DirectoryName + Path.DirectorySeparatorChar)
                 }
                 ).ReadAsync(stream);
 

--- a/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
+++ b/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
@@ -38,8 +38,8 @@ namespace Microsoft.OpenApi.Tests.Services
         }
         
         [Theory]
-        [InlineData("Todos.Todo.UpdateTodoById",null, 1)]
-        [InlineData("Todos.Todo.ListTodo",null, 1)]
+        [InlineData("Todos.Todo.UpdateTodo",null, 1)]
+        [InlineData("Todos.Todo.ListTodo", null, 1)]
         [InlineData(null, "Todos.Todo", 4)]
         public async Task ReturnFilteredOpenApiDocBasedOnOperationIdsAndInputCsdlDocument(string operationIds, string tags, int expectedPathCount)
         {


### PR DESCRIPTION
Uses `Path.DirectorySeparatorChar`, a platform-specific directory separator character to construct the absolute uri path to an Open API document for parsing during validation and transformation.
Should fix #1142 
Reference: https://learn.microsoft.com/en-us/dotnet/api/system.io.path.directoryseparatorchar?view=net-7.0