### PR TITLE
- fixes a bug where copy constructors would fail on relative urls

### DIFF
--- a/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+++ b/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi.Readers</Title>
         <PackageId>Microsoft.OpenApi.Readers</PackageId>
-        <Version>1.6.0</Version>
+        <Version>1.6.1</Version>
         <Description>OpenAPI.NET Readers for JSON and YAML documents</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -11,7 +11,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi</Title>
         <PackageId>Microsoft.OpenApi</PackageId>
-        <Version>1.6.0</Version>
+        <Version>1.6.1</Version>
         <Description>.NET models with JSON and YAML writers for OpenAPI specification</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/src/Microsoft.OpenApi/Models/OpenApiContact.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiContact.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiContact(OpenApiContact contact)
         {
             Name = contact?.Name ?? Name;
-            Url = contact?.Url != null ? new Uri(contact.Url.OriginalString) : null;
+            Url = contact?.Url != null ? new Uri(contact.Url.OriginalString, UriKind.RelativeOrAbsolute) : null;
             Email = contact?.Email ?? Email;
             Extensions = contact?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(contact.Extensions) : null;
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiExternalDocs.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExternalDocs.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Parameter-less constructor
         /// </summary>
-        public OpenApiExternalDocs() {}
+        public OpenApiExternalDocs() { }
 
         /// <summary>
         /// Initializes a copy of an <see cref="OpenApiExternalDocs"/> object
@@ -40,7 +40,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiExternalDocs(OpenApiExternalDocs externalDocs)
         {
             Description = externalDocs?.Description ?? Description;
-            Url = externalDocs?.Url != null ? new Uri(externalDocs.Url.OriginalString) : null;
+            Url = externalDocs?.Url != null ? new Uri(externalDocs.Url.OriginalString, UriKind.RelativeOrAbsolute) : null;
             Extensions = externalDocs?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(externalDocs.Extensions) : null;
         }
 

--- a/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Parameterless constructor
         /// </summary>
-        public OpenApiLicense() {}
+        public OpenApiLicense() { }
 
         /// <summary>
         /// Initializes a copy of an <see cref="OpenApiLicense"/> object
@@ -40,7 +40,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiLicense(OpenApiLicense license)
         {
             Name = license?.Name ?? Name;
-            Url = license?.Url != null ? new Uri(license.Url.OriginalString) : null;
+            Url = license?.Url != null ? new Uri(license.Url.OriginalString, UriKind.RelativeOrAbsolute) : null;
             Extensions = license?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(license.Extensions) : null;
         }
 

--- a/src/Microsoft.OpenApi/Models/OpenApiOAuthFlow.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOAuthFlow.cs
@@ -44,16 +44,16 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Parameterless constructor
         /// </summary>
-        public OpenApiOAuthFlow() {}
+        public OpenApiOAuthFlow() { }
 
         /// <summary>
         /// Initializes a copy of an <see cref="OpenApiOAuthFlow"/> object
         /// </summary>
         public OpenApiOAuthFlow(OpenApiOAuthFlow oAuthFlow)
         {
-            AuthorizationUrl = oAuthFlow?.AuthorizationUrl != null ? new Uri(oAuthFlow.AuthorizationUrl.OriginalString) : null;
-            TokenUrl = oAuthFlow?.TokenUrl != null ? new Uri(oAuthFlow.TokenUrl.OriginalString) : null;
-            RefreshUrl = oAuthFlow?.RefreshUrl != null ? new Uri(oAuthFlow.RefreshUrl.OriginalString) : null;
+            AuthorizationUrl = oAuthFlow?.AuthorizationUrl != null ? new Uri(oAuthFlow.AuthorizationUrl.OriginalString, UriKind.RelativeOrAbsolute) : null;
+            TokenUrl = oAuthFlow?.TokenUrl != null ? new Uri(oAuthFlow.TokenUrl.OriginalString, UriKind.RelativeOrAbsolute) : null;
+            RefreshUrl = oAuthFlow?.RefreshUrl != null ? new Uri(oAuthFlow.RefreshUrl.OriginalString, UriKind.RelativeOrAbsolute) : null;
             Scopes = oAuthFlow?.Scopes != null ? new Dictionary<string, string>(oAuthFlow.Scopes) : null;
             Extensions = oAuthFlow?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(oAuthFlow.Extensions) : null;
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiSecurityScheme.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSecurityScheme.cs
@@ -77,7 +77,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Parameterless constructor
         /// </summary>
-        public OpenApiSecurityScheme() {}
+        public OpenApiSecurityScheme() { }
 
         /// <summary>
         /// Initializes a copy of <see cref="OpenApiSecurityScheme"/> object
@@ -91,7 +91,7 @@ namespace Microsoft.OpenApi.Models
             Scheme = securityScheme?.Scheme ?? Scheme;
             BearerFormat = securityScheme?.BearerFormat ?? BearerFormat;
             Flows = securityScheme?.Flows != null ? new(securityScheme?.Flows) : null;
-            OpenIdConnectUrl = securityScheme?.OpenIdConnectUrl != null ? new Uri(securityScheme.OpenIdConnectUrl.OriginalString) : null;
+            OpenIdConnectUrl = securityScheme?.OpenIdConnectUrl != null ? new Uri(securityScheme.OpenIdConnectUrl.OriginalString, UriKind.RelativeOrAbsolute) : null;
             Extensions = securityScheme?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(securityScheme.Extensions) : null;
             UnresolvedReference = securityScheme?.UnresolvedReference ?? UnresolvedReference;
             Reference = securityScheme?.Reference != null ? new(securityScheme?.Reference) : null;
@@ -107,8 +107,8 @@ namespace Microsoft.OpenApi.Models
                 throw Error.ArgumentNull(nameof(writer));
             }
 
-           
-            if (Reference != null) 
+
+            if (Reference != null)
             {
                 Reference.SerializeAsV3(writer);
                 return;

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiYamlWriterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiYamlWriterTests.cs
@@ -618,7 +618,12 @@ definitions:
     type: object
     properties:
       children:
-        $ref: '#/definitions/thing'
+        type: object
+        properties:
+          children:
+            $ref: '#/definitions/thing'
+          related:
+            type: integer
       related:
         type: integer";
             // Component schemas that are there due to cycles are still inlined because the items they reference may not exist in the components because they don't have cycles.


### PR DESCRIPTION
the constructor that was used [assumes absolute URLs](https://learn.microsoft.com/en-us/dotnet/api/system.uri.-ctor?view=net-7.0#system-uri-ctor(system-string)) (see the remarks section) which make validation fail