### PR TITLE
Fix: Error generated when security scheme in Components is a reference

### DIFF
--- a/src/Microsoft.OpenApi.Readers/OpenApiYamlDocumentReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiYamlDocumentReader.cs
@@ -166,7 +166,6 @@ namespace Microsoft.OpenApi.Readers
             }
         }
 
-
         /// <summary>
         /// Reads the stream input and parses the fragment of an OpenAPI description into an Open API Element.
         /// </summary>

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSecuritySchemeDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSecuritySchemeDeserializer.cs
@@ -76,7 +76,11 @@ namespace Microsoft.OpenApi.Readers.V3
         public static OpenApiSecurityScheme LoadSecurityScheme(ParseNode node)
         {
             var mapNode = node.CheckMapNode("securityScheme");
-
+            var pointer = mapNode.GetReferencePointer();
+            if (pointer != null)
+            {
+                return mapNode.GetReferencedObject<OpenApiSecurityScheme>(ReferenceType.SecurityScheme, pointer);
+            }
             var securityScheme = new OpenApiSecurityScheme();
             foreach (var property in mapNode)
             {

--- a/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
 using System;
@@ -116,7 +116,18 @@ namespace Microsoft.OpenApi.Services
                     }
                 }
             });
-
+            
+            Walk(OpenApiConstants.SecuritySchemes, () =>
+            {
+                if (components.SecuritySchemes != null)
+                {
+                    foreach (var item in components.SecuritySchemes)
+                    {
+                        Walk(item.Key, () => Walk(item.Value, isComponent: true));
+                    }
+                }
+            });
+            
             Walk(OpenApiConstants.Callbacks, () =>
             {
                 if (components.Callbacks != null)
@@ -996,9 +1007,9 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits <see cref="OpenApiSecurityScheme"/> and child objects
         /// </summary>
-        internal void Walk(OpenApiSecurityScheme securityScheme)
+        internal void Walk(OpenApiSecurityScheme securityScheme, bool isComponent = false)
         {
-            if (securityScheme == null || ProcessAsReference(securityScheme))
+            if (securityScheme == null || ProcessAsReference(securityScheme, isComponent))
             {
                 return;
             }

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -137,6 +137,9 @@
       <EmbeddedResource Include="V3Tests\Samples\OpenApiDocument\minimalDocument.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>
+      <EmbeddedResource Include="V3Tests\Samples\OpenApiDocument\docWithSecuritySchemeReference.yaml">
+        <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      </EmbeddedResource>
       <EmbeddedResource Include="V3Tests\Samples\OpenApiDocument\apiWithFullHeaderComponent.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiDocument/docWithSecuritySchemeReference.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiDocument/docWithSecuritySchemeReference.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: Example API
+  version: 1.0.0
+paths: { }
+components:
+  securitySchemes:
+    OAuth2:
+      $ref: '#/components/securitySchemes/RefOAuth2'
+    RefOAuth2:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://example.com/api/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets


### PR DESCRIPTION
This PR adds logic for resolving a security scheme reference object in the `components` section which previously was generating an error.
Fixes #1166 