### PR TITLE
Feature: removes default conversion settings

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -324,27 +324,7 @@ namespace Microsoft.OpenApi.Hidi
             var edmModel = CsdlReader.Parse(XElement.Parse(csdlText).CreateReader());
 
             var config = GetConfiguration(settingsFile);
-            var settings = new OpenApiConvertSettings()
-            {
-                AddSingleQuotesForStringParameters = true,
-                AddEnumDescriptionExtension = true,
-                DeclarePathParametersOnPathItem = true,
-                EnableKeyAsSegment = true,
-                EnableOperationId = true,
-                ErrorResponsesAsDefault = false,
-                PrefixEntityTypeNameBeforeKey = true,
-                TagDepth = 2,
-                EnablePagination = true,
-                EnableDiscriminatorValue = true,
-                EnableDerivedTypesReferencesForRequestBody = false,
-                EnableDerivedTypesReferencesForResponses = false,
-                ShowRootPath = false,
-                ShowLinks = false,
-                ExpandDerivedTypesNavigationProperties = false,
-                EnableCount = true,
-                UseSuccessStatusCodeRange = true,
-                EnableTypeDisambiguationForDefaultValueOfOdataTypeProperty = true
-            };
+            var settings = new OpenApiConvertSettings();
             config.GetSection("OpenApiConvertSettings").Bind(settings);
 
             OpenApiDocument document = edmModel.ConvertToOpenApi(settings);


### PR DESCRIPTION
Fixes #1177 

Supported apps are passing in their settings to get more specialised details.
If no settings are passed, the default open api conversion settings in the conversion lib are used.

This makes it possible for other apps to only care about what they want instead of checking whether their preferences match the default kiota settings that were baked in