### PR TITLE
Replaces obsolete ApiGenerator option

### DIFF
--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApiTests.cs
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApiTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OpenApi.Tests.PublicApi
             // It takes a human to read the change, determine if it is breaking and update the PublicApi.approved.txt with the new approved API surface
 
             // Arrange
-            var publicApi = typeof(OpenApiSpecVersion).Assembly.GeneratePublicApi(new ApiGeneratorOptions() { WhitelistedNamespacePrefixes = new[] { "Microsoft.OpenApi" } } );
+            var publicApi = typeof(OpenApiSpecVersion).Assembly.GeneratePublicApi(new ApiGeneratorOptions() { AllowNamespacePrefixes = new[] { "Microsoft.OpenApi" } } );
 
             // Act
             var approvedFilePath = Path.Combine("PublicApi", "PublicApi.approved.txt");


### PR DESCRIPTION
Replaces the obsolete ApiGeneratorOption `WhitelistedNamespacePrefixes` with `AllowNamespacePrefixes` for assembly generation