### PR TITLE
Add a commandline option that takes in a metadata version for OpenAPI conversion

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Handlers/TransformCommandHandler.cs
+++ b/src/Microsoft.OpenApi.Hidi/Handlers/TransformCommandHandler.cs
@@ -19,6 +19,7 @@ namespace Microsoft.OpenApi.Hidi.Handlers
         public Option<FileInfo> OutputOption { get; set; }
         public Option<bool> CleanOutputOption { get; set; }
         public Option<string?> VersionOption { get; set; }
+        public Option<string?> MetadataVersionOption { get; set; }
         public Option<OpenApiFormat?> FormatOption { get; set; }
         public Option<bool> TerseOutputOption { get; set; }
         public Option<string> SettingsFileOption { get; set; }
@@ -41,6 +42,7 @@ namespace Microsoft.OpenApi.Hidi.Handlers
             FileInfo output = context.ParseResult.GetValueForOption(OutputOption);
             bool cleanOutput = context.ParseResult.GetValueForOption(CleanOutputOption);
             string? version = context.ParseResult.GetValueForOption(VersionOption);
+            string metadataVersion = context.ParseResult.GetValueForOption(MetadataVersionOption);
             OpenApiFormat? format = context.ParseResult.GetValueForOption(FormatOption);
             bool terseOutput = context.ParseResult.GetValueForOption(TerseOutputOption);
             string settingsFile = context.ParseResult.GetValueForOption(SettingsFileOption);
@@ -57,7 +59,7 @@ namespace Microsoft.OpenApi.Hidi.Handlers
             var logger = loggerFactory.CreateLogger<OpenApiService>();
             try
             {
-                await OpenApiService.TransformOpenApiDocument(openapi, csdl, csdlFilter, output, cleanOutput, version, format, terseOutput, settingsFile, inlineLocal, inlineExternal, filterbyoperationids, filterbytags, filterbycollection, logger, cancellationToken);
+                await OpenApiService.TransformOpenApiDocument(openapi, csdl, csdlFilter, output, cleanOutput, version, metadataVersion, format, terseOutput, settingsFile, inlineLocal, inlineExternal, filterbyoperationids, filterbytags, filterbycollection, logger, cancellationToken);
 
                 return 0;
             }

--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.15.0" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.3.0-preview4" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.3.0" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
   </ItemGroup>
 

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -46,9 +46,12 @@ namespace Microsoft.OpenApi.Hidi
             var versionOption = new Option<string?>("--version", "OpenAPI specification version");
             versionOption.AddAlias("-v");
 
+            var metadataVersionOption = new Option<string?>("--metadata-version", "Graph metadata version to use. Defaults to v1.0");
+            metadataVersionOption.AddAlias("--mv");
+
             var formatOption = new Option<OpenApiFormat?>("--format", "File format");
             formatOption.AddAlias("-f");
-
+            
             var terseOutputOption = new Option<bool>("--terse-output", "Produce terse json output");
             terseOutputOption.AddAlias("--to");
 
@@ -93,6 +96,7 @@ namespace Microsoft.OpenApi.Hidi
                 outputOption,
                 cleanOutputOption,
                 versionOption,
+                metadataVersionOption,
                 formatOption,
                 terseOutputOption,
                 settingsFileOption,
@@ -112,6 +116,7 @@ namespace Microsoft.OpenApi.Hidi
                 OutputOption = outputOption,
                 CleanOutputOption = cleanOutputOption,
                 VersionOption = versionOption,
+                MetadataVersionOption = metadataVersionOption,
                 FormatOption = formatOption,
                 TerseOutputOption = terseOutputOption,
                 SettingsFileOption = settingsFileOption,

--- a/src/Microsoft.OpenApi.Hidi/Program.cs
+++ b/src/Microsoft.OpenApi.Hidi/Program.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OpenApi.Hidi
             var versionOption = new Option<string?>("--version", "OpenAPI specification version");
             versionOption.AddAlias("-v");
 
-            var metadataVersionOption = new Option<string?>("--metadata-version", "Graph metadata version to use. Defaults to v1.0");
+            var metadataVersionOption = new Option<string?>("--metadata-version", "Graph metadata version to use.");
             metadataVersionOption.AddAlias("--mv");
 
             var formatOption = new Option<OpenApiFormat?>("--format", "File format");

--- a/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
+++ b/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
@@ -190,7 +190,7 @@ namespace Microsoft.OpenApi.Tests.Services
         {
             var fileinfo = new FileInfo("sample.json");
             // create a dummy ILogger instance for testing
-            await OpenApiService.TransformOpenApiDocument("UtilityFiles\\SampleOpenApi.yml",null, null,  fileinfo, true, null, null,false,null,false,false,null,null,null,new Logger<OpenApiService>(new LoggerFactory()), new CancellationToken());
+            await OpenApiService.TransformOpenApiDocument("UtilityFiles\\SampleOpenApi.yml",null, null,  fileinfo, true, null, null, null,false,null,false,false,null,null,null,new Logger<OpenApiService>(new LoggerFactory()), new CancellationToken());
 
             var output = File.ReadAllText("sample.json");
             Assert.NotEmpty(output);
@@ -201,7 +201,7 @@ namespace Microsoft.OpenApi.Tests.Services
         public async Task TransformCommandConvertsOpenApiWithDefaultOutputname()
         {
             // create a dummy ILogger instance for testing
-            await OpenApiService.TransformOpenApiDocument("UtilityFiles\\SampleOpenApi.yml", null, null, null, true, null, null, false, null, false, false, null, null, null, new Logger<OpenApiService>(new LoggerFactory()), new CancellationToken());
+            await OpenApiService.TransformOpenApiDocument("UtilityFiles\\SampleOpenApi.yml", null, null, null, true, null, null, null, false, null, false, false, null, null, null, new Logger<OpenApiService>(new LoggerFactory()), new CancellationToken());
 
             var output = File.ReadAllText("output.yml");
             Assert.NotEmpty(output);
@@ -211,7 +211,7 @@ namespace Microsoft.OpenApi.Tests.Services
         public async Task TransformCommandConvertsCsdlWithDefaultOutputname()
         {
             // create a dummy ILogger instance for testing
-            await OpenApiService.TransformOpenApiDocument(null, "UtilityFiles\\Todo.xml", null, null, true, null, null, false, null, false, false, null, null, null, new Logger<OpenApiService>(new LoggerFactory()), new CancellationToken());
+            await OpenApiService.TransformOpenApiDocument(null, "UtilityFiles\\Todo.xml", null, null, true, null, null, null, false, null, false, false, null, null, null, new Logger<OpenApiService>(new LoggerFactory()), new CancellationToken());
 
             var output = File.ReadAllText("output.yml");
             Assert.NotEmpty(output);
@@ -221,7 +221,7 @@ namespace Microsoft.OpenApi.Tests.Services
         public async Task TransformCommandConvertsOpenApiWithDefaultOutputnameAndSwitchFormat()
         {
             // create a dummy ILogger instance for testing
-            await OpenApiService.TransformOpenApiDocument("UtilityFiles\\SampleOpenApi.yml", null, null, null, true, "3.0", OpenApiFormat.Yaml, false, null, false, false, null, null, null, new Logger<OpenApiService>(new LoggerFactory()), new CancellationToken());
+            await OpenApiService.TransformOpenApiDocument("UtilityFiles\\SampleOpenApi.yml", null, null, null, true, "3.0", null, OpenApiFormat.Yaml, false, null, false, false, null, null, null, new Logger<OpenApiService>(new LoggerFactory()), new CancellationToken());
 
             var output = File.ReadAllText("output.yml");
             Assert.NotEmpty(output);
@@ -231,7 +231,7 @@ namespace Microsoft.OpenApi.Tests.Services
         public async Task ThrowTransformCommandIfOpenApiAndCsdlAreEmpty()
         {
             await Assert.ThrowsAsync<ArgumentException>(async () =>
-                await OpenApiService.TransformOpenApiDocument(null, null, null, null, true, null, null, false, null, false, false, null, null, null, new Logger<OpenApiService>(new LoggerFactory()), new CancellationToken()));
+                await OpenApiService.TransformOpenApiDocument(null, null, null, null, true, null, null, null, false, null, false, false, null, null, null, new Logger<OpenApiService>(new LoggerFactory()), new CancellationToken()));
 
         }
 

--- a/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
+++ b/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
@@ -38,9 +38,9 @@ namespace Microsoft.OpenApi.Tests.Services
         }
         
         [Theory]
-        [InlineData("Todos.Todo.UpdateTodo",null, 1)]
+        [InlineData("Todos.Todo.UpdateTodo", null, 1)]
         [InlineData("Todos.Todo.ListTodo", null, 1)]
-        [InlineData(null, "Todos.Todo", 4)]
+        [InlineData(null, "Todos.Todo", 5)]
         public async Task ReturnFilteredOpenApiDocBasedOnOperationIdsAndInputCsdlDocument(string operationIds, string tags, int expectedPathCount)
         {
             // Arrange


### PR DESCRIPTION
Adds the commandline option `--metadata-version` which takes in a metadata version parameter to be passed as a convert setting during CSDL to OpenApi conversion
Fixes #1196 