### PR TITLE
- fixes a bug where the base path would be forcibly set to the description

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
@@ -139,6 +139,12 @@ namespace Microsoft.OpenApi.Readers.V2
             var schemes = context.GetFromTempStorage<List<string>>("schemes");
             Uri defaultUrl = rootNode.Context.BaseUrl;
 
+            // so we don't default to the document path when a host is provided
+            if (string.IsNullOrEmpty(basePath) && !string.IsNullOrEmpty(host))
+            {
+                basePath = "/";
+            }
+
             // If nothing is provided, don't create a server
             if (host == null && basePath == null && schemes == null)
             {

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiServerTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiServerTests.cs
@@ -75,6 +75,31 @@ paths: {}
         }
 
         [Fact]
+        public void NoBasePath()
+        {
+            var input = @"
+swagger: 2.0
+info: 
+  title: test
+  version: 1.0.0
+host: www.foo.com
+schemes:
+  - http
+paths: {}
+";
+            var reader = new OpenApiStringReader(new OpenApiReaderSettings()
+            {
+                BaseUrl = new Uri("https://www.foo.com/spec.yaml")
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
+            var server = doc.Servers.First();
+            Assert.Equal(1, doc.Servers.Count);
+            Assert.Equal("http://www.foo.com", server.Url);
+        }
+
+        [Fact]
         public void JustBasePathNoDefault()
         {
             var input = @"
@@ -203,14 +228,14 @@ paths: {}
 ";
             var reader = new OpenApiStringReader(new OpenApiReaderSettings()
             {
-                BaseUrl = new Uri("https://dev.bing.com/api")
+                BaseUrl = new Uri("https://dev.bing.com/api/description.yaml")
             });
 
             var doc = reader.Read(input, out var diagnostic);
 
             var server = doc.Servers.First();
             Assert.Equal(1, doc.Servers.Count);
-            Assert.Equal("https://prod.bing.com/api", server.Url);
+            Assert.Equal("https://prod.bing.com", server.Url);
         }
 
         [Fact]


### PR DESCRIPTION
according to [the spec](https://swagger.io/specification/v2/) the base path should be defaulted to the description path value ONLY when the host is NOT provided