### PR TITLE
Track cloned objects to avoid StackOverflowExceptions during cloning

### DIFF
--- a/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+++ b/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi.Readers</Title>
         <PackageId>Microsoft.OpenApi.Readers</PackageId>
-        <Version>1.6.4-preview2</Version>
+        <Version>1.6.4-preview3</Version>
         <Description>OpenAPI.NET Readers for JSON and YAML documents</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/src/Microsoft.OpenApi/Helpers/DictionaryCloneHelper.cs
+++ b/src/Microsoft.OpenApi/Helpers/DictionaryCloneHelper.cs
@@ -21,14 +21,26 @@ namespace Microsoft.OpenApi.Helpers
         internal static Dictionary<T, U> Clone<T, U>(IDictionary<T, U> dictionary)
         {            
             if (dictionary is null) return null;
+            
             var clonedDictionary = new Dictionary<T, U>(dictionary.Keys.Count);
+            var clonedObjects = new Dictionary<object, object>();
             
-            foreach (var kvp in dictionary)
+            foreach (var keyValuePair in dictionary)
             {
-                // Create instance of the specified type using the constructor matching the specified parameter types.
-                clonedDictionary[kvp.Key] = (U)Activator.CreateInstance(kvp.Value.GetType(), kvp.Value);
-            }
-            
+                // If the object has already been cloned, use the cloned object instead of cloning it again
+                if (clonedObjects.TryGetValue(keyValuePair.Value, out var clonedValue))
+                {
+                    clonedDictionary[keyValuePair.Key] = (U)clonedValue;
+                }
+                else
+                {
+                    // Create instance of the specified type using the constructor matching the specified parameter types.
+                    clonedDictionary[keyValuePair.Key] = (U)Activator.CreateInstance(keyValuePair.Value.GetType(), keyValuePair.Value);
+                    
+                    // Add the cloned object to the dictionary of cloned objects
+                    clonedObjects.Add(keyValuePair.Value, clonedDictionary[keyValuePair.Key]);
+                }                
+            }            
 
             return clonedDictionary;
         }

--- a/src/Microsoft.OpenApi/Helpers/DictionaryCloneHelper.cs
+++ b/src/Microsoft.OpenApi/Helpers/DictionaryCloneHelper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OpenApi.Helpers
     /// <summary>
     /// Helper class for deep cloning dictionaries.
     /// </summary>
-    internal class DictionaryCloneHelper
+    internal static class DictionaryCloneHelper
     {
         /// <summary>
         /// Deep clone key value pairs in a dictionary.

--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -11,7 +11,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi</Title>
         <PackageId>Microsoft.OpenApi</PackageId>
-        <Version>1.6.4-preview2</Version>
+        <Version>1.6.4-preview3</Version>
         <Description>.NET models with JSON and YAML writers for OpenAPI specification</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>


### PR DESCRIPTION
Modifies the `DictionaryCloneHelper's` `Clone()` method to keep track of cloned objects in order to avoid recursively cloning an object afresh that's already been cloned using reflection. This reduces circular dependencies caused by recursion that lead to StackOverflowExceptions.