### PR TITLE
ISSUE-1131: Added diagnostic reporting recursive concatenation of dia…

### DIFF
--- a/src/Microsoft.OpenApi.Readers/OpenApiDiagnostic.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiDiagnostic.cs
@@ -26,5 +26,61 @@ namespace Microsoft.OpenApi.Readers
         /// Open API specification version of the document parsed.
         /// </summary>
         public OpenApiSpecVersion SpecificationVersion { get; set; }
+
+        /// <summary>
+        /// Append another set of diagnostic Errors and Warnings to this one, this may be appended from another external
+        /// document's parsing and we want to indicate which file it originated from.
+        /// </summary>
+        /// <param name="diagnosticToAdd"></param>
+        /// <param name="fileNameToAdd"></param>
+        public void AppendDiagnostic(OpenApiDiagnostic diagnosticToAdd, string fileNameToAdd)
+        {
+            foreach (var err in diagnosticToAdd.Errors)
+            {
+                string errMsgWithFileName;
+                if (!(string.IsNullOrEmpty(fileNameToAdd) || string.IsNullOrWhiteSpace(fileNameToAdd)))
+                {
+                    errMsgWithFileName = $"[File: {fileNameToAdd}] {err.Message}";
+                }
+                else
+                {
+                    errMsgWithFileName = err.Message;
+                }
+                Errors.Add(new OpenApiError(err.Pointer, errMsgWithFileName));
+            }
+            foreach (var warn in diagnosticToAdd.Warnings)
+            {
+                string warnMsgWithFileName;
+                if (!(string.IsNullOrEmpty(fileNameToAdd) || string.IsNullOrWhiteSpace(fileNameToAdd)))
+                {
+                    warnMsgWithFileName = $"[File: {fileNameToAdd}] {warn.Message}";
+                }
+                else
+                {
+                    warnMsgWithFileName = warn.Message;
+                }
+                Errors.Add(new OpenApiError(warn.Pointer, warnMsgWithFileName));
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Extension class for IList to add the Method "AddRange" used above
+/// </summary>
+public static class IDiagnosticExtensions
+{
+    /// <summary>
+    /// Extension method for IList so that another list can be added to the current list.
+    /// </summary>
+    /// <param name="collection"></param>
+    /// <param name="enumerable"></param>
+    /// <typeparam name="T"></typeparam>
+    public static void AddRange<T>(this ICollection<T> collection, IEnumerable<T> enumerable)
+    {
+        foreach (var cur in enumerable)
+        {
+            collection.Add(cur);
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -13,6 +13,8 @@
         <AssemblyOriginatorKeyFile>..\..\src\Microsoft.OpenApi.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
     <ItemGroup>
+      <None Remove="OpenApiReaderTests\Samples\OpenApiDiagnosticReportMerged\TodoMain.yaml" />
+      <None Remove="OpenApiReaderTests\Samples\OpenApiDiagnosticReportMerged\TodoReference.yaml" />
       <None Remove="V2Tests\Samples\ComponentRootReference.json" />
       <None Remove="V2Tests\Samples\OpenApiPathItem\pathItemWithBodyPathParameter.yaml" />
       <None Remove="V2Tests\Samples\OpenApiPathItem\pathItemWithFormDataPathParameter.yaml" />
@@ -20,6 +22,8 @@
       <None Remove="V3Tests\Samples\OpenApiWorkspace\TodoMain.yaml" />
     </ItemGroup>
     <ItemGroup>
+      <EmbeddedResource Include="OpenApiReaderTests\Samples\OpenApiDiagnosticReportMerged\TodoMain.yaml" />
+      <EmbeddedResource Include="OpenApiReaderTests\Samples\OpenApiDiagnosticReportMerged\TodoReference.yaml" />
       <EmbeddedResource Include="OpenApiReaderTests\Samples\unsupported.v1.yaml">
         <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       </EmbeddedResource>

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiDiagnosticTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiDiagnosticTests.cs
@@ -1,8 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System;
 using FluentAssertions;
+using Microsoft.OpenApi.Exceptions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers.Tests.OpenApiWorkspaceTests;
 using Xunit;
+using Microsoft.OpenApi.Readers.Interface;
+using System.IO;
 
 namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
 {
@@ -31,6 +39,46 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
                 diagnostic.Should().NotBeNull();
                 diagnostic.SpecificationVersion.Should().Be(OpenApiSpecVersion.OpenApi3_0);
             }
+        }
+
+        [Fact]
+        public async Task DiagnosticReportMergedForExternalReference()
+        {
+            // Create a reader that will resolve all references
+            var reader = new OpenApiStreamReader(new OpenApiReaderSettings()
+            {
+                LoadExternalRefs = true,
+                CustomExternalLoader = new ResourceLoader(),
+                BaseUrl = new Uri("fie://c:\\")
+            });
+
+            ReadResult result;
+            using (var stream = Resources.GetStream("OpenApiReaderTests/Samples/OpenApiDiagnosticReportMerged/TodoMain.yaml"))
+            {
+                result = await reader.ReadAsync(stream);
+            }
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.OpenApiDocument.Workspace);
+            Assert.True(result.OpenApiDocument.Workspace.Contains("TodoReference.yaml"));
+            result.OpenApiDiagnostic.Errors.Should().BeEquivalentTo(new List<OpenApiError> {
+                new OpenApiError( new OpenApiException("[File: ./TodoReference.yaml] Invalid Reference identifier 'object-not-existing'.")) });
+
+        }
+    }
+
+    public class ResourceLoader : IStreamLoader
+    {
+        public Stream Load(Uri uri)
+        {
+            return null;
+        }
+
+        public Task<Stream> LoadAsync(Uri uri)
+        {
+            var path = new Uri(new Uri("http://example.org/OpenApiReaderTests/Samples/OpenApiDiagnosticReportMerged/"), uri).AbsolutePath;
+            path = path.Substring(1); // remove leading slash
+            return Task.FromResult(Resources.GetStream(path));
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/Samples/OpenApiDiagnosticReportMerged/TodoMain.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/Samples/OpenApiDiagnosticReportMerged/TodoMain.yaml
@@ -1,0 +1,16 @@
+﻿openapi: 3.0.1
+info:
+  title: Example using a remote reference
+  version: 1.0.0
+paths:
+    "/todos":
+      get:
+        parameters:
+          - $ref: ./TodoReference.yaml#/components/parameters/filter
+        responses:
+          200:
+            description: Ok
+            content:
+              application/json:
+                schema:
+                  $ref: ./TodoReference.yaml#/components/schemas/todo

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/Samples/OpenApiDiagnosticReportMerged/TodoReference.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/Samples/OpenApiDiagnosticReportMerged/TodoReference.yaml
@@ -1,0 +1,26 @@
+﻿openapi: 3.0.1
+info:
+  title: Components for the todo app
+  version: 1.0.0
+paths: {}
+components:
+  parameters:
+    filter:
+      name: filter
+      in: query
+      schema:
+        type: string
+  schemas:
+    todo:
+      type: object
+      allOf: 
+        - $ref: "#/components/schemas/entity"
+        - $ref: "#/components/schemas/object-not-existing"
+      properties:
+        subject:
+          type: string
+    entity:
+      type: object
+      properties:
+        id:
+          type:string


### PR DESCRIPTION
Added diagnostic reporting recursive concatenation of diagnostic reports from referenced files to the main file's diagnostic report.
Also added a unit test in `C:\Users\Elize.van.der.Riet\Work\OpenAPI\OpenAPI.NET - Fork\OpenAPI.NET\test\Microsoft.OpenApi.Readers.Tests\OpenApiReaderTests\OpenApiDiagnosticTests.cs`, my apologies not sure if this is the right place for the test, please let me know if I should move it.