### PR TITLE
[Breaking] Modify validation rules to add CRUD operations

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OpenApi.Interfaces;

--- a/src/Microsoft.OpenApi/Properties/SRResource.Designer.cs
+++ b/src/Microsoft.OpenApi/Properties/SRResource.Designer.cs
@@ -77,7 +77,18 @@ namespace Microsoft.OpenApi.Properties {
                 return ResourceManager.GetString("ArgumentNullOrWhiteSpace", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to The argument &apos;{0}&apos; is null..
+        /// </summary>
+        internal static string ArgumentNull
+        {
+            get
+            {
+                return ResourceManager.GetString("ArgumentNull", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The filed name &apos;{0}&apos; of extension doesn&apos;t begin with x-..
         /// </summary>

--- a/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
+++ b/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
@@ -317,7 +317,7 @@ namespace Microsoft.OpenApi.Validations
                 type = typeof(IOpenApiReferenceable);
             }
 
-            var rules = _ruleSet.FindRules(type);
+            var rules = _ruleSet.FindRules(type.Name);
             foreach (var rule in rules)
             {
                 rule.Evaluate(this as IValidationContext, item);

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -1339,15 +1339,27 @@ namespace Microsoft.OpenApi.Validations
     {
         protected ValidationRule() { }
     }
-    public sealed class ValidationRuleSet : System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Validations.ValidationRule>, System.Collections.IEnumerable
+    public sealed class ValidationRuleSet
     {
         public ValidationRuleSet() { }
         public ValidationRuleSet(Microsoft.OpenApi.Validations.ValidationRuleSet ruleSet) { }
-        public ValidationRuleSet(System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Validations.ValidationRule> rules) { }
-        public System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Validations.ValidationRule> Rules { get; }
-        public void Add(Microsoft.OpenApi.Validations.ValidationRule rule) { }
-        public System.Collections.Generic.IList<Microsoft.OpenApi.Validations.ValidationRule> FindRules(System.Type type) { }
+        public ValidationRuleSet(System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<Microsoft.OpenApi.Validations.ValidationRule>> rules) { }
+        public int Count { get; }
+        public System.Collections.Generic.ICollection<string> Keys { get; }
+        public System.Collections.Generic.IList<Microsoft.OpenApi.Validations.ValidationRule> Rules { get; }
+        public void Add(string key, Microsoft.OpenApi.Validations.ValidationRule rule) { }
+        public void Add(string key, System.Collections.Generic.IList<Microsoft.OpenApi.Validations.ValidationRule> rules) { }
+        public void Clear() { }
+        public bool Contains(string key, Microsoft.OpenApi.Validations.ValidationRule rule) { }
+        public bool ContainsKey(string key) { }
+        public System.Collections.Generic.IList<Microsoft.OpenApi.Validations.ValidationRule> FindRules(string key) { }
         public System.Collections.Generic.IEnumerator<Microsoft.OpenApi.Validations.ValidationRule> GetEnumerator() { }
+        public bool Remove(Microsoft.OpenApi.Validations.ValidationRule rule) { }
+        public bool Remove(string key) { }
+        public bool Remove(string key, Microsoft.OpenApi.Validations.ValidationRule rule) { }
+        public bool TryGetValue(string key, out System.Collections.Generic.IList<Microsoft.OpenApi.Validations.ValidationRule> rules) { }
+        public bool Update(string key, Microsoft.OpenApi.Validations.ValidationRule newRule, Microsoft.OpenApi.Validations.ValidationRule oldRule) { }
+        public static void AddValidationRules(Microsoft.OpenApi.Validations.ValidationRuleSet ruleSet, System.Collections.Generic.IDictionary<string, System.Collections.Generic.IList<Microsoft.OpenApi.Validations.ValidationRule>> rules) { }
         public static Microsoft.OpenApi.Validations.ValidationRuleSet GetDefaultRuleSet() { }
         public static Microsoft.OpenApi.Validations.ValidationRuleSet GetEmptyRuleSet() { }
     }

--- a/test/Microsoft.OpenApi.Tests/Services/OpenApiValidatorTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Services/OpenApiValidatorTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.OpenApi.Tests.Services
         {
             var ruleset = ValidationRuleSet.GetDefaultRuleSet();
 
-            ruleset.Add(
+            ruleset.Add(typeof(FooExtension).Name,
              new ValidationRule<FooExtension>(
                  (context, item) =>
                  {

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiReferenceValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiReferenceValidationTests.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
@@ -67,7 +64,14 @@ namespace Microsoft.OpenApi.Tests.Validations
             };
 
             // Act
-            var errors = document.Validate(new ValidationRuleSet() { new AlwaysFailRule<OpenApiSchema>() });
+            var rules = new Dictionary<string, IList<ValidationRule>>()
+            {
+                { typeof(OpenApiSchema).Name,
+                    new List<ValidationRule>() { new AlwaysFailRule<OpenApiSchema>() }
+                }
+            };
+
+            var errors = document.Validate(new ValidationRuleSet(rules));
 
 
             // Assert
@@ -97,8 +101,15 @@ namespace Microsoft.OpenApi.Tests.Validations
                 }
             };
 
-            // Act
-            var errors = document.Validate(new ValidationRuleSet() { new AlwaysFailRule<OpenApiSchema>() });
+            // Act            
+            var rules = new Dictionary<string, IList<ValidationRule>>()
+            {
+                { typeof(AlwaysFailRule<OpenApiSchema>).Name,
+                    new List<ValidationRule>() { new AlwaysFailRule<OpenApiSchema>() }
+                }
+            };
+
+            var errors = document.Validate(new ValidationRuleSet(rules));
 
             // Assert
             Assert.True(errors.Count() == 0);
@@ -147,7 +158,14 @@ namespace Microsoft.OpenApi.Tests.Validations
             };
 
             // Act
-            var errors = document.Validate(new ValidationRuleSet() { new AlwaysFailRule<OpenApiSchema>() });
+            var rules = new Dictionary<string, IList<ValidationRule>>()
+            {
+                { typeof(AlwaysFailRule<OpenApiSchema>).Name,
+                    new List<ValidationRule>() { new AlwaysFailRule<OpenApiSchema>() }
+                }
+            };
+
+            var errors = document.Validate(new ValidationRuleSet(rules));
 
             // Assert
             Assert.True(errors.Count() == 0);


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET/issues/1140

This PR:
- Modifies validation rules to add Create, Read, Update and Delete operations to allow for a configurable experience by clients.
- Updates relevant tests.
- This is a breaking change.