### PR TITLE
Clone extensions in the OpenApiSchema copy constructor

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -288,6 +288,7 @@ namespace Microsoft.OpenApi.Models
             ExternalDocs = schema?.ExternalDocs != null ? new(schema?.ExternalDocs) : null;
             Deprecated = schema?.Deprecated ?? Deprecated;
             Xml = schema?.Xml != null ? new(schema?.Xml) : null;
+            Extensions = schema?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(schema.Extensions) : null;
             UnresolvedReference = schema?.UnresolvedReference ?? UnresolvedReference;
             Reference = schema?.Reference != null ? new(schema?.Reference) : null;
         }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Writers;
 using VerifyXunit;
@@ -478,6 +479,30 @@ namespace Microsoft.OpenApi.Tests.Models
             Assert.Equal("string", actualSchema.Type);
             Assert.Equal("date", actualSchema.Format);
             Assert.True(actualSchema.Nullable);
+        }
+
+        [Fact]
+        public void CloningSchemaExtensionsWorks()
+        {
+            // Arrange
+            var schema = new OpenApiSchema
+            {
+                Extensions =
+                {
+                    { "x-myextension", new OpenApiInteger(42) }
+                }
+            };
+
+            // Act && Assert
+            var schemaCopy = new OpenApiSchema(schema);
+            Assert.Equal(1, schemaCopy.Extensions.Count);
+
+            // Act && Assert
+            schemaCopy.Extensions = new Dictionary<string, IOpenApiExtension>
+            {
+                { "x-myextension" , new OpenApiInteger(40) }
+            };
+            Assert.NotEqual(schema.Extensions, schemaCopy.Extensions);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -1024,6 +1024,8 @@ namespace Microsoft.OpenApi.Models
         Callback = 8,
         [Microsoft.OpenApi.Attributes.Display("tags")]
         Tag = 9,
+        [Microsoft.OpenApi.Attributes.Display("paths")]
+        Path = 10,
     }
     public class RuntimeExpressionAnyWrapper : Microsoft.OpenApi.Interfaces.IOpenApiElement
     {


### PR DESCRIPTION
Fixes #1261 