### PR TITLE
Bump hidi version

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <ToolCommandName>hidi</ToolCommandName>
     <PackageOutputPath>./../../artifacts</PackageOutputPath>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Description>OpenAPI.NET CLI tool for slicing OpenAPI documents</Description>
     <SignAssembly>true</SignAssembly>
     <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#embeduntrackedsources -->
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.18.0" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.5.0-preview4" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.5.0-preview5" />
     <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="0.5.0-preview" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
   </ItemGroup>


### PR DESCRIPTION
Bumps hidi version to release changes made in https://github.com/microsoft/OpenAPI.NET.OData/pull/430