### PR TITLE
Fix warnings blocking release

### DIFF
--- a/test/Microsoft.OpenApi.Tests/MicrosoftExtensions/OpenApiPrimaryErrorMessageExtensionTests.cs
+++ b/test/Microsoft.OpenApi.Tests/MicrosoftExtensions/OpenApiPrimaryErrorMessageExtensionTests.cs
@@ -16,7 +16,7 @@ public class OpenApiPrimaryErrorMessageExtensionTests
     public void ExtensionNameMatchesExpected()
     {
         // Act
-        string name = OpenApiPrimaryErrorMessageExtension.Name;
+        string name = Microsoft.OpenApi.MicrosoftExtensions.OpenApiPrimaryErrorMessageExtension.Name;
         string expectedName = "x-ms-primary-error-message";
 
         // Assert
@@ -27,7 +27,7 @@ public class OpenApiPrimaryErrorMessageExtensionTests
     public void WritesValue()
     {
         // Arrange
-        OpenApiPrimaryErrorMessageExtension extension = new()
+        Microsoft.OpenApi.MicrosoftExtensions.OpenApiPrimaryErrorMessageExtension extension = new()
         {
             IsPrimaryErrorMessage = true
         };
@@ -50,7 +50,7 @@ public class OpenApiPrimaryErrorMessageExtensionTests
         var value = new OpenApiBoolean(true);
 
         // Act
-        var extension = OpenApiPrimaryErrorMessageExtension.Parse(value);
+        var extension = Microsoft.OpenApi.MicrosoftExtensions.OpenApiPrimaryErrorMessageExtension.Parse(value);
 
         // Assert
         Assert.True(extension.IsPrimaryErrorMessage);


### PR DESCRIPTION
Unblocks release build at https://github.com/microsoft/OpenAPI.NET/pull/1393 due to obsolete warnings

Refactors tests to fix obsolete warnings