### PR TITLE
dont return null on exception in JsonPointerExtensions.Find

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ParseNodes/JsonPointerExtensions.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/JsonPointerExtensions.cs
@@ -21,33 +21,26 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
                 return baseYamlNode;
             }
 
-            try
+            var pointer = baseYamlNode;
+            foreach (var token in currentPointer.Tokens)
             {
-                var pointer = baseYamlNode;
-                foreach (var token in currentPointer.Tokens)
+                if (pointer is YamlSequenceNode sequence)
                 {
-                    if (pointer is YamlSequenceNode sequence)
+                    pointer = sequence.Children[Convert.ToInt32(token)];
+                }
+                else
+                {
+                    if (pointer is YamlMappingNode map)
                     {
-                        pointer = sequence.Children[Convert.ToInt32(token)];
-                    }
-                    else
-                    {
-                        if (pointer is YamlMappingNode map)
+                        if (!map.Children.TryGetValue(new YamlScalarNode(token), out pointer))
                         {
-                            if (!map.Children.TryGetValue(new YamlScalarNode(token), out pointer))
-                            {
-                                return null;
-                            }
+                            return null;
                         }
                     }
                 }
+            }
 
-                return pointer;
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            return pointer;
         }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/JsonPointerExtensions.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/JsonPointerExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Linq;
 using SharpYaml.Serialization;
 
 namespace Microsoft.OpenApi.Readers.ParseNodes
@@ -24,19 +25,13 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             var pointer = baseYamlNode;
             foreach (var token in currentPointer.Tokens)
             {
-                if (pointer is YamlSequenceNode sequence)
+                if (pointer is YamlSequenceNode sequence && sequence.Children is not null && int.TryParse(token, out var index) && index < sequence.Children.Count)
                 {
-                    pointer = sequence.Children[Convert.ToInt32(token)];
+                    pointer = sequence.Children[index];
                 }
-                else
+                else if (pointer is YamlMappingNode map && map.Children is not null && !map.Children.TryGetValue(new YamlScalarNode(token), out pointer))
                 {
-                    if (pointer is YamlMappingNode map)
-                    {
-                        if (!map.Children.TryGetValue(new YamlScalarNode(token), out pointer))
-                        {
-                            return null;
-                        }
-                    }
+                    return null;
                 }
             }
 


### PR DESCRIPTION
IMO catching an unknown exception type and return null will hide real errors