### PR TITLE
Use lookup collections

### DIFF
--- a/src/Microsoft.OpenApi/Writers/SpecialCharacterStringExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/SpecialCharacterStringExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
@@ -14,34 +15,34 @@ namespace Microsoft.OpenApi.Writers
     {
         // Plain style strings cannot start with indicators.
         // http://www.yaml.org/spec/1.2/spec.html#indicator//
-        private static readonly char[] _yamlIndicators =
+        private static readonly HashSet<string> _yamlIndicators = new()
         {
-            '-',
-            '?',
-            ':',
-            ',',
-            '{',
-            '}',
-            '[',
-            ']',
-            '&',
-            '*',
-            '#',
-            '?',
-            '|',
-            '-',
-            '>',
-            '!',
-            '%',
-            '@',
-            '`',
-            '\'',
-            '"',
+            "-",
+            "?",
+            ":",
+            ",",
+            "{",
+            "}",
+            "[",
+            "]",
+            "&",
+            "*",
+            "#",
+            "?",
+            "|",
+            "-",
+            ">",
+            "!",
+            "%",
+            "@",
+            "`",
+            "'",
+            "\""
         };
 
         // Plain style strings cannot contain these character combinations.
         // http://www.yaml.org/spec/1.2/spec.html#style/flow/plain
-        private static readonly string[] _yamlPlainStringForbiddenCombinations =
+        private static readonly HashSet<string> _yamlPlainStringForbiddenCombinations = new()
         {
             ": ",
             " #",
@@ -57,47 +58,47 @@ namespace Microsoft.OpenApi.Writers
 
         // Plain style strings cannot end with these characters.
         // http://www.yaml.org/spec/1.2/spec.html#style/flow/plain
-        private static readonly string[] _yamlPlainStringForbiddenTerminals =
+        private static readonly HashSet<string> _yamlPlainStringForbiddenTerminals = new()
         {
             ":"
         };
 
         // Double-quoted strings are needed for these non-printable control characters.
         // http://www.yaml.org/spec/1.2/spec.html#style/flow/double-quoted
-        private static readonly char[] _yamlControlCharacters =
+        private static readonly Dictionary<char, string> _yamlControlCharacterReplacements = new()
         {
-            '\0',
-            '\x01',
-            '\x02',
-            '\x03',
-            '\x04',
-            '\x05',
-            '\x06',
-            '\a',
-            '\b',
-            '\t',
-            '\n',
-            '\v',
-            '\f',
-            '\r',
-            '\x0e',
-            '\x0f',
-            '\x10',
-            '\x11',
-            '\x12',
-            '\x13',
-            '\x14',
-            '\x15',
-            '\x16',
-            '\x17',
-            '\x18',
-            '\x19',
-            '\x1a',
-            '\x1b',
-            '\x1c',
-            '\x1d',
-            '\x1e',
-            '\x1f'
+            {'\0', "\\0"},
+            {'\x01', "\\x01"},
+            {'\x02', "\\x02"},
+            {'\x03', "\\x03"},
+            {'\x04', "\\x04"},
+            {'\x05', "\\x05"},
+            {'\x06', "\\x06"},
+            {'\a', "\\a"},
+            {'\b', "\\b"},
+            {'\t', "\\t"},
+            {'\n', "\\n"},
+            {'\v', "\\v"},
+            {'\f', "\\f"},
+            {'\r', "\\r"},
+            {'\x0e', "\\x0e"},
+            {'\x0f', "\\x0f"},
+            {'\x10', "\\x10"},
+            {'\x11', "\\x11"},
+            {'\x12', "\\x12"},
+            {'\x13', "\\x13"},
+            {'\x14', "\\x14"},
+            {'\x15', "\\x15"},
+            {'\x16', "\\x16"},
+            {'\x17', "\\x17"},
+            {'\x18', "\\x18"},
+            {'\x19', "\\x19"},
+            {'\x1a', "\\x1a"},
+            {'\x1b', "\\x1b"},
+            {'\x1c', "\\x1c"},
+            {'\x1d', "\\x1d"},
+            {'\x1e', "\\x1e"},
+            {'\x1f', "\\x1f"},
         };
 
         /// <summary>
@@ -125,7 +126,7 @@ namespace Microsoft.OpenApi.Writers
             }
 
             // If string includes a control character, wrapping in double quote is required.
-            if (input.Any(c => _yamlControlCharacters.Contains(c)))
+            if (input.Any(c => _yamlControlCharacterReplacements.ContainsKey(c)))
             {
                 // Replace the backslash first, so that the new backslashes created by other Replaces are not duplicated.
                 input = input.Replace("\\", "\\\\");
@@ -134,39 +135,11 @@ namespace Microsoft.OpenApi.Writers
                 input = input.Replace("\"", "\\\"");
 
                 // Escape all the control characters.
-                input = input.Replace("\0", "\\0");
-                input = input.Replace("\x01", "\\x01");
-                input = input.Replace("\x02", "\\x02");
-                input = input.Replace("\x03", "\\x03");
-                input = input.Replace("\x04", "\\x04");
-                input = input.Replace("\x05", "\\x05");
-                input = input.Replace("\x06", "\\x06");
-                input = input.Replace("\a", "\\a");
-                input = input.Replace("\b", "\\b");
-                input = input.Replace("\t", "\\t");
-                input = input.Replace("\n", "\\n");
-                input = input.Replace("\v", "\\v");
-                input = input.Replace("\f", "\\f");
-                input = input.Replace("\r", "\\r");
-                input = input.Replace("\x0e", "\\x0e");
-                input = input.Replace("\x0f", "\\x0f");
-                input = input.Replace("\x10", "\\x10");
-                input = input.Replace("\x11", "\\x11");
-                input = input.Replace("\x12", "\\x12");
-                input = input.Replace("\x13", "\\x13");
-                input = input.Replace("\x14", "\\x14");
-                input = input.Replace("\x15", "\\x15");
-                input = input.Replace("\x16", "\\x16");
-                input = input.Replace("\x17", "\\x17");
-                input = input.Replace("\x18", "\\x18");
-                input = input.Replace("\x19", "\\x19");
-                input = input.Replace("\x1a", "\\x1a");
-                input = input.Replace("\x1b", "\\x1b");
-                input = input.Replace("\x1c", "\\x1c");
-                input = input.Replace("\x1d", "\\x1d");
-                input = input.Replace("\x1e", "\\x1e");
-                input = input.Replace("\x1f", "\\x1f");
-
+                foreach (var replacement in _yamlControlCharacterReplacements)
+                {
+                    input = input.Replace(replacement.Key.ToString(), replacement.Value);
+                }
+                
                 return $"\"{input}\"";
             }
 
@@ -177,8 +150,8 @@ namespace Microsoft.OpenApi.Writers
             // wrap the string in single quote.
             // http://www.yaml.org/spec/1.2/spec.html#style/flow/plain
             if (_yamlPlainStringForbiddenCombinations.Any(fc => input.Contains(fc)) ||
-                _yamlIndicators.Any(i => input.StartsWith(i.ToString())) ||
-                _yamlPlainStringForbiddenTerminals.Any(i => input.EndsWith(i.ToString())) ||
+                _yamlIndicators.Any(i => input.StartsWith(i)) ||
+                _yamlPlainStringForbiddenTerminals.Any(i => input.EndsWith(i)) ||
                 input.Trim() != input)
             {
                 // Escape single quotes with two single quotes.
@@ -215,21 +188,20 @@ namespace Microsoft.OpenApi.Writers
             // http://json.org/
 
             // Replace the backslash first, so that the new backslashes created by other Replaces are not duplicated.
-            value = value.Replace("\\", "\\\\");
-
-            value = value.Replace("\b", "\\b");
-            value = value.Replace("\f", "\\f");
-            value = value.Replace("\n", "\\n");
-            value = value.Replace("\r", "\\r");
-            value = value.Replace("\t", "\\t");
-            value = value.Replace("\"", "\\\"");
+            value = value.Replace("\\", "\\\\")
+                .Replace("\b", "\\b")
+                .Replace("\f", "\\f")
+                .Replace("\n", "\\n")
+                .Replace("\r", "\\r")
+                .Replace("\t", "\\t")
+                .Replace("\"", "\\\"");
 
             return $"\"{value}\"";
         }
 
         internal static bool IsHexadecimalNotation(string input)
         {
-            return input.StartsWith("0x") && int.TryParse(input.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var _);
+            return input.StartsWith("0x") && int.TryParse(input.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out _);
         }
     }
 }


### PR DESCRIPTION
Changed collection types to either Dictionary or HashSet from arrays where lookups are used.
Keeping single collection definition over yaml control characters.