### PR TITLE
Handle number overflow during parsing of min/max values

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ParseNodes/ParserHelper.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/ParserHelper.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.OpenApi.Readers.ParseNodes
+{
+    /// <summary>
+    /// Useful tools to parse data
+    /// </summary>
+    internal class ParserHelper
+    {
+        /// <summary>
+        /// Parses decimal in invariant culture.
+        /// If the decimal is too big or small, it returns the default value
+        /// 
+        /// Note: sometimes developers put Double.MaxValue or Long.MaxValue as min/max values for numbers in json schema even if their numbers are not expected to be that big/small.
+        /// As we have already released the library with Decimal type for Max/Min, let's not introduce the breaking change and just fallback to Decimal.Max / Min. This should satisfy almost every scenario.
+        /// We can revisit this if somebody really needs to have double or long here.
+        /// </summary>
+        /// <returns></returns>
+        public static decimal ParseDecimalWithFallbackOnOverflow(string value, decimal defaultValue)
+        {
+            try
+            {
+                return decimal.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
+            }
+            catch (OverflowException)
+            {
+                return defaultValue;
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -44,7 +44,7 @@ namespace Microsoft.OpenApi.Readers.V2
             },
             {
                 "maximum",
-                (o, n) => GetOrCreateSchema(o).Maximum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
+                (o, n) => GetOrCreateSchema(o).Maximum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MaxValue)
             },
             {
                 "exclusiveMaximum",
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.Readers.V2
             },
             {
                 "minimum",
-                (o, n) => GetOrCreateSchema(o).Minimum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
+                (o, n) => GetOrCreateSchema(o).Minimum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MinValue)
             },
             {
                 "exclusiveMinimum",

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
@@ -61,11 +61,11 @@ namespace Microsoft.OpenApi.Readers.V2
                 },
                 {
                     "minimum",
-                    (o, n) => GetOrCreateSchema(o).Minimum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
+                    (o, n) => GetOrCreateSchema(o).Minimum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MinValue)
                 },
                 {
                     "maximum",
-                    (o, n) => GetOrCreateSchema(o).Maximum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
+                    (o, n) => GetOrCreateSchema(o).Maximum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MaxValue)
                 },
                 {
                     "maxLength",

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OpenApi.Readers.V2
             },
             {
                 "maximum",
-                (o, n) => o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture)
+                (o, n) => o.Maximum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MaxValue)
             },
             {
                 "exclusiveMaximum",
@@ -35,7 +35,7 @@ namespace Microsoft.OpenApi.Readers.V2
             },
             {
                 "minimum",
-                (o, n) => o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture)
+                (o, n) => o.Minimum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MinValue)
             },
             {
                 "exclusiveMinimum",

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OpenApi.Readers.V3
             },
             {
                 "maximum",
-                (o, n) => o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture)
+                (o, n) => o.Maximum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MaxValue)
             },
             {
                 "exclusiveMaximum",
@@ -35,7 +35,7 @@ namespace Microsoft.OpenApi.Readers.V3
             },
             {
                 "minimum",
-                (o, n) => o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture)
+                (o, n) => o.Minimum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MinValue)
             },
             {
                 "exclusiveMinimum",

--- a/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/ParserHelperTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/ParserHelperTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using Microsoft.OpenApi.Readers.ParseNodes;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.ParseNodes
+{
+    [Collection("DefaultSettings")]
+    public class ParserHelperTests
+    {
+        [Fact]
+        public void ParseDecimalWithFallbackOnOverflow_ReturnsParsedValue()
+        {
+            Assert.Equal(23434, ParserHelper.ParseDecimalWithFallbackOnOverflow("23434", 10));
+        }
+
+        [Fact]
+        public void ParseDecimalWithFallbackOnOverflow_Overflows_ReturnsFallback()
+        {
+            Assert.Equal(10, ParserHelper.ParseDecimalWithFallbackOnOverflow(double.MaxValue.ToString(), 10));
+        }
+    }
+}


### PR DESCRIPTION
Sometimes developers put Double.MaxValue or Long.MaxValue asmax values for numbers in json schema, even if their numbers are not expected to be that big/small.  As we have already released the library with Decimal type for Max/Min, let's not introduce the breaking change and just fallback to Decimal.Max / Min in case of overflow. This should satisfy almost every scenario. We can revisit this if somebody really needs to have double or long here.

Fixing this exception stacktrace

ExceptionType: System.OverflowException
ExceptionMessage:      Value was either too large or too small for a Decimal.
InnerExceptionType:    
InnerExceptionMessage: 
StackTrace: 
   at System.Number.ThrowOverflowOrFormatException(ParsingStatus status, TypeCode type)
   at System.Decimal.Parse(String s, NumberStyles style, IFormatProvider provider)
   at Microsoft.OpenApi.Readers.V2.OpenApiV2Deserializer.<>c.<.cctor>b__83_141(OpenApiSchema o, ParseNode n)
   at Microsoft.OpenApi.Readers.ParseNodes.PropertyNode.ParseField[T](T parentInstance, IDictionary`2 fixedFields, IDictionary`2 patternFields)
   at Microsoft.OpenApi.Readers.V2.OpenApiV2Deserializer.LoadSchema(ParseNode node)
   at Microsoft.OpenApi.Readers.ParseNodes.MapNode.<>c__DisplayClass6_0`1.<CreateMap>b__0(KeyValuePair`2 n)
   at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
   at Microsoft.OpenApi.Readers.V2.OpenApiV2Deserializer.<>c.<.cctor>b__83_158(OpenApiSchema o, ParseNode n)
   at Microsoft.OpenApi.Readers.ParseNodes.PropertyNode.ParseField[T](T parentInstance, IDictionary`2 fixedFields, IDictionary`2 patternFields)
   at Microsoft.OpenApi.Readers.V2.OpenApiV2Deserializer.LoadSchema(ParseNode node)
   at Microsoft.OpenApi.Readers.V2.OpenApiV2VersionService.LoadElement[T](ParseNode node)
   at Microsoft.OpenApi.Readers.ParsingContext.ParseFragment[T](YamlDocument yamlDocument, OpenApiSpecVersion version)
   at Microsoft.OpenApi.Readers.OpenApiYamlDocumentReader.ReadFragment[T](YamlDocument input, OpenApiSpecVersion version, OpenApiDiagnostic& diagnostic)
   at Microsoft.OpenApi.Readers.OpenApiTextReaderReader.ReadFragment[T](TextReader input, OpenApiSpecVersion version, OpenApiDiagnostic& diagnostic)
   at Microsoft.OpenApi.Readers.OpenApiStringReader.ReadFragment[T](String input, OpenApiSpecVersion version, OpenApiDiagnostic& diagnostic)