### PR TITLE
Fix culture dependency in ParseDecimalWithFallbackOnOverflow_Overflows_ReturnsFallback test

### DIFF
--- a/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/ParserHelperTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/ParserHelperTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Globalization;
 using Microsoft.OpenApi.Readers.ParseNodes;
 using Xunit;
 
@@ -18,7 +19,7 @@ namespace Microsoft.OpenApi.Readers.Tests.ParseNodes
         [Fact]
         public void ParseDecimalWithFallbackOnOverflow_Overflows_ReturnsFallback()
         {
-            Assert.Equal(10, ParserHelper.ParseDecimalWithFallbackOnOverflow(double.MaxValue.ToString(), 10));
+            Assert.Equal(10, ParserHelper.ParseDecimalWithFallbackOnOverflow(double.MaxValue.ToString(CultureInfo.InvariantCulture), 10));
         }
     }
 }


### PR DESCRIPTION
Fixes a problem when the tests are failing because the test input is generated with a culture dependend input. 

This happens on for example german systems because the dot is replaced with a comma and therefore a FormatException is throw.