### PR TITLE
fix possible RegexMatchTimeoutException

### DIFF
--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiPathsRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiPathsRules.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Properties;
 
@@ -36,7 +35,6 @@ namespace Microsoft.OpenApi.Validations.Rules
                     }
                 });
 
-        private static readonly Regex regexPath = new Regex("\\{([^/}]+)\\}", RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
         /// <summary>
         /// A relative path to an individual endpoint. The field name MUST begin with a slash.
         /// </summary>
@@ -50,7 +48,7 @@ namespace Microsoft.OpenApi.Validations.Rules
                     {
                         context.Enter(path);
 
-                        var pathSignature = regexPath.Replace(path, "{}");
+                        var pathSignature = GetPathSignature(path);
                         
                         if (!hashSet.Add(pathSignature))
                             context.CreateError(nameof(PathMustBeUnique),
@@ -59,6 +57,28 @@ namespace Microsoft.OpenApi.Validations.Rules
                         context.Exit();
                     }
                 });
+
+        /// <summary>
+        ///  Replaces placeholders in the path with {}, e.g. /pets/{petId} becomes /pets/{} .
+        /// </summary>
+        /// <param name="path">The input path</param>
+        /// <returns>The path signature</returns>
+        private static string GetPathSignature(string path)
+        {
+            for (int openBrace = path.IndexOf('{'); openBrace > -1; openBrace = path.IndexOf('{', openBrace + 2))
+            {
+                int closeBrace = path.IndexOf('}', openBrace);
+
+                if (closeBrace < 0)
+                {
+                    return path;
+                }
+
+                path = path.Substring(0, openBrace + 1) + path.Substring(closeBrace);
+            }
+
+            return path;
+        }
 
         // add more rules
     }


### PR DESCRIPTION
6bda890fc7f19db283123a7aa4327b2cc39bc99e introduced a Timeout on RegEx compilation. We hit this timeout a few times since this change.

Removed the timeout so it uses the default like before.

Stacktrace:

```
System.Text.RegularExpressions.RegexMatchTimeoutException: The Regex engine has timed out while trying to match a pattern to an input string. This can occur for many reasons, including very large inputs or excessive backtracking caused by nested quantifiers, back-references and other factors.
   at System.Text.RegularExpressions.RegexRunner.<CheckTimeout>g__ThrowRegexTimeout|25_0()
   at Regex5_TryMatchAtCurrentPosition(RegexRunner, ReadOnlySpan`1)
   at Regex5_Scan(RegexRunner, ReadOnlySpan`1)
   at System.Text.RegularExpressions.Regex.RunAllMatchesWithCallback[TState](String inputString, ReadOnlySpan`1 inputSpan, Int32 startat, TState& state, MatchCallback`1 callback, RegexRunnerMode mode, Boolean reuseMatchObject)
   at System.Text.RegularExpressions.RegexReplacement.ReplaceSimpleText(Regex regex, String input, String replacement, Int32 count, Int32 startat)
   at System.Text.RegularExpressions.Regex.Replace(String input, String replacement)
   at Microsoft.OpenApi.Validations.Rules.OpenApiPathsRules.<>c.<get_PathMustBeUnique>b__4_0(IValidationContext context, OpenApiPaths item)
   at Microsoft.OpenApi.Validations.ValidationRule`1.Evaluate(IValidationContext context, Object item)
   at Microsoft.OpenApi.Validations.OpenApiValidator.Validate(Object item, Type type)
   at Microsoft.OpenApi.Validations.OpenApiValidator.Validate[T](T item)
   at Microsoft.OpenApi.Validations.OpenApiValidator.Visit(OpenApiPaths item)
   at Microsoft.OpenApi.Services.OpenApiWalker.Walk(OpenApiPaths paths)
   at Microsoft.OpenApi.Services.OpenApiWalker.<>c__DisplayClass4_0.<Walk>b__2()
   at Microsoft.OpenApi.Services.OpenApiWalker.Walk(String context, Action walk)
   at Microsoft.OpenApi.Services.OpenApiWalker.Walk(OpenApiDocument doc)
   at Microsoft.OpenApi.Services.OpenApiWalker.Walk(IOpenApiElement element)
   at Microsoft.OpenApi.Extensions.OpenApiElementExtensions.Validate(IOpenApiElement element, ValidationRuleSet ruleSet)
   at Microsoft.OpenApi.Readers.OpenApiYamlDocumentReader.Read(YamlDocument input, OpenApiDiagnostic& diagnostic)
   at Microsoft.OpenApi.Readers.OpenApiTextReaderReader.Read(TextReader input, OpenApiDiagnostic& diagnostic)
   at Microsoft.OpenApi.Readers.OpenApiStringReader.Read(String input, OpenApiDiagnostic& diagnostic)
```