### PR TITLE
Fix: OpenApiJsonWriter produces non-standard JSON values when a schema has 'NaN' or 'Infinity' values

### DIFF
--- a/src/Microsoft.OpenApi/Any/OpenApiPrimitive.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiPrimitive.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Globalization;
 using System.Text;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Properties;
@@ -74,7 +75,19 @@ namespace Microsoft.OpenApi.Any
 
                 case PrimitiveType.Double:
                     var doubleValue = (OpenApiDouble)(IOpenApiPrimitive)this;
-                    writer.WriteValue(doubleValue.Value);
+                    var actualValue = doubleValue.Value;
+                    if (actualValue.Equals(double.NaN)
+                        || actualValue.Equals(double.NegativeInfinity)
+                        || actualValue.Equals(double.PositiveInfinity))
+                    {
+                        // Write out NaN, -Infinity, Infinity as strings
+                        writer.WriteValue(actualValue.ToString(CultureInfo.InvariantCulture));
+                        break;
+                    }
+                    else
+                    {
+                        writer.WriteValue(actualValue);
+                    }
                     break;
 
                 case PrimitiveType.String:

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiJsonWriterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiJsonWriterTests.cs
@@ -7,7 +7,11 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
+using System.Text.Json;
 using FluentAssertions;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Writers;
 using Newtonsoft.Json;
 using Xunit;
@@ -264,6 +268,30 @@ namespace Microsoft.OpenApi.Tests.Writers
 
             // Assert
             writtenString.Should().Be(expectedString);
+        }
+
+        [Fact]
+        public void OpenApiJsonWriterOutputsValidJsonValueWhenSchemaHasNanOrInfinityValues()
+        {
+            // Arrange
+            var schema = new OpenApiSchema
+            {
+                Enum = new List<IOpenApiAny> {
+                        new OpenApiDouble(double.NaN),
+                        new OpenApiDouble(double.PositiveInfinity),
+                        new OpenApiDouble(double.NegativeInfinity) 
+                }
+            };
+
+            // Act
+            var schemaBuilder = new StringBuilder();
+            var jsonWriter = new OpenApiJsonWriter(new StringWriter(schemaBuilder));
+            schema.SerializeAsV3(jsonWriter);
+            var jsonString = schemaBuilder.ToString();
+
+            // Assert
+            var exception = Record.Exception(() => System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(jsonString));
+            Assert.Null(exception);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiJsonWriterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiJsonWriterTests.cs
@@ -8,7 +8,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.Json;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;


### PR DESCRIPTION
Fixes #1519 