### PR TITLE
Fix data and type mismatch warning for an example object with a date value

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
@@ -63,7 +63,7 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             {
                 // More narrow type detection for explicit strings, only check types that are passed as strings
                 if (schema == null)
-                 {
+                {
                     if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTimeValue))
                     {
                         // if the time component is exactly midnight(00:00:00) meaning no time has elapsed, return a date-only value

--- a/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/OpenApiAnyConverter.cs
@@ -63,10 +63,12 @@ namespace Microsoft.OpenApi.Readers.ParseNodes
             {
                 // More narrow type detection for explicit strings, only check types that are passed as strings
                 if (schema == null)
-                {
+                 {
                     if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dateTimeValue))
                     {
-                        return new OpenApiDateTime(dateTimeValue);
+                        // if the time component is exactly midnight(00:00:00) meaning no time has elapsed, return a date-only value
+                        return dateTimeValue.TimeOfDay == TimeSpan.Zero ? new OpenApiDate(dateTimeValue.Date) 
+                            : new OpenApiDateTime(dateTimeValue);
                     }
                 }
                 else if (type == "string")

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -1338,5 +1338,22 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             Assert.False(securityScheme.UnresolvedReference);
             Assert.NotNull(securityScheme.Flows);
         }
+
+        [Fact]
+        public void ValidateExampleShouldNotHaveDataTypeMismatch()
+        {
+            // Arrange
+            using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "documentWithDateExampleInSchema.yaml"));
+
+            // Act
+            var doc = new OpenApiStreamReader(new()
+            {
+                ReferenceResolution = ReferenceResolutionSetting.ResolveLocalReferences
+            }).Read(stream, out var diagnostic);
+
+            // Assert
+            var warnings = diagnostic.Warnings;
+            Assert.False(warnings.Any());
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiDocument/documentWithDateExampleInSchema.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiDocument/documentWithDateExampleInSchema.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: Lorem Ipsum
+  version: 1.0.0
+servers:
+  - url: http://api.example.com/v1
+    description: Lorem Ipsum
+paths:
+  /issues:
+    get:
+      summary: Returns a list of issues.
+      description: Lorem Ipsum
+      responses:
+        "200":
+          description: Lorem Ipsum
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - data
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/issueData"
+              example:
+                data:
+                  - issuedAt: "2023-10-12"
+components:
+  schemas:
+    issueData:
+      type: object
+      title: Issue Data
+      description: Information about the issue.
+      properties:
+        issuedAt:
+          type: string
+          format: date
+          description: Lorem Ipsum
+          example: "2023-10-12"


### PR DESCRIPTION
- Inspects the `TimeOfDay` property of a `DateTimeOffSet` value in an example object during parsing to determine whether it's a `date-only` or `date-time` type. 
-  If the time component is exactly midnight(00:00:00) meaning no time has elapsed, we conclude that it is a date-only value hence cast it to an `OpenApiDate` type, otherwise its converted to an `OpenApiDateTime` object.

- Fixes #1526