### PR TITLE
Fix: Examples serialization in a response object during v2->v3 upcasting or vice versa

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiOperationDeserializer.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Xml.Linq;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
@@ -194,7 +195,8 @@ namespace Microsoft.OpenApi.Readers.V2
                     k => k,
                     _ => new OpenApiMediaType
                     {
-                        Schema = bodyParameter.Schema
+                        Schema = bodyParameter.Schema,
+                        Examples = bodyParameter.Examples
                     }),
                 Extensions = bodyParameter.Extensions
             };

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -259,6 +259,14 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 parameter.Schema = schema;
                 node.Context.SetTempStorage("schema", null);
+            }
+
+            // load examples from storage and add them to the parameter
+            var examples = node.Context.GetFromTempStorage<Dictionary<string, OpenApiExample>>(TempStorageKeys.Examples, parameter);
+            if (examples != null)
+            {
+                parameter.Examples = examples;
+                node.Context.SetTempStorage("examples", null);
             }
 
             var isBodyOrFormData = (bool)node.Context.GetFromTempStorage<object>(TempStorageKeys.ParameterIsBodyOrFormData);

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -95,12 +95,17 @@ namespace Microsoft.OpenApi.Readers.V2
                     "schema",
                     (o, n) => o.Schema = LoadSchema(n)
                 },
+                {
+                    "x-examples",
+                    LoadParameterExamplesExtension
+                },
             };
 
         private static readonly PatternFieldMap<OpenApiParameter> _parameterPatternFields =
             new()
             {
-                {s => s.StartsWith("x-"), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
+                {s => s.StartsWith("x-") && !s.Equals(OpenApiConstants.ExamplesExtension, StringComparison.OrdinalIgnoreCase),
+                    (o, p, n) => o.AddExtension(p, LoadExtension(p, n))} 
             };
 
         private static readonly AnyFieldMap<OpenApiParameter> _parameterAnyFields =
@@ -164,6 +169,12 @@ namespace Microsoft.OpenApi.Readers.V2
                     p.Explode = true;
                     return;
             }
+        }
+
+        private static void LoadParameterExamplesExtension(OpenApiParameter parameter, ParseNode node)
+        {
+            var examples = LoadExamplesExtension(node);
+            node.Context.SetTempStorage(TempStorageKeys.Examples, examples, parameter);
         }
 
         private static OpenApiSchema GetOrCreateSchema(OpenApiParameter p)

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
@@ -42,7 +42,7 @@ namespace Microsoft.OpenApi.Readers.V2
         private static readonly PatternFieldMap<OpenApiResponse> _responsePatternFields =
             new()
             {
-                {s => s.StartsWith("x-") && !s.Equals("x-examples", StringComparison.OrdinalIgnoreCase), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
+                {s => s.StartsWith("x-") && !s.Equals(OpenApiConstants.ExamplesExtension), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
             };
 
         private static readonly AnyFieldMap<OpenApiMediaType> _mediaTypeAnyFields =
@@ -106,7 +106,7 @@ namespace Microsoft.OpenApi.Readers.V2
 
         private static void LoadExamplesExtension(OpenApiResponse response, ParseNode node)
         {
-            var mapNode = node.CheckMapNode("x-examples");
+            var mapNode = node.CheckMapNode(OpenApiConstants.ExamplesExtension);
             var examples = new Dictionary<string, OpenApiExample>();
 
             foreach (var examplesNode in mapNode)
@@ -116,7 +116,7 @@ namespace Microsoft.OpenApi.Readers.V2
                 var exampleNode = examplesNode.Value.CheckMapNode(examplesNode.Name);
                 foreach (var valueNode in exampleNode)
                 {
-                    switch (valueNode.Name)
+                    switch (valueNode.Name.ToLowerInvariant())
                     {
                         case "summary":
                             example.Summary = valueNode.Value.GetScalarValue();

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.OpenApi.Readers.V2
         private static readonly PatternFieldMap<OpenApiResponse> _responsePatternFields =
             new()
             {
-                {s => s.StartsWith("x-") && !s.Equals("x-examples"), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
+                {s => s.StartsWith("x-") && !s.Equals("x-examples", StringComparison.OrdinalIgnoreCase), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
             };
 
         private static readonly AnyFieldMap<OpenApiMediaType> _mediaTypeAnyFields =

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
@@ -73,7 +73,8 @@ namespace Microsoft.OpenApi.Readers.V2
                 ?? context.DefaultContentType ?? new List<string> { "application/octet-stream" };
 
             var schema = context.GetFromTempStorage<OpenApiSchema>(TempStorageKeys.ResponseSchema, response);
-            var examples = context.GetFromTempStorage<Dictionary<string, OpenApiExample>>(TempStorageKeys.Examples, response);
+            var examples = context.GetFromTempStorage<Dictionary<string, OpenApiExample>>(TempStorageKeys.Examples, response)
+                ?? new Dictionary<string, OpenApiExample>();
 
             foreach (var produce in produces)
             {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OpenApi.Readers.V2
             },
             {
                 "x-examples",
-                LoadExamplesExtension
+                LoadResponseExamplesExtension
             },
             {
                 "schema",
@@ -42,7 +42,8 @@ namespace Microsoft.OpenApi.Readers.V2
         private static readonly PatternFieldMap<OpenApiResponse> _responsePatternFields =
             new()
             {
-                {s => s.StartsWith("x-") && !s.Equals(OpenApiConstants.ExamplesExtension, StringComparison.OrdinalIgnoreCase), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
+                {s => s.StartsWith("x-") && !s.Equals(OpenApiConstants.ExamplesExtension, StringComparison.OrdinalIgnoreCase), 
+                    (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
             };
 
         private static readonly AnyFieldMap<OpenApiMediaType> _mediaTypeAnyFields =
@@ -104,7 +105,13 @@ namespace Microsoft.OpenApi.Readers.V2
             context.SetTempStorage(TempStorageKeys.ResponseProducesSet, true, response);
         }
 
-        private static void LoadExamplesExtension(OpenApiResponse response, ParseNode node)
+        private static void LoadResponseExamplesExtension(OpenApiResponse response, ParseNode node)
+        {
+            var examples = LoadExamplesExtension(node);
+            node.Context.SetTempStorage(TempStorageKeys.Examples, examples, response);
+        }
+
+        private static Dictionary<string, OpenApiExample> LoadExamplesExtension(ParseNode node)
         {
             var mapNode = node.CheckMapNode(OpenApiConstants.ExamplesExtension);
             var examples = new Dictionary<string, OpenApiExample>();
@@ -131,12 +138,12 @@ namespace Microsoft.OpenApi.Readers.V2
                             example.ExternalValue = valueNode.Value.GetScalarValue();
                             break;
                     }
-                }                
+                }
 
                 examples.Add(examplesNode.Name, example);
             }
 
-            node.Context.SetTempStorage(TempStorageKeys.Examples, examples, response);
+            return examples;
         }
 
         private static void LoadExamples(OpenApiResponse response, ParseNode node)

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -42,7 +42,7 @@ namespace Microsoft.OpenApi.Readers.V2
         private static readonly PatternFieldMap<OpenApiResponse> _responsePatternFields =
             new()
             {
-                {s => s.StartsWith("x-") && !s.Equals(OpenApiConstants.ExamplesExtension), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
+                {s => s.StartsWith("x-") && !s.Equals(OpenApiConstants.ExamplesExtension, StringComparison.OrdinalIgnoreCase), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
             };
 
         private static readonly AnyFieldMap<OpenApiMediaType> _mediaTypeAnyFields =
@@ -125,7 +125,7 @@ namespace Microsoft.OpenApi.Readers.V2
                             example.Description = valueNode.Value.GetScalarValue();
                             break;
                         case "value":
-                            example.Value = valueNode.Value.CreateAny();
+                            example.Value = OpenApiAnyConverter.GetSpecificOpenApiAny(valueNode.Value.CreateAny());
                             break;
                         case "externalValue":
                             example.ExternalValue = valueNode.Value.GetScalarValue();

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiResponseDeserializer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;

--- a/src/Microsoft.OpenApi.Readers/V2/TempStorageKeys.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/TempStorageKeys.cs
@@ -17,5 +17,6 @@ namespace Microsoft.OpenApi.Readers.V2
         public const string GlobalConsumes = "globalConsumes";
         public const string GlobalProduces = "globalProduces";
         public const string ParameterIsBodyOrFormData = "parameterIsBodyOrFormData";
+        public const string Examples = "examples";
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
@@ -566,6 +566,11 @@ namespace Microsoft.OpenApi.Models
         public const string BodyName = "x-bodyName";
 
         /// <summary>
+        /// Field: Examples Extension
+        /// </summary>
+        public const string ExamplesExtension = "x-examples";
+
+        /// <summary>
         /// Field: version3_0_0
         /// </summary>
         public static readonly Version version3_0_0 = new(3, 0, 0);

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;

--- a/src/Microsoft.OpenApi/Models/OpenApiExample.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExample.cs
@@ -119,6 +119,16 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         public void SerializeAsV3WithoutReference(IOpenApiWriter writer)
         {
+            Serialize(writer, OpenApiSpecVersion.OpenApi3_0);
+        }
+
+        /// <summary>
+        /// Writes out existing examples in a mediatype object
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="version"></param>
+        public void Serialize(IOpenApiWriter writer, OpenApiSpecVersion version)
+        {
             writer.WriteStartObject();
 
             // summary
@@ -134,7 +144,7 @@ namespace Microsoft.OpenApi.Models
             writer.WriteProperty(OpenApiConstants.ExternalValue, ExternalValue);
 
             // extensions
-            writer.WriteExtensions(Extensions, OpenApiSpecVersion.OpenApi3_0);
+            writer.WriteExtensions(Extensions, version);
 
             writer.WriteEndObject();
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
@@ -204,14 +204,7 @@ namespace Microsoft.OpenApi.Models
         /// <returns>OpenApiParameter</returns>
         public OpenApiParameter GetEffective(OpenApiDocument doc)
         {
-            if (this.Reference != null)
-            {
-                return doc.ResolveReferenceTo<OpenApiParameter>(this.Reference);
-            }
-            else
-            {
-                return this;
-            }
+            return Reference != null ? doc.ResolveReferenceTo<OpenApiParameter>(Reference) : this;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
@@ -397,7 +397,7 @@ namespace Microsoft.OpenApi.Models
                 foreach (var example in Examples)
                 {
                     writer.WritePropertyName(example.Key);
-                    writer.WriteV2Examples(writer, example.Value, OpenApiSpecVersion.OpenApi2_0);
+                    example.Value.Serialize(writer, OpenApiSpecVersion.OpenApi2_0);
                 }
                 writer.WriteEndObject();
             }

--- a/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
@@ -1,8 +1,9 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;

--- a/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
@@ -390,7 +390,7 @@ namespace Microsoft.OpenApi.Models
             //examples
             if (Examples != null && Examples.Any())
             {
-                writer.WritePropertyName("x-examples");
+                writer.WritePropertyName(OpenApiConstants.ExamplesExtension);
                 writer.WriteStartObject();
 
                 foreach (var example in Examples)

--- a/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -392,6 +392,20 @@ namespace Microsoft.OpenApi.Models
                         writer.WriteProperty("collectionFormat", "ssv");
                     }
                 }
+            }
+
+            //examples
+            if (Examples != null && Examples.Any())
+            {
+                writer.WritePropertyName("x-examples");
+                writer.WriteStartObject();
+
+                foreach (var example in Examples)
+                {
+                    writer.WritePropertyName(example.Key);
+                    writer.WriteV2Examples(writer, example.Value, OpenApiSpecVersion.OpenApi2_0);
+                }
+                writer.WriteEndObject();
             }
 
             // extensions

--- a/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
@@ -150,7 +150,7 @@ namespace Microsoft.OpenApi.Models
                 Required = Required,
                 Extensions = Extensions.ToDictionary(static k => k.Key, static v => v.Value)  // Clone extensions so we can remove the x-bodyName extensions from the output V2 model.
             };
-            if (bodyParameter.Extensions.TryGetValue(OpenApiConstants.BodyName, out var bodyParameterName))
+            if (bodyParameter.Extensions.ContainsKey(OpenApiConstants.BodyName))
             {
                 bodyParameter.Name = (Extensions[OpenApiConstants.BodyName] as OpenApiString)?.Value ?? "body";
                 bodyParameter.Extensions.Remove(OpenApiConstants.BodyName);

--- a/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -152,7 +152,8 @@ namespace Microsoft.OpenApi.Models
                 // V2 spec actually allows the body to have custom name.
                 // To allow round-tripping we use an extension to hold the name
                 Name = "body",
-                Schema = Content.Values.FirstOrDefault()?.Schema ?? new OpenApiSchema(),
+                Schema = Content.Values.FirstOrDefault()?.Schema ?? new JsonSchemaBuilder().Build(),
+                Examples = Content.Values.FirstOrDefault()?.Examples,
                 Required = Required,
                 Extensions = Extensions.ToDictionary(static k => k.Key, static v => v.Value)  // Clone extensions so we can remove the x-bodyName extensions from the output V2 model.
             };
@@ -184,7 +185,8 @@ namespace Microsoft.OpenApi.Models
                     Description = property.Value.Description,
                     Name = property.Key,
                     Schema = property.Value,
-                    Required = Content.First().Value.Schema.Required.Contains(property.Key)
+                    Examples = Content.Values.FirstOrDefault()?.Examples,
+                    Required = Content.First().Value.Schema.GetRequired()?.Contains(property.Key) ?? false
                 };
             }
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
@@ -96,14 +96,7 @@ namespace Microsoft.OpenApi.Models
         /// <returns>OpenApiRequestBody</returns>
         public OpenApiRequestBody GetEffective(OpenApiDocument doc)
         {
-            if (this.Reference != null)
-            {
-                return doc.ResolveReferenceTo<OpenApiRequestBody>(this.Reference);
-            }
-            else
-            {
-                return this;
-            }
+            return Reference != null ? doc.ResolveReferenceTo<OpenApiRequestBody>(Reference) : this;
         }
 
         /// <summary>
@@ -157,7 +150,7 @@ namespace Microsoft.OpenApi.Models
                 Required = Required,
                 Extensions = Extensions.ToDictionary(static k => k.Key, static v => v.Value)  // Clone extensions so we can remove the x-bodyName extensions from the output V2 model.
             };
-            if (bodyParameter.Extensions.ContainsKey(OpenApiConstants.BodyName))
+            if (bodyParameter.Extensions.TryGetValue(OpenApiConstants.BodyName, out var bodyParameterName))
             {
                 bodyParameter.Name = (Extensions[OpenApiConstants.BodyName] as OpenApiString)?.Value ?? "body";
                 bodyParameter.Extensions.Remove(OpenApiConstants.BodyName);

--- a/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -145,7 +145,7 @@ namespace Microsoft.OpenApi.Models
                 // V2 spec actually allows the body to have custom name.
                 // To allow round-tripping we use an extension to hold the name
                 Name = "body",
-                Schema = Content.Values.FirstOrDefault()?.Schema ?? new JsonSchemaBuilder().Build(),
+                Schema = Content.Values.FirstOrDefault()?.Schema ?? new OpenApiSchema(),
                 Examples = Content.Values.FirstOrDefault()?.Examples,
                 Required = Required,
                 Extensions = Extensions.ToDictionary(static k => k.Key, static v => v.Value)  // Clone extensions so we can remove the x-bodyName extensions from the output V2 model.
@@ -179,7 +179,7 @@ namespace Microsoft.OpenApi.Models
                     Name = property.Key,
                     Schema = property.Value,
                     Examples = Content.Values.FirstOrDefault()?.Examples,
-                    Required = Content.First().Value.Schema.GetRequired()?.Contains(property.Key) ?? false
+                    Required = Content.First().Value.Schema.Required?.Contains(property.Key) ?? false
                 };
             }
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
@@ -204,7 +204,7 @@ namespace Microsoft.OpenApi.Models
                             .SelectMany(mediaTypePair => mediaTypePair.Value.Examples))
                         {
                             writer.WritePropertyName(example.Key);
-                            writer.WriteV2Examples(writer, example.Value, OpenApiSpecVersion.OpenApi2_0);
+                            example.Value.Serialize(writer, OpenApiSpecVersion.OpenApi2_0);
                         }
 
                         writer.WriteEndObject();

--- a/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
@@ -199,17 +199,12 @@ namespace Microsoft.OpenApi.Models
                         writer.WritePropertyName("x-examples");
                         writer.WriteStartObject();
 
-                        foreach (var mediaTypePair in Content)
+                        foreach (var example in Content
+                            .Where(mediaTypePair => mediaTypePair.Value.Examples != null && mediaTypePair.Value.Examples.Any())
+                            .SelectMany(mediaTypePair => mediaTypePair.Value.Examples))
                         {
-                            var examples = mediaTypePair.Value.Examples;
-                            if (examples != null && examples.Any())
-                            {
-                                foreach (var example in examples)
-                                {
-                                    writer.WritePropertyName(example.Key);
-                                    writer.WriteV2Examples(writer, example.Value, OpenApiSpecVersion.OpenApi2_0);
-                                }
-                            }
+                            writer.WritePropertyName(example.Key);
+                            writer.WriteV2Examples(writer, example.Value, OpenApiSpecVersion.OpenApi2_0);
                         }
 
                         writer.WriteEndObject();

--- a/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
@@ -195,6 +195,27 @@ namespace Microsoft.OpenApi.Models
                             {
                                 writer.WritePropertyName(mediaTypePair.Key);
                                 writer.WriteAny(mediaTypePair.Value.Example);
+                            }
+                        }
+
+                        writer.WriteEndObject();
+                    }
+
+                    if (Content.Values.Any(m => m.Examples != null && m.Examples.Any()))
+                    {
+                        writer.WritePropertyName("x-examples");
+                        writer.WriteStartObject();
+
+                        foreach (var mediaTypePair in Content)
+                        {
+                            var examples = mediaTypePair.Value.Examples;
+                            if (examples != null && examples.Any())
+                            {
+                                foreach (var example in examples)
+                                {
+                                    writer.WritePropertyName(example.Key);
+                                    writer.WriteV2Examples(writer, example.Value, OpenApiSpecVersion.OpenApi2_0);
+                                }
                             }
                         }
 

--- a/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
@@ -196,7 +196,7 @@ namespace Microsoft.OpenApi.Models
 
                     if (Content.Values.Any(m => m.Examples != null && m.Examples.Any()))
                     {
-                        writer.WritePropertyName("x-examples");
+                        writer.WritePropertyName(OpenApiConstants.ExamplesExtension);
                         writer.WriteStartObject();
 
                         foreach (var example in Content

--- a/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
@@ -101,14 +101,7 @@ namespace Microsoft.OpenApi.Models
         /// <returns>OpenApiResponse</returns>
         public OpenApiResponse GetEffective(OpenApiDocument doc)
         {
-            if (this.Reference != null)
-            {
-                return doc.ResolveReferenceTo<OpenApiResponse>(this.Reference);
-            }
-            else
-            {
-                return this;
-            }
+            return Reference != null ? doc.ResolveReferenceTo<OpenApiResponse>(Reference) : this;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Writers/IOpenApiWriter.cs
+++ b/src/Microsoft.OpenApi/Writers/IOpenApiWriter.cs
@@ -1,7 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-
-using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Writers
 {
@@ -74,13 +72,5 @@ namespace Microsoft.OpenApi.Writers
         /// Flush the writer.
         /// </summary>
         void Flush();
-
-        /// <summary>
-        /// Writes out existing examples in a mediatype object
-        /// </summary>
-        /// <param name="writer"></param>
-        /// <param name="example"></param>
-        /// <param name="version"></param>
-        void WriteV2Examples(IOpenApiWriter writer, OpenApiExample example, OpenApiSpecVersion version);
     }
 }

--- a/src/Microsoft.OpenApi/Writers/IOpenApiWriter.cs
+++ b/src/Microsoft.OpenApi/Writers/IOpenApiWriter.cs
@@ -1,5 +1,7 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+
+using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Writers
 {
@@ -72,5 +74,13 @@ namespace Microsoft.OpenApi.Writers
         /// Flush the writer.
         /// </summary>
         void Flush();
+
+        /// <summary>
+        /// Writes out existing examples in a mediatype object
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="example"></param>
+        /// <param name="version"></param>
+        void WriteV2Examples(IOpenApiWriter writer, OpenApiExample example, OpenApiSpecVersion version);
     }
 }

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -404,6 +404,29 @@ namespace Microsoft.OpenApi.Writers
                 throw new OpenApiWriterException(
                     string.Format(SRResource.ObjectScopeNeededForPropertyNameWriting, name));
             }
+        }
+
+        /// <inheritdoc/>
+        public void WriteV2Examples(IOpenApiWriter writer, OpenApiExample example, OpenApiSpecVersion version)
+        {
+            writer.WriteStartObject();
+
+            // summary
+            writer.WriteProperty(OpenApiConstants.Summary, example.Summary);
+
+            // description
+            writer.WriteProperty(OpenApiConstants.Description, example.Description);
+
+            // value
+            writer.WriteOptionalObject(OpenApiConstants.Value, example.Value, (w, v) => w.WriteAny(v));
+
+            // externalValue
+            writer.WriteProperty(OpenApiConstants.ExternalValue, example.ExternalValue);
+
+            // extensions
+            writer.WriteExtensions(example.Extensions, version);
+
+            writer.WriteEndObject();
         }
     }
 }

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.OpenApi.Exceptions;
-using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Properties;
 
 namespace Microsoft.OpenApi.Writers
@@ -405,29 +404,6 @@ namespace Microsoft.OpenApi.Writers
                 throw new OpenApiWriterException(
                     string.Format(SRResource.ObjectScopeNeededForPropertyNameWriting, name));
             }
-        }
-
-        /// <inheritdoc/>
-        public void WriteV2Examples(IOpenApiWriter writer, OpenApiExample example, OpenApiSpecVersion version)
-        {
-            writer.WriteStartObject();
-
-            // summary
-            writer.WriteProperty(OpenApiConstants.Summary, example.Summary);
-
-            // description
-            writer.WriteProperty(OpenApiConstants.Description, example.Description);
-
-            // value
-            writer.WriteOptionalObject(OpenApiConstants.Value, example.Value, (w, v) => w.WriteAny(v));
-
-            // externalValue
-            writer.WriteProperty(OpenApiConstants.ExternalValue, example.ExternalValue);
-
-            // extensions
-            writer.WriteExtensions(example.Extensions, version);
-
-            writer.WriteEndObject();
         }
     }
 }

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterBase.cs
@@ -1,10 +1,11 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.OpenApi.Exceptions;
+using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Properties;
 
 namespace Microsoft.OpenApi.Writers

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -28,6 +28,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\Microsoft.OpenApi\Microsoft.OpenApi.csproj" />
         <ProjectReference Include="..\..\src\Microsoft.OpenApi.Readers\Microsoft.OpenApi.Readers.csproj" />
+        <ProjectReference Include="..\Microsoft.OpenApi.Tests\Microsoft.OpenApi.Tests.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiOperationTests.cs
@@ -11,6 +11,7 @@ using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
 using Microsoft.OpenApi.Readers.V2;
+using Microsoft.OpenApi.Readers.V3;
 using Microsoft.OpenApi.Tests;
 using Xunit;
 
@@ -484,7 +485,56 @@ responses:
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
-            //Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void LoadV3ExamplesInResponseAsExtensionsWorks()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "v3OperationWithResponseExamples.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var operation = OpenApiV3Deserializer.LoadOperation(node);
+            var actual = operation.SerializeAsYaml(OpenApiSpecVersion.OpenApi2_0);
+
+            // Assert
+            var expected = @"summary: Get all pets
+produces:
+  - application/json
+responses:
+  '200':
+    description: Successful response
+    schema:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+          age:
+            type: integer
+    x-examples:
+      example1:
+        summary: Example - List of Pets
+        value:
+          - name: Buddy
+            age: 2
+          - name: Whiskers
+            age: 1
+      example2:
+        summary: Example - Playful Cat
+        value:
+          name: Whiskers
+          age: 1";
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiOperationTests.cs
@@ -536,5 +536,108 @@ responses:
             expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
         }
+
+        [Fact]
+        public void LoadV2OperationWithBodyParameterExamplesWorks()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "opWithBodyParameterExamples.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var operation = OpenApiV2Deserializer.LoadOperation(node);
+            var actual = operation.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_0);
+
+            // Assert
+            var expected = @"summary: Get all pets
+requestBody:
+  content:
+    application/json:
+      schema:
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+            age:
+              type: integer
+      examples:
+        example1:
+          summary: Example - List of Pets
+          value:
+            - name: Buddy
+              age: 2
+            - name: Whiskers
+              age: 1
+        example2:
+          summary: Example - Playful Cat
+          value:
+            name: Whiskers
+            age: 1
+  required: true
+  x-bodyName: body
+responses: { }";
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void LoadV3ExamplesInRequestBodyParameterAsExtensionsWorks()
+        {
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "v3OperationWithBodyParameterExamples.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var operation = OpenApiV3Deserializer.LoadOperation(node);
+            var actual = operation.SerializeAsYaml(OpenApiSpecVersion.OpenApi2_0);
+
+            // Assert
+            var expected = @"summary: Get all pets
+consumes:
+  - application/json
+parameters:
+  - in: body
+    name: body
+    required: true
+    schema:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+          age:
+            type: integer
+    x-examples:
+      example1:
+        summary: Example - List of Pets
+        value:
+          - name: Buddy
+            age: 2
+          - name: Whiskers
+            age: 1
+      example2:
+        summary: Example - Playful Cat
+        value:
+          name: Whiskers
+          age: 1
+responses: { }";
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiOperationTests.cs
@@ -11,6 +11,7 @@ using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
 using Microsoft.OpenApi.Readers.V2;
+using Microsoft.OpenApi.Tests;
 using Xunit;
 
 namespace Microsoft.OpenApi.Readers.Tests.V2Tests
@@ -433,6 +434,57 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
 
             // Assert
             operation.Should().BeEquivalentTo(_operationWithBody);
+        }
+
+        [Fact]
+        public void ParseV2ResponseWithExamplesExtensionWorks()
+        {            
+            // Arrange
+            MapNode node;
+            using (var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "opWithResponseExamplesExtension.yaml")))
+            {
+                node = TestHelper.CreateYamlMapNode(stream);
+            }
+
+            // Act
+            var operation = OpenApiV2Deserializer.LoadOperation(node);
+            var actual = operation.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_0);
+
+            // Assert
+            var expected = @"summary: Get all pets
+responses:
+  '200':
+    description: Successful response
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              age:
+                type: integer
+        examples:
+          example1:
+            summary: Example - List of Pets
+            value:
+              - name: Buddy
+                age: 2
+              - name: Whiskers
+                age: 1
+          example2:
+            summary: Example - Playful Cat
+            value:
+              name: Whiskers
+              age: 1";
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+            //Assert.Equal(expected, actual);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/opWithBodyParameterExamples.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/opWithBodyParameterExamples.yaml
@@ -1,0 +1,29 @@
+summary: Get all pets
+consumes:
+  - application/json
+parameters:
+  - in: body
+    name: body
+    required: true
+    schema:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+          age:
+            type: integer
+    x-examples:
+      example1:
+        summary: Example - List of Pets
+        value:
+          - name: Buddy
+            age: 2
+          - name: Whiskers
+            age: 1
+      example2:
+        summary: Example - Playful Cat
+        value:
+          name: Whiskers
+          age: 1

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/opWithResponseExamplesExtension.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/opWithResponseExamplesExtension.yaml
@@ -1,0 +1,28 @@
+summary: Get all pets
+produces:
+- application/json
+responses:
+  '200':
+    description: Successful response
+    schema:
+      type: array
+      items:
+        type: object
+        properties:
+           name:
+             type: string
+           age:
+             type: integer
+    x-examples:
+      example1:
+        summary: Example - List of Pets
+        value:
+         - name: "Buddy"
+           age: 2
+         - name: "Whiskers"
+           age: 1
+      example2:
+        summary: Example - Playful Cat
+        value:
+          name: "Whiskers"
+          age: 1

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/v3OperationWithBodyParameterExamples.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/v3OperationWithBodyParameterExamples.yaml
@@ -1,0 +1,27 @@
+summary: Get all pets
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+            age:
+              type: integer
+      examples:
+        example1:
+          summary: Example - List of Pets
+          value:
+            - name: "Buddy"
+              age: 2
+            - name: "Whiskers"
+              age: 1
+        example2:
+          summary: Example - Playful Cat
+          value:
+            name: "Whiskers"
+            age: 1

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/v3OperationWithResponseExamples.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/Samples/OpenApiOperation/v3OperationWithResponseExamples.yaml
@@ -1,0 +1,28 @@
+summary: Get all pets
+responses:
+  '200':
+    description: Successful response
+    content:
+      application/json:
+        schema:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              age:
+                type: integer
+        examples:
+          example1:
+            summary: Example - List of Pets
+            value:
+            - name: "Buddy"
+              age: 2
+            - name: "Whiskers"
+              age: 1
+          example2:
+            summary: Example - Playful Cat
+            value:
+              name: "Whiskers"
+              age: 1

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.SerializeParameterWithSchemaReferenceAsV2JsonWorksAsync_produceTerseOutput=False.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.SerializeParameterWithSchemaReferenceAsV2JsonWorksAsync_produceTerseOutput=False.verified.txt
@@ -3,5 +3,11 @@
   "name": "name1",
   "description": "description1",
   "required": true,
-  "type": "string"
+  "type": "string",
+  "x-examples": {
+    "test": {
+      "summary": "summary3",
+      "description": "description3"
+    }
+  }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.SerializeParameterWithSchemaReferenceAsV2JsonWorksAsync_produceTerseOutput=True.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.SerializeParameterWithSchemaReferenceAsV2JsonWorksAsync_produceTerseOutput=True.verified.txt
@@ -1,1 +1,1 @@
-{"in":"header","name":"name1","description":"description1","required":true,"type":"string"}
+{"in":"header","name":"name1","description":"description1","required":true,"type":"string","x-examples":{"test":{"summary":"summary3","description":"description3"}}}

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.SerializeParameterWithSchemaTypeObjectAsV2JsonWorksAsync_produceTerseOutput=False.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.SerializeParameterWithSchemaTypeObjectAsV2JsonWorksAsync_produceTerseOutput=False.verified.txt
@@ -3,5 +3,11 @@
   "name": "name1",
   "description": "description1",
   "required": true,
-  "type": "string"
+  "type": "string",
+  "x-examples": {
+    "test": {
+      "summary": "summary3",
+      "description": "description3"
+    }
+  }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.SerializeParameterWithSchemaTypeObjectAsV2JsonWorksAsync_produceTerseOutput=True.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.SerializeParameterWithSchemaTypeObjectAsV2JsonWorksAsync_produceTerseOutput=True.verified.txt
@@ -1,1 +1,1 @@
-{"in":"header","name":"name1","description":"description1","required":true,"type":"string"}
+{"in":"header","name":"name1","description":"description1","required":true,"type":"string","x-examples":{"test":{"summary":"summary3","description":"description3"}}}

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
@@ -272,7 +272,13 @@ namespace Microsoft.OpenApi.Tests.Models
                   "name": "name1",
                   "description": "description1",
                   "required": true,
-                  "format": "double"
+                  "format": "double",
+                  "x-examples": {
+                    "test": {
+                      "summary": "summary3",
+                      "description": "description3"
+                    }
+                  }
                 }
                 """;
 

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -1486,6 +1486,7 @@ namespace Microsoft.OpenApi.Writers
         void WriteRaw(string value);
         void WriteStartArray();
         void WriteStartObject();
+        void WriteV2Examples(Microsoft.OpenApi.Writers.IOpenApiWriter writer, Microsoft.OpenApi.Models.OpenApiExample example, Microsoft.OpenApi.OpenApiSpecVersion version);
         void WriteValue(bool value);
         void WriteValue(decimal value);
         void WriteValue(int value);
@@ -1547,6 +1548,7 @@ namespace Microsoft.OpenApi.Writers
         public abstract void WriteRaw(string value);
         public abstract void WriteStartArray();
         public abstract void WriteStartObject();
+        public void WriteV2Examples(Microsoft.OpenApi.Writers.IOpenApiWriter writer, Microsoft.OpenApi.Models.OpenApiExample example, Microsoft.OpenApi.OpenApiSpecVersion version) { }
         public virtual void WriteValue(bool value) { }
         public virtual void WriteValue(System.DateTime value) { }
         public virtual void WriteValue(System.DateTimeOffset value) { }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -643,6 +643,7 @@ namespace Microsoft.OpenApi.Models
         public bool UnresolvedReference { get; set; }
         public Microsoft.OpenApi.Any.IOpenApiAny Value { get; set; }
         public Microsoft.OpenApi.Models.OpenApiExample GetEffective(Microsoft.OpenApi.Models.OpenApiDocument doc) { }
+        public void Serialize(Microsoft.OpenApi.Writers.IOpenApiWriter writer, Microsoft.OpenApi.OpenApiSpecVersion version) { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV2WithoutReference(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1487,7 +1488,6 @@ namespace Microsoft.OpenApi.Writers
         void WriteRaw(string value);
         void WriteStartArray();
         void WriteStartObject();
-        void WriteV2Examples(Microsoft.OpenApi.Writers.IOpenApiWriter writer, Microsoft.OpenApi.Models.OpenApiExample example, Microsoft.OpenApi.OpenApiSpecVersion version);
         void WriteValue(bool value);
         void WriteValue(decimal value);
         void WriteValue(int value);
@@ -1549,7 +1549,6 @@ namespace Microsoft.OpenApi.Writers
         public abstract void WriteRaw(string value);
         public abstract void WriteStartArray();
         public abstract void WriteStartObject();
-        public void WriteV2Examples(Microsoft.OpenApi.Writers.IOpenApiWriter writer, Microsoft.OpenApi.Models.OpenApiExample example, Microsoft.OpenApi.OpenApiSpecVersion version) { }
         public virtual void WriteValue(bool value) { }
         public virtual void WriteValue(System.DateTime value) { }
         public virtual void WriteValue(System.DateTimeOffset value) { }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -480,6 +480,7 @@ namespace Microsoft.OpenApi.Models
         public const string Enum = "enum";
         public const string Example = "example";
         public const string Examples = "examples";
+        public const string ExamplesExtension = "x-examples";
         public const string ExclusiveMaximum = "exclusiveMaximum";
         public const string ExclusiveMinimum = "exclusiveMinimum";
         public const string Explode = "explode";


### PR DESCRIPTION
This is a rebase of #1524 on our `vnext` branch since its not a breaking change