### PR TITLE
Use the server URL to uniquely ID schema models from different clouds during registration

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -156,9 +156,9 @@ namespace Microsoft.OpenApi.Readers.V2
             // Fill in missing information based on the defaultUrl
             if (defaultUrl != null)
             {
-                host = host ?? defaultUrl.GetComponents(UriComponents.NormalizedHost, UriFormat.SafeUnescaped);
-                basePath = basePath ?? defaultUrl.GetComponents(UriComponents.Path, UriFormat.SafeUnescaped);
-                schemes = schemes ?? new List<string> { defaultUrl.GetComponents(UriComponents.Scheme, UriFormat.SafeUnescaped) };
+                host ??= defaultUrl.GetComponents(UriComponents.NormalizedHost, UriFormat.SafeUnescaped);
+                basePath ??= defaultUrl.GetComponents(UriComponents.Path, UriFormat.SafeUnescaped);
+                schemes ??= [defaultUrl.GetComponents(UriComponents.Scheme, UriFormat.SafeUnescaped)];
             }
             else if (String.IsNullOrEmpty(host) && String.IsNullOrEmpty(basePath))
             {

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
@@ -326,11 +326,14 @@ namespace Microsoft.OpenApi.Readers.V2
             {
                 var servers = context.GetFromTempStorage<IList<OpenApiServer>>(TempStorageKeys.Servers);
                 var serverUrl = servers?.FirstOrDefault()?.Url;
-                serverUrl = serverUrl.Contains("http://") || serverUrl.Contains("https://")
-                    ? serverUrl.Substring(0, serverUrl.IndexOf("/", serverUrl.Length-1))
-                    : null;
 
-                var refPath = serverUrl != null ? string.Concat(serverUrl, OpenApiConstants.V2ReferencedSchemaPath)
+                // Remove any trailing slashes from the server URL
+                if (!string.IsNullOrEmpty(serverUrl) && serverUrl.EndsWith("/"))
+                {
+                    serverUrl = serverUrl.Substring(0, serverUrl.Length - 1);
+                }
+
+                var refPath = !string.IsNullOrEmpty(serverUrl) ? string.Concat(serverUrl, OpenApiConstants.V2ReferencedSchemaPath)
                     : OpenApiConstants.V2ReferenceUri;
 
                 var refUri = new Uri(refPath + schema.Key);

--- a/src/Microsoft.OpenApi.Readers/V2/TempStorageKeys.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/TempStorageKeys.cs
@@ -17,5 +17,6 @@ namespace Microsoft.OpenApi.Readers.V2
         public const string GlobalConsumes = "globalConsumes";
         public const string GlobalProduces = "globalProduces";
         public const string ParameterIsBodyOrFormData = "parameterIsBodyOrFormData";
+        public const string Servers = "servers";
     }
 }

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiComponentsDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiComponentsDeserializer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.OpenApi.Readers.V3
             // Examples of server url ----> "https://graph.microsoft.com/v1.0", "https://graph.microsoft.com/v1.0-fairfax"
             foreach (var schema in components.Schemas)
             {
-                var refPath = serverUrl != null ? string.Concat(serverUrl, OpenApiConstants.V3ReferencedSchemaPath)
+                var refPath = !string.IsNullOrEmpty(serverUrl) ? string.Concat(serverUrl, OpenApiConstants.V3ReferencedSchemaPath)
                     : OpenApiConstants.V3ReferenceUri;
 
                 var refUri = new Uri(refPath + schema.Key);

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiDocumentDeserializer.cs
@@ -4,6 +4,7 @@
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
+using Microsoft.OpenApi.Readers.V2;
 
 namespace Microsoft.OpenApi.Readers.V3
 {
@@ -21,7 +22,7 @@ namespace Microsoft.OpenApi.Readers.V3
                 } /* Version is valid field but we already parsed it */
             },
             {"info", (o, n) => o.Info = LoadInfo(n)},
-            {"servers", (o, n) => o.Servers = n.CreateList(LoadServer)},
+            {"servers", (o, n) => n.Context.SetTempStorage(TempStorageKeys.Servers, o.Servers = n.CreateList(LoadServer))},
             {"paths", (o, n) => o.Paths = LoadPaths(n)},
             {"components", (o, n) => o.Components = LoadComponents(n)},
             {"tags", (o, n) => {o.Tags = n.CreateList(LoadTag);

--- a/src/Microsoft.OpenApi.Readers/V31/OpenApiComponentsDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V31/OpenApiComponentsDeserializer.cs
@@ -2,10 +2,13 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Json.Schema;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
+using Microsoft.OpenApi.Readers.V2;
 
 namespace Microsoft.OpenApi.Readers.V31
 {
@@ -42,9 +45,15 @@ namespace Microsoft.OpenApi.Readers.V31
 
             ParseMap(mapNode, components, _componentsFixedFields, _componentsPatternFields);
 
+            var servers = node.Context.GetFromTempStorage<IList<OpenApiServer>>(TempStorageKeys.Servers);
+            var serverUrl = servers?.FirstOrDefault()?.Url;
+
             foreach (var schema in components.Schemas)
             {
-                var refUri = new Uri(OpenApiConstants.V3ReferenceUri + schema.Key);
+                var refPath = serverUrl != null ? string.Concat(serverUrl, OpenApiConstants.V3ReferencedSchemaPath)
+                    : OpenApiConstants.V3ReferenceUri;
+
+                var refUri = new Uri(refPath + schema.Key);
                 SchemaRegistry.Global.Register(refUri, schema.Value);
             }
 

--- a/src/Microsoft.OpenApi.Readers/V31/OpenApiComponentsDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V31/OpenApiComponentsDeserializer.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OpenApi.Readers.V31
 
             foreach (var schema in components.Schemas)
             {
-                var refPath = serverUrl != null ? string.Concat(serverUrl, OpenApiConstants.V3ReferencedSchemaPath)
+                var refPath = !string.IsNullOrEmpty(serverUrl) ? string.Concat(serverUrl, OpenApiConstants.V3ReferencedSchemaPath)
                     : OpenApiConstants.V3ReferenceUri;
 
                 var refUri = new Uri(refPath + schema.Key);

--- a/src/Microsoft.OpenApi.Readers/V31/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V31/OpenApiDocumentDeserializer.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
+using Microsoft.OpenApi.Readers.V2;
 
 namespace Microsoft.OpenApi.Readers.V31
 {
@@ -19,7 +20,7 @@ namespace Microsoft.OpenApi.Readers.V31
             },
             {"info", (o, n) => o.Info = LoadInfo(n)},
             {"jsonSchemaDialect", (o, n) => o.JsonSchemaDialect = n.GetScalarValue() },
-            {"servers", (o, n) => o.Servers = n.CreateList(LoadServer)},
+            {"servers", (o, n) => n.Context.SetTempStorage(TempStorageKeys.Servers, o.Servers = n.CreateList(LoadServer))},
             {"paths", (o, n) => o.Paths = LoadPaths(n)},
             {"webhooks", (o, n) => o.Webhooks = LoadPaths(n)},
             {"components", (o, n) => o.Components = LoadComponents(n)},

--- a/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
@@ -598,6 +598,16 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Field: V3 JsonSchema Reference Uri
         /// </summary>
+        public const string V3ReferencedSchemaPath = "/components/schemas/";
+
+        /// <summary>
+        /// Field: V2 JsonSchema Reference Uri
+        /// </summary>
+        public const string V2ReferencedSchemaPath = "/definitions/";
+
+        /// <summary>
+        /// Field: V3 JsonSchema Reference Uri
+        /// </summary>
         public const string V3ReferenceUri = "https://registry/components/schemas/";
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Services/OpenApiReferenceResolver.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiReferenceResolver.cs
@@ -254,10 +254,8 @@ namespace Microsoft.OpenApi.Services
         {
             var servers = _currentDocument.Servers;
             var basePath = servers?.FirstOrDefault()?.Url;
-            basePath = basePath.Contains("http://") || basePath.Contains("https://")
-                    ? basePath.Substring(0, basePath.IndexOf("/", basePath.Length - 1))
-                    : null;
 
+            basePath = RemoveTrailingSlash(basePath);
             var refPath = basePath ?? "https://registry";
 
             var refUri = $"{refPath}{reference.OriginalString.Split('#').LastOrDefault()}";
@@ -450,6 +448,16 @@ namespace Microsoft.OpenApi.Services
         private bool IsUnresolvedReference(IOpenApiReferenceable possibleReference)
         {
             return possibleReference != null && possibleReference.UnresolvedReference;
+        }
+
+        private string RemoveTrailingSlash(string url)
+        {
+            if (!string.IsNullOrEmpty(url) && url.EndsWith("/"))
+            {
+                // https://
+                return url.Substring(0, url.Length - 1);
+            }
+            return url;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Services/OpenApiReferenceResolver.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiReferenceResolver.cs
@@ -454,7 +454,6 @@ namespace Microsoft.OpenApi.Services
         {
             if (!string.IsNullOrEmpty(url) && url.EndsWith("/"))
             {
-                // https://
                 return url.Substring(0, url.Length - 1);
             }
             return url;

--- a/src/Microsoft.OpenApi/Services/OpenApiReferenceResolver.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiReferenceResolver.cs
@@ -252,7 +252,15 @@ namespace Microsoft.OpenApi.Services
         /// <returns></returns>
         public JsonSchema ResolveJsonSchemaReference(Uri reference, string description = null, string summary = null)
         {
-            var refUri = $"https://registry{reference.OriginalString.Split('#').LastOrDefault()}";
+            var servers = _currentDocument.Servers;
+            var basePath = servers?.FirstOrDefault()?.Url;
+            basePath = basePath.Contains("http://") || basePath.Contains("https://")
+                    ? basePath.Substring(0, basePath.IndexOf("/", basePath.Length - 1))
+                    : null;
+
+            var refPath = basePath ?? "https://registry";
+
+            var refUri = $"{refPath}{reference.OriginalString.Split('#').LastOrDefault()}";
             var resolvedSchema = (JsonSchema)SchemaRegistry.Global.Get(new Uri(refUri));
 
             if (resolvedSchema != null)

--- a/src/Microsoft.OpenApi/Services/OpenApiWorkspace.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWorkspace.cs
@@ -159,7 +159,11 @@ namespace Microsoft.OpenApi.Services
                 {
                     foreach (var jsonSchema in doc.Components.Schemas)
                     {
-                        var refUri = new Uri(OpenApiConstants.V3ReferenceUri + jsonSchema.Key);
+                        var serverUrl = doc.Servers.FirstOrDefault()?.Url;
+                        var refPath = serverUrl != null ? string.Concat(serverUrl, OpenApiConstants.V3ReferencedSchemaPath)
+                                            : OpenApiConstants.V3ReferenceUri;
+
+                        var refUri = new Uri(refPath + jsonSchema.Key);
                         SchemaRegistry.Global.Register(refUri, jsonSchema.Value);
                     }
 

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -530,7 +530,9 @@ namespace Microsoft.OpenApi.Models
         public const string UniqueItems = "uniqueItems";
         public const string Url = "url";
         public const string V2ReferenceUri = "https://registry/definitions/";
+        public const string V2ReferencedSchemaPath = "/definitions/";
         public const string V3ReferenceUri = "https://registry/components/schemas/";
+        public const string V3ReferencedSchemaPath = "/components/schemas/";
         public const string Value = "value";
         public const string Variables = "variables";
         public const string Version = "version";


### PR DESCRIPTION
Fixes #1555