### PR TITLE
Enables null reference types

### DIFF
--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiExtensible.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiExtensible.cs
@@ -13,6 +13,6 @@ namespace Microsoft.OpenApi.Interfaces
         /// <summary>
         /// Specification extensions.
         /// </summary>
-        IDictionary<string, IOpenApiExtension> Extensions { get; set; }
+        IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
     }
 }

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiReferenceable.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiReferenceable.cs
@@ -19,7 +19,7 @@ namespace Microsoft.OpenApi.Interfaces
         /// <summary>
         /// Reference object.
         /// </summary>
-        OpenApiReference Reference { get; set; }
+        OpenApiReference? Reference { get; set; }
 
         /// <summary>
         /// Serialize to OpenAPI V31 document without using reference.

--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>Latest</LangVersion>
+        <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Version>1.6.11</Version>
         <Description>.NET models with JSON and YAML writers for OpenAPI specification</Description>

--- a/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// A Path Item Object used to define a callback request and expected responses.
         /// </summary>
-        public virtual Dictionary<RuntimeExpression, OpenApiPathItem> PathItems { get; set; }
+        public virtual Dictionary<RuntimeExpression, OpenApiPathItem>? PathItems { get; set; }
             = new();
 
         /// <summary>
@@ -28,12 +28,12 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Reference pointer.
         /// </summary>
-        public OpenApiReference Reference { get; set; }
+        public OpenApiReference? Reference { get; set; }
 
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public virtual IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
+        public virtual IDictionary<string, IOpenApiExtension>? Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Parameter-less constructor
@@ -45,9 +45,9 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         public OpenApiCallback(OpenApiCallback callback)
         {
-            PathItems = callback?.PathItems != null ? new(callback?.PathItems) : null;
+            PathItems = callback?.PathItems != null ? new(callback.PathItems) : null;
             UnresolvedReference = callback?.UnresolvedReference ?? UnresolvedReference;
-            Reference = callback?.Reference != null ? new(callback?.Reference) : null;
+            Reference = callback?.Reference != null ? new(callback.Reference) : null;
             Extensions = callback?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(callback.Extensions) : null;
         }
 
@@ -160,13 +160,16 @@ namespace Microsoft.OpenApi.Models
             writer.WriteStartObject();
 
             // path items
-            foreach (var item in PathItems)
+            if (PathItems != null)
             {
-                writer.WriteRequiredObject(item.Key.Expression, item.Value, callback);
-            }
+                foreach (var item in PathItems)
+                {
+                    writer.WriteRequiredObject(item.Key.Expression, item.Value, callback);
+                }
+            }            
 
             // extensions
-            writer.WriteExtensions(Extensions, version);
+            writer.WriteExtensions(Extensions!, version);
 
             writer.WriteEndObject();
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
@@ -19,60 +19,60 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// An object to hold reusable <see cref="JsonSchema"/> Objects.
         /// </summary>
-        public IDictionary<string, JsonSchema> Schemas { get; set; } = new Dictionary<string, JsonSchema>();
+        public IDictionary<string, JsonSchema>? Schemas { get; set; } = new Dictionary<string, JsonSchema>();
 
         /// <summary>
         /// An object to hold reusable <see cref="OpenApiResponse"/> Objects.
         /// </summary>
-        public virtual IDictionary<string, OpenApiResponse> Responses { get; set; } = new Dictionary<string, OpenApiResponse>();
+        public virtual IDictionary<string, OpenApiResponse>? Responses { get; set; } = new Dictionary<string, OpenApiResponse>();
 
         /// <summary>
         /// An object to hold reusable <see cref="OpenApiParameter"/> Objects.
         /// </summary>
-        public virtual IDictionary<string, OpenApiParameter> Parameters { get; set; } =
+        public virtual IDictionary<string, OpenApiParameter>? Parameters { get; set; } =
             new Dictionary<string, OpenApiParameter>();
 
         /// <summary>
         /// An object to hold reusable <see cref="OpenApiExample"/> Objects.
         /// </summary>
-        public virtual IDictionary<string, OpenApiExample> Examples { get; set; } = new Dictionary<string, OpenApiExample>();
+        public virtual IDictionary<string, OpenApiExample>? Examples { get; set; } = new Dictionary<string, OpenApiExample>();
 
         /// <summary>
         /// An object to hold reusable <see cref="OpenApiRequestBody"/> Objects.
         /// </summary>
-        public virtual IDictionary<string, OpenApiRequestBody> RequestBodies { get; set; } =
+        public virtual IDictionary<string, OpenApiRequestBody>? RequestBodies { get; set; } =
             new Dictionary<string, OpenApiRequestBody>();
 
         /// <summary>
         /// An object to hold reusable <see cref="OpenApiHeader"/> Objects.
         /// </summary>
-        public virtual IDictionary<string, OpenApiHeader> Headers { get; set; } = new Dictionary<string, OpenApiHeader>();
+        public virtual IDictionary<string, OpenApiHeader>? Headers { get; set; } = new Dictionary<string, OpenApiHeader>();
 
         /// <summary>
         /// An object to hold reusable <see cref="OpenApiSecurityScheme"/> Objects.
         /// </summary>
-        public virtual IDictionary<string, OpenApiSecurityScheme> SecuritySchemes { get; set; } =
+        public virtual IDictionary<string, OpenApiSecurityScheme>? SecuritySchemes { get; set; } =
             new Dictionary<string, OpenApiSecurityScheme>();
 
         /// <summary>
         /// An object to hold reusable <see cref="OpenApiLink"/> Objects.
         /// </summary>
-        public virtual IDictionary<string, OpenApiLink> Links { get; set; } = new Dictionary<string, OpenApiLink>();
+        public virtual IDictionary<string, OpenApiLink>? Links { get; set; } = new Dictionary<string, OpenApiLink>();
 
         /// <summary>
         /// An object to hold reusable <see cref="OpenApiCallback"/> Objects.
         /// </summary>
-        public virtual IDictionary<string, OpenApiCallback> Callbacks { get; set; } = new Dictionary<string, OpenApiCallback>();
+        public virtual IDictionary<string, OpenApiCallback>? Callbacks { get; set; } = new Dictionary<string, OpenApiCallback>();
 
         /// <summary>
         /// An object to hold reusable <see cref="OpenApiPathItem"/> Object.
         /// </summary>
-        public virtual IDictionary<string, OpenApiPathItem> PathItems { get; set; } = new Dictionary<string, OpenApiPathItem>();
+        public virtual IDictionary<string, OpenApiPathItem>? PathItems { get; set; } = new Dictionary<string, OpenApiPathItem>();
 
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public virtual IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
+        public virtual IDictionary<string, IOpenApiExtension>? Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Parameter-less constructor
@@ -118,7 +118,7 @@ namespace Microsoft.OpenApi.Models
             // pathItems - only present in v3.1
             writer.WriteOptionalMap(
             OpenApiConstants.PathItems,
-            PathItems,
+            PathItems!,
             (w, key, component) =>
             {
                 if (component.Reference != null &&
@@ -170,7 +170,7 @@ namespace Microsoft.OpenApi.Models
             // schemas
             writer.WriteOptionalMap(
                 OpenApiConstants.Schemas,
-                Schemas,
+                Schemas!,
                 (w, key, s) =>
                 {
                     var reference = s.GetRef();
@@ -188,7 +188,7 @@ namespace Microsoft.OpenApi.Models
             // responses
             writer.WriteOptionalMap(
                 OpenApiConstants.Responses,
-                Responses,
+                Responses!,
                 (w, key, component) =>
                 {
                     if (component.Reference != null &&
@@ -206,7 +206,7 @@ namespace Microsoft.OpenApi.Models
             // parameters
             writer.WriteOptionalMap(
                 OpenApiConstants.Parameters,
-                Parameters,
+                Parameters!,
                 (w, key, component) =>
                 {
                     if (component.Reference != null &&
@@ -224,7 +224,7 @@ namespace Microsoft.OpenApi.Models
             // examples
             writer.WriteOptionalMap(
                 OpenApiConstants.Examples,
-                Examples,
+                Examples!,
                 (w, key, component) =>
                 {
                     if (component.Reference != null &&
@@ -242,7 +242,7 @@ namespace Microsoft.OpenApi.Models
             // requestBodies
             writer.WriteOptionalMap(
                 OpenApiConstants.RequestBodies,
-                RequestBodies,
+                RequestBodies!,
                 (w, key, component) =>
                 {
                     if (component.Reference != null &&
@@ -261,7 +261,7 @@ namespace Microsoft.OpenApi.Models
             // headers
             writer.WriteOptionalMap(
                 OpenApiConstants.Headers,
-                Headers,
+                Headers!,
                 (w, key, component) =>
                 {
                     if (component.Reference != null &&
@@ -279,7 +279,7 @@ namespace Microsoft.OpenApi.Models
             // securitySchemes
             writer.WriteOptionalMap(
                 OpenApiConstants.SecuritySchemes,
-                SecuritySchemes,
+                SecuritySchemes!,
                 (w, key, component) =>
                 {
                     if (component.Reference != null &&
@@ -297,7 +297,7 @@ namespace Microsoft.OpenApi.Models
             // links
             writer.WriteOptionalMap(
                 OpenApiConstants.Links,
-                Links,
+                Links!,
                 (w, key, component) =>
                 {
                     if (component.Reference != null &&
@@ -315,7 +315,7 @@ namespace Microsoft.OpenApi.Models
             // callbacks
             writer.WriteOptionalMap(
                 OpenApiConstants.Callbacks,
-                Callbacks,
+                Callbacks!,
                 (w, key, component) =>
                 {
                     if (component.Reference != null &&
@@ -331,7 +331,7 @@ namespace Microsoft.OpenApi.Models
                 });
 
             // extensions
-            writer.WriteExtensions(Extensions, version);
+            writer.WriteExtensions(Extensions!, version);
             writer.WriteEndObject();
         }
 
@@ -343,7 +343,7 @@ namespace Microsoft.OpenApi.Models
             {
                 writer.WriteOptionalMap(
                    OpenApiConstants.Schemas,
-                   Schemas,
+                   Schemas!,
                    (w, key, s) => { w.WriteJsonSchema(s, version); });
             }
             writer.WriteEndObject();

--- a/src/Microsoft.OpenApi/Models/OpenApiExternalDocs.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExternalDocs.cs
@@ -13,20 +13,22 @@ namespace Microsoft.OpenApi.Models
     /// </summary>
     public class OpenApiExternalDocs : IOpenApiSerializable, IOpenApiExtensible
     {
+        private const string DefaultUrl = "https://example.com";
+
         /// <summary>
         /// A short description of the target documentation.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// REQUIRED. The URL for the target documentation. Value MUST be in the format of a URL.
         /// </summary>
-        public Uri Url { get; set; }
+        public Uri Url { get; set; } = new Uri(DefaultUrl);
 
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
 
         /// <summary>
         /// Parameter-less constructor
@@ -39,7 +41,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiExternalDocs(OpenApiExternalDocs externalDocs)
         {
             Description = externalDocs?.Description ?? Description;
-            Url = externalDocs?.Url != null ? new Uri(externalDocs.Url.OriginalString, UriKind.RelativeOrAbsolute) : null;
+            Url = externalDocs?.Url != null ? new Uri(externalDocs.Url.OriginalString, UriKind.RelativeOrAbsolute) : new Uri(DefaultUrl);
             Extensions = externalDocs?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(externalDocs.Extensions) : null;
         }
 
@@ -74,13 +76,16 @@ namespace Microsoft.OpenApi.Models
             writer.WriteStartObject();
 
             // description
-            writer.WriteProperty(OpenApiConstants.Description, Description);
+            if (!string.IsNullOrEmpty(Description))
+            {
+                writer.WriteProperty(OpenApiConstants.Description, Description!);
+            }
 
             // url
-            writer.WriteProperty(OpenApiConstants.Url, Url?.OriginalString);
+            writer.WriteProperty(OpenApiConstants.Url, Url.OriginalString);
 
             // extensions
-            writer.WriteExtensions(Extensions, specVersion);
+            writer.WriteExtensions(Extensions!, specVersion);
 
             writer.WriteEndObject();
         }


### PR DESCRIPTION
Fixes https://github.com/microsoft/OpenAPI.NET/issues/1202

**NB**
This is still a draft PR. Early feedback is welcomed though.

This draft PR:
- Enables nullable reference types on the global `Microsoft.OpenApi` model project.

The changes expected to come in here will be massive, so it is good to have early feedback and incorporate feedback early on, instead of at the very last stage. 

In this and upcoming changes, all model properties will be made nullable except those which are REQUIRED. When writing out the  nullable properties, the compiler complains of possible null reference arguments. Since argument nullability is checked at the OpenApiWriter methods level, we shall be using the null forgiving operator (**!**) to remove the compiler warnings.