### PR TITLE
Fix OpenApiStreamReader.ReadAsync doesn't respect "leave open" setting

### DIFF
--- a/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
@@ -73,7 +73,7 @@ namespace Microsoft.OpenApi.Readers
                 bufferedStream.Position = 0;
             }
 
-            using var reader = new StreamReader(bufferedStream);
+            using var reader = new StreamReader(bufferedStream, default, true, -1, leaveOpen: _settings.LeaveStreamOpen);
             return await new OpenApiTextReaderReader(_settings).ReadAsync(reader, cancellationToken);
         }
 

--- a/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiStreamReader.cs
@@ -73,7 +73,7 @@ namespace Microsoft.OpenApi.Readers
                 bufferedStream.Position = 0;
             }
 
-            using var reader = new StreamReader(bufferedStream, default, true, -1, leaveOpen: _settings.LeaveStreamOpen);
+            using var reader = new StreamReader(bufferedStream, default, true, -1, _settings.LeaveStreamOpen);
             return await new OpenApiTextReaderReader(_settings).ReadAsync(reader, cancellationToken);
         }
 

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiStreamReaderTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiStreamReaderTests.cs
@@ -27,5 +27,21 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
             reader.Read(stream, out _);
             Assert.True(stream.CanRead);
         }
+
+        [Fact]
+        public async void StreamShouldNotBeDisposedIfLeaveStreamOpenSettingIsTrue()
+        {
+            var memoryStream = new MemoryStream();
+            using var fileStream = Resources.GetStream(Path.Combine(SampleFolderPath, "petStore.yaml"));
+
+            await fileStream.CopyToAsync(memoryStream);
+            memoryStream.Position = 0;
+            var stream = memoryStream;
+
+            var reader = new OpenApiStreamReader(new() { LeaveStreamOpen = true });
+            _ = await reader.ReadAsync(stream);
+            stream.Seek(0, SeekOrigin.Begin); // does not throw an object disposed exception
+            Assert.True(stream.CanRead);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1579