### PR TITLE
Removes `JsonSchema` reference resolution when parsing a doc.

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -447,9 +447,9 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Walks the OpenApiDocument and sets the host document for all IOpenApiReferenceable objects
         /// </summary>
-        public void ResolveHostDocument()
+        public void SetReferenceHostDocument()
         {
-            var resolver = new HostDocumentResolver(this);
+            var resolver = new ReferenceHostDocumentSetter(this);
             var walker = new OpenApiWalker(resolver);
             walker.Walk(this);
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -446,14 +446,12 @@ namespace Microsoft.OpenApi.Models
 
         /// <summary>
         /// Walks the OpenApiDocument and sets the host document for all IOpenApiReferenceable objects
-        /// and resolves JsonSchema references
         /// </summary>
-        public IEnumerable<OpenApiError> ResolveReferences()
+        public void ResolveHostDocument()
         {
-            var resolver = new ReferenceResolver(this);
+            var resolver = new HostDocumentResolver(this);
             var walker = new OpenApiWalker(resolver);
             walker.Walk(this);
-            return resolver.Errors;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
@@ -95,7 +95,7 @@ namespace Microsoft.OpenApi.Reader
                     }
                 }
 
-                ResolveReferences(diagnostic, document);
+                document.ResolveHostDocument();
             }
             catch (OpenApiException ex)
             {
@@ -198,17 +198,6 @@ namespace Microsoft.OpenApi.Reader
             var streamLoader = new DefaultStreamLoader(settings.BaseUrl);
             var workspaceLoader = new OpenApiWorkspaceLoader(openApiWorkSpace, settings.CustomExternalLoader ?? streamLoader, settings);
             return await workspaceLoader.LoadAsync(new OpenApiReference() { ExternalResource = "/" }, document, format ?? OpenApiConstants.Json, null, cancellationToken);
-        }
-
-        private void ResolveReferences(OpenApiDiagnostic diagnostic, OpenApiDocument document)
-        {
-            List<OpenApiError> errors = new();
-            errors.AddRange(document.ResolveReferences());
-
-            foreach (var item in errors)
-            {
-                diagnostic.Errors.Add(item);
-            }
         }
     }
 }

--- a/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
@@ -95,7 +95,7 @@ namespace Microsoft.OpenApi.Reader
                     }
                 }
 
-                document.ResolveHostDocument();
+                document.SetReferenceHostDocument();
             }
             catch (OpenApiException ex)
             {

--- a/src/Microsoft.OpenApi/Services/HostDocumentResolver.cs
+++ b/src/Microsoft.OpenApi/Services/HostDocumentResolver.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models;
+
+namespace Microsoft.OpenApi.Services
+{
+    /// <summary>
+    /// This class is used to walk an OpenApiDocument and sets the host document of OpenApiReferences.
+    /// </summary>
+    internal class HostDocumentResolver : OpenApiVisitorBase
+    {
+        private readonly OpenApiDocument _currentDocument;
+
+        public HostDocumentResolver(OpenApiDocument currentDocument)
+        {
+            _currentDocument = currentDocument;
+        }
+
+        /// <summary>
+        /// Visits the referenceable element in the host document
+        /// </summary>
+        /// <param name="referenceable">The referenceable element in the doc.</param>
+        public override void Visit(IOpenApiReferenceable referenceable)
+        {
+            if (referenceable.Reference != null)
+            {
+                referenceable.Reference.HostDocument = _currentDocument;
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Services/JsonSchemaReferenceResolver.cs
+++ b/src/Microsoft.OpenApi/Services/JsonSchemaReferenceResolver.cs
@@ -6,22 +6,20 @@ using System.Collections.Generic;
 using Json.Schema;
 using Microsoft.OpenApi.Exceptions;
 using System.Linq;
-using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Extensions;
 
 namespace Microsoft.OpenApi.Services
 {
     /// <summary>
-    /// This class is used to wallk an OpenApiDocument and sets the host document of OpenApiReferences
-    /// and resolves JsonSchema references.
+    /// This class is used to walk an OpenApiDocument and resolves JsonSchema references.
     /// </summary>
-    internal class ReferenceResolver : OpenApiVisitorBase
+    internal class JsonSchemaReferenceResolver : OpenApiVisitorBase
     {
         private readonly OpenApiDocument _currentDocument;
         private readonly List<OpenApiError> _errors = new();
 
-        public ReferenceResolver(OpenApiDocument currentDocument)
+        public JsonSchemaReferenceResolver(OpenApiDocument currentDocument)
         {
             _currentDocument = currentDocument;
         }
@@ -30,18 +28,6 @@ namespace Microsoft.OpenApi.Services
         /// List of errors related to the OpenApiDocument
         /// </summary>
         public IEnumerable<OpenApiError> Errors => _errors;
-
-        /// <summary>
-        /// Visits the referenceable element in the host document
-        /// </summary>
-        /// <param name="referenceable">The referenceable element in the doc.</param>
-        public override void Visit(IOpenApiReferenceable referenceable)
-        {
-            if (referenceable.Reference != null)
-            {
-                referenceable.Reference.HostDocument = _currentDocument;
-            }
-        }
 
         /// <summary>
         /// Resolves schemas in components

--- a/src/Microsoft.OpenApi/Services/ReferenceHostDocumentSetter.cs
+++ b/src/Microsoft.OpenApi/Services/ReferenceHostDocumentSetter.cs
@@ -7,13 +7,13 @@ using Microsoft.OpenApi.Models;
 namespace Microsoft.OpenApi.Services
 {
     /// <summary>
-    /// This class is used to walk an OpenApiDocument and sets the host document of OpenApiReferences.
+    /// This class is used to walk an OpenApiDocument and sets the host document of IOpenApiReferenceable objects
     /// </summary>
-    internal class HostDocumentResolver : OpenApiVisitorBase
+    internal class ReferenceHostDocumentSetter : OpenApiVisitorBase
     {
         private readonly OpenApiDocument _currentDocument;
 
-        public HostDocumentResolver(OpenApiDocument currentDocument)
+        public ReferenceHostDocumentSetter(OpenApiDocument currentDocument)
         {
             _currentDocument = currentDocument;
         }

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiDiagnosticTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiDiagnosticTests.cs
@@ -54,13 +54,11 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
             ReadResult result;
             result = await OpenApiDocument.LoadAsync("OpenApiReaderTests/Samples/OpenApiDiagnosticReportMerged/TodoMain.yaml", settings);
 
-
             Assert.NotNull(result);
             Assert.NotNull(result.OpenApiDocument.Workspace);
             result.OpenApiDiagnostic.Errors.Should().BeEquivalentTo(new List<OpenApiError>
             {
-                new OpenApiError("", "[File: ./TodoReference.yaml] Paths is a REQUIRED field at #/"),
-                new(new OpenApiException("[File: ./TodoReference.yaml] Invalid Reference identifier 'object-not-existing'."))
+                new OpenApiError("", "[File: ./TodoReference.yaml] Paths is a REQUIRED field at #/")
             });
         }
     }

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiWorkspaceTests/OpenApiWorkspaceStreamTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiWorkspaceTests/OpenApiWorkspaceStreamTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiWorkspaceTests
         }
 
         [Fact]
-        public async Task LoadDocumentWithExternalReferenceShouldLoadBothDocumentsIntoWorkspace()
+        public async Task LoadDocumentWithExternalReferenceShouldLoadExternalDocumentComponentsIntoWorkspace()
         {
             // Create a reader that will resolve all references
             var settings = new OpenApiReaderSettings
@@ -63,28 +63,16 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiWorkspaceTests
             };
 
             ReadResult result;
-            result = await OpenApiDocument.LoadAsync("V3Tests/Samples/OpenApiWorkspace/TodoMain.yaml", settings);            
+            result = await OpenApiDocument.LoadAsync("V3Tests/Samples/OpenApiWorkspace/TodoMain.yaml", settings);
 
-            Assert.NotNull(result.OpenApiDocument.Workspace);
+            var externalDocBaseUri = result.OpenApiDocument.Workspace.GetDocumentId("./TodoComponents.yaml");
+            var schemasPath = "/components/schemas/";
+            var parametersPath = "/components/parameters/";
 
-            var referencedSchema = result.OpenApiDocument
-                                    .Paths["/todos"]
-                                    .Operations[OperationType.Get]
-                                    .Responses["200"]
-                                    .Content["application/json"]
-                                    .Schema;
-
-            var x = referencedSchema.GetProperties().TryGetValue("subject", out var schema);
-            Assert.Equal(SchemaValueType.Object, referencedSchema.GetJsonType());
-            Assert.Equal(SchemaValueType.String, schema.GetJsonType());
-
-            var referencedParameter = result.OpenApiDocument
-                                        .Paths["/todos"]
-                                        .Operations[OperationType.Get]
-                                        .Parameters.Select(p => p)
-                                        .FirstOrDefault(p => p.Name == "filter");
-
-            Assert.Equal(SchemaValueType.String, referencedParameter.Schema.GetJsonType());
+            Assert.NotNull(externalDocBaseUri);
+            Assert.True(result.OpenApiDocument.Workspace.Contains(externalDocBaseUri + schemasPath + "todo"));
+            Assert.True(result.OpenApiDocument.Workspace.Contains(externalDocBaseUri + schemasPath + "entity"));
+            Assert.True(result.OpenApiDocument.Workspace.Contains(externalDocBaseUri + parametersPath + "filter"));
         }
     }
 

--- a/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/TryLoadReferenceV2Tests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/TryLoadReferenceV2Tests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
@@ -100,11 +100,6 @@ namespace Microsoft.OpenApi.Readers.Tests.ReferenceService
                         {
                             Schema = new JsonSchemaBuilder()
                             .Ref("#/definitions/SampleObject2")
-                            .Description("Sample description")
-                            .Required("name")
-                            .Properties(
-                                ("name", new JsonSchemaBuilder().Type(SchemaValueType.String)),
-                                ("tag", new JsonSchemaBuilder().Type(SchemaValueType.String)))
                             .Build()
                         }
                     }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
@@ -2,15 +2,12 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
 using Json.Schema;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
-using Microsoft.OpenApi.Writers;
-using VerifyXunit;
 using Xunit;
 
 namespace Microsoft.OpenApi.Readers.Tests.V2Tests
@@ -30,15 +27,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             var result = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "twoResponses.json"));
 
             var okSchema = new JsonSchemaBuilder()
-                    .Ref("#/definitions/Item")
-                    .Properties(("id", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("Item identifier.")));
+                    .Ref("#/definitions/Item");
 
             var errorSchema = new JsonSchemaBuilder()
-                    .Ref("#/definitions/Error")
-                    .Properties(
-                    ("code", new JsonSchemaBuilder().Type(SchemaValueType.Integer).Format("int32")),
-                    ("message", new JsonSchemaBuilder().Type(SchemaValueType.String)),
-                    ("fields", new JsonSchemaBuilder().Type(SchemaValueType.String)));
+                    .Ref("#/definitions/Error");
 
             var okMediaType = new OpenApiMediaType
             {
@@ -147,12 +139,18 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 {
                     Schemas =
                         {
-                            ["Item"] = okSchema,
-                            ["Error"] = errorSchema
+                            ["Item"] = new JsonSchemaBuilder()
+                                            .Ref("#/definitions/Item")
+                                            .Properties(("id", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("Item identifier."))),
+                            ["Error"] = new JsonSchemaBuilder()
+                                            .Ref("#/definitions/Error")
+                                            .Properties(
+                                            ("code", new JsonSchemaBuilder().Type(SchemaValueType.Integer).Format("int32")),
+                                            ("message", new JsonSchemaBuilder().Type(SchemaValueType.String)),
+                                            ("fields", new JsonSchemaBuilder().Type(SchemaValueType.String)))
                         }
                 }
             }, options => options.Excluding(x => x.Workspace).Excluding(y => y.BaseUri));
-
         }
 
         [Fact]
@@ -169,10 +167,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                     .Properties(("id", new JsonSchemaBuilder().Type(SchemaValueType.String).Description("Item identifier."))));
 
             var errorSchema = new JsonSchemaBuilder()
-                    .Ref("#/definitions/Error")
-                    .Properties(("code", new JsonSchemaBuilder().Type(SchemaValueType.Integer).Format("int32")),
-                        ("message", new JsonSchemaBuilder().Type(SchemaValueType.String)),
-                        ("fields", new JsonSchemaBuilder().Type(SchemaValueType.String)));
+                    .Ref("#/definitions/Error");
 
             var responses = result.OpenApiDocument.Paths["/items"].Operations[OperationType.Get].Responses;
             foreach (var response in responses)

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiDocumentTests.cs
@@ -44,40 +44,37 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
         public void ParseDocumentWithWebhooksShouldSucceed()
         {
             // Arrange and Act
-            var actual = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "documentWithWebhooks.yaml"));
-
-            var petSchema = new JsonSchemaBuilder()
-                        .Type(SchemaValueType.Object)
-                        .Required("id", "name")
-                        .Properties(
-                            ("id", new JsonSchemaBuilder()
-                                .Type(SchemaValueType.Integer)
-                                .Format("int64")),
-                            ("name", new JsonSchemaBuilder()
-                                .Type(SchemaValueType.String)
-                            ),
-                            ("tag", new JsonSchemaBuilder().Type(SchemaValueType.String))
-                        );
-
-            var newPetSchema = new JsonSchemaBuilder()
-                        .Type(SchemaValueType.Object)
-                        .Required("name")
-                        .Properties(
-                            ("id", new JsonSchemaBuilder()
-                                .Type(SchemaValueType.Integer)
-                                .Format("int64")),
-                            ("name", new JsonSchemaBuilder()
-                                .Type(SchemaValueType.String)
-                            ),
-                            ("tag", new JsonSchemaBuilder().Type(SchemaValueType.String))
-                        );
+            var actual = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "documentWithWebhooks.yaml"));            
+            var petSchema = new JsonSchemaBuilder().Ref("#/components/schemas/petSchema");
+            var newPetSchema = new JsonSchemaBuilder().Ref("#/components/schemas/newPetSchema");
 
             var components = new OpenApiComponents
             {
                 Schemas =
                 {
-                    ["petSchema"] = petSchema,
-                    ["newPetSchema"] = newPetSchema
+                    ["petSchema"] = new JsonSchemaBuilder()
+                            .Type(SchemaValueType.Object)
+                            .Required("id", "name")
+                            .Properties(
+                                ("id", new JsonSchemaBuilder()
+                                    .Type(SchemaValueType.Integer)
+                                    .Format("int64")),
+                                ("name", new JsonSchemaBuilder()
+                                    .Type(SchemaValueType.String)
+                                ),
+                                ("tag", new JsonSchemaBuilder().Type(SchemaValueType.String))
+                            ),
+                    ["newPetSchema"] = new JsonSchemaBuilder()
+                                .Type(SchemaValueType.Object)
+                                .Required("name")
+                                .Properties(
+                                    ("id", new JsonSchemaBuilder()
+                                        .Type(SchemaValueType.Integer)
+                                        .Format("int64")),
+                                    ("name", new JsonSchemaBuilder()
+                                        .Type(SchemaValueType.String)
+                                    ),
+                                    ("tag", new JsonSchemaBuilder().Type(SchemaValueType.String)))
                 }
             };
 
@@ -213,9 +210,11 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                 }
             };
 
+
+
             // Create a clone of the schema to avoid modifying things in components.
-            var petSchema = components.Schemas["petSchema"];
-            var newPetSchema = components.Schemas["newPetSchema"];
+            var petSchema = new JsonSchemaBuilder().Ref("#/components/schemas/petSchema");
+            var newPetSchema = new JsonSchemaBuilder().Ref("#/components/schemas/newPetSchema");
 
             components.PathItems = new Dictionary<string, OpenApiPathItem>
             {

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/JsonSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/JsonSchemaTests.cs
@@ -239,12 +239,7 @@ get:
                                 .Ref("#/components/schemas/ExtendedErrorModel")
                                 .AllOf(
                                     new JsonSchemaBuilder()
-                                        .Ref("#/components/schemas/ErrorModel")
-                                        .Type(SchemaValueType.Object)
-                                        .Properties(
-                                            ("code", new JsonSchemaBuilder().Type(SchemaValueType.Integer).Minimum(100).Maximum(600)),
-                                            ("message", new JsonSchemaBuilder().Type(SchemaValueType.String)))
-                                        .Required("message", "code"),
+                                        .Ref("#/components/schemas/ErrorModel"),
                                     new JsonSchemaBuilder()
                                         .Type(SchemaValueType.Object)
                                         .Required("rootCause")

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
 using System;
@@ -239,11 +239,11 @@ paths: {}",
                                         ("message", new JsonSchemaBuilder().Type(SchemaValueType.String)))
                 }
             };
-            var petSchema = components.Schemas["pet1"];
+            var petSchema = new JsonSchemaBuilder().Ref("#/components/schemas/pet1");
 
-            var newPetSchema = components.Schemas["newPet"];
+            var newPetSchema = new JsonSchemaBuilder().Ref("#/components/schemas/newPet");
 
-            var errorModelSchema = components.Schemas["errorModel"];
+            var errorModelSchema = new JsonSchemaBuilder().Ref("#/components/schemas/errorModel");
 
             var expectedDoc = new OpenApiDocument
             {
@@ -568,11 +568,11 @@ paths: {}",
                 }
             };
 
-            var petSchema = components.Schemas["pet1"];
+            var petSchema = new JsonSchemaBuilder().Ref("#/components/schemas/pet1");
 
-            var newPetSchema = components.Schemas["newPet"];
+            var newPetSchema = new JsonSchemaBuilder().Ref("#/components/schemas/newPet");
 
-            var errorModelSchema = components.Schemas["errorModel"];
+            var errorModelSchema = new JsonSchemaBuilder().Ref("#/components/schemas/errorModel");
 
             var tag1 = new OpenApiTag
             {
@@ -1061,11 +1061,6 @@ paths: {}",
 
             var expectedSchema = new JsonSchemaBuilder()
                 .Ref("#/components/schemas/User")
-                .Type(SchemaValueType.Object)
-                .Properties(
-                    ("id", new JsonSchemaBuilder().Type(SchemaValueType.Integer)),
-                    ("username", new JsonSchemaBuilder().Type(SchemaValueType.String)),
-                    ("email", new JsonSchemaBuilder().Type(SchemaValueType.String)))
                 .Build();
 
             // Assert

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -619,12 +619,12 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiPathItem> Webhooks { get; set; }
         public Microsoft.OpenApi.Services.OpenApiWorkspace Workspace { get; set; }
         public Json.Schema.JsonSchema FindSubschema(Json.Pointer.JsonPointer pointer, Json.Schema.EvaluationOptions options) { }
-        public void ResolveHostDocument() { }
         public Json.Schema.JsonSchema ResolveJsonSchemaReference(System.Uri referenceUri) { }
         public Microsoft.OpenApi.Interfaces.IOpenApiReferenceable ResolveReference(Microsoft.OpenApi.Models.OpenApiReference reference) { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public void SetReferenceHostDocument() { }
         public static string GenerateHashValue(Microsoft.OpenApi.Models.OpenApiDocument doc) { }
         public static Microsoft.OpenApi.Reader.ReadResult Load(string url, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null) { }
         public static Microsoft.OpenApi.Reader.ReadResult Load(System.IO.Stream stream, string format, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null) { }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -619,9 +619,9 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiPathItem> Webhooks { get; set; }
         public Microsoft.OpenApi.Services.OpenApiWorkspace Workspace { get; set; }
         public Json.Schema.JsonSchema FindSubschema(Json.Pointer.JsonPointer pointer, Json.Schema.EvaluationOptions options) { }
+        public void ResolveHostDocument() { }
         public Json.Schema.JsonSchema ResolveJsonSchemaReference(System.Uri referenceUri) { }
         public Microsoft.OpenApi.Interfaces.IOpenApiReferenceable ResolveReference(Microsoft.OpenApi.Models.OpenApiReference reference) { }
-        public System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Models.OpenApiError> ResolveReferences() { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }

--- a/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiWorkspaceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiWorkspaceTests.cs
@@ -76,41 +76,6 @@ namespace Microsoft.OpenApi.Tests
         }
 
         [Fact]
-        public void OpenApiWorkspacesAllowDocumentsToReferenceEachOther_short()
-        {
-            var doc = new OpenApiDocument();
-            var reference = "common#/components/schemas/test";
-            doc.CreatePathItem("/", p =>
-            {
-                p.Description = "Consumer";
-                p.CreateOperation(OperationType.Get, op =>
-                  op.CreateResponse("200", re =>
-                  {
-                      re.Description = "Success";
-                      re.CreateContent("application/json", co =>
-                          co.Schema = new JsonSchemaBuilder().Ref(reference).Build()                      
-                      );
-                  })
-                );
-            });
-
-            var doc2 = CreateCommonDocument();
-            doc.Workspace.RegisterComponents(doc2);
-            doc2.Workspace.RegisterComponents(doc);
-            doc.Workspace.AddDocumentId("common", doc2.BaseUri);
-            var errors = doc.ResolveReferences();
-            Assert.Empty(errors);
-        }
-                
-        // Enable Workspace to load from any reader, not just streams.
-
-        // Test fragments
-        internal void OpenApiWorkspacesShouldLoadDocumentFragments()
-        {
-            Assert.True(false);
-        }
-
-        [Fact]
         public void OpenApiWorkspacesCanResolveReferencesToDocumentFragments()
         {
             // Arrange

--- a/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiWorkspaceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiWorkspaceTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Json.Schema;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;


### PR DESCRIPTION
This PR:

- Partially closes https://github.com/microsoft/OpenAPI.NET/issues/1613
- Removes `JsonSchema` reference resolution step when parsing a doc.
- Splits `JsonSchema` reference resolution from the reference host document setting into separate classes.
- Updates some tests in line with the above changes.
- Deletes some tests that were not relevant in light of the above changes.

**NB:** By removing `JsonSchema` reference resolution, we now don't validate whether the `JsonSchema` references concrete instances are defined in the `components/schemas` section of a document (locally or externally).