### PR TITLE
Add a package parent path argument

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -230,6 +230,7 @@ extends:
                 inputs:
                   useDotNetTask: true
                   packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.Hidi.*.nupkg'
+                  packageParentPath: '$(Pipeline.Workspace)'
                   nuGetFeedType: external
                   publishFeedCredentials: 'OpenAPI Nuget Connection'
               - task: GitHubRelease@1
@@ -279,6 +280,7 @@ extends:
                 inputs:
                   useDotNetTask: true
                   packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.*.nupkg'
+                  packageParentPath: '$(Pipeline.Workspace)'
                   nuGetFeedType: external
                   publishFeedCredentials: 'OpenAPI Nuget Connection'
 
@@ -301,5 +303,6 @@ extends:
                 inputs:
                   useDotNetTask: true
                   packagesToPush: '$(Pipeline.Workspace)/Nugets/Microsoft.OpenApi.Readers.*.nupkg'
+                  packageParentPath: '$(Pipeline.Workspace)'
                   nuGetFeedType: external
                   publishFeedCredentials: 'OpenAPI Nuget Connection'

--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
     <ToolCommandName>hidi</ToolCommandName>
     <PackageOutputPath>./../../artifacts</PackageOutputPath>
-    <Version>1.4.3</Version>
+    <Version>1.4.4</Version>
     <Description>OpenAPI.NET CLI tool for slicing OpenAPI documents</Description>
     <SignAssembly>true</SignAssembly>
     <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#embeduntrackedsources -->


### PR DESCRIPTION
Fixes failing Nuget deploy step by adding a package parent path argument