### PR TITLE
Return -1 exit code when the document is not valid

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Handlers/ValidateCommandHandler.cs
+++ b/src/Microsoft.OpenApi.Hidi/Handlers/ValidateCommandHandler.cs
@@ -33,8 +33,8 @@ namespace Microsoft.OpenApi.Hidi.Handlers
             try
             {
                 if (hidiOptions.OpenApi is null) throw new InvalidOperationException("OpenApi file is required");
-                await OpenApiService.ValidateOpenApiDocument(hidiOptions.OpenApi, logger, cancellationToken).ConfigureAwait(false);
-                return 0;
+                var isValid = await OpenApiService.ValidateOpenApiDocument(hidiOptions.OpenApi, logger, cancellationToken).ConfigureAwait(false);
+                return isValid is not false ? 0 : -1;
             }
 #if RELEASE
 #pragma warning disable CA1031 // Do not catch general exception types

--- a/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
+++ b/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
@@ -203,6 +203,31 @@ namespace Microsoft.OpenApi.Hidi.Tests
             Assert.True(true);
         }
 
+        [Fact]
+        public async Task ValidFileReturnsTrue()
+        {
+            var isValid = await OpenApiService.ValidateOpenApiDocument(Path.Combine("UtilityFiles", "SampleOpenApi.yml"), _logger);
+
+            Assert.True(isValid);
+        }
+
+        [Fact]
+        public async Task InvalidFileReturnsFalse()
+        {
+            var isValid = await OpenApiService.ValidateOpenApiDocument(Path.Combine("UtilityFiles", "InvalidSampleOpenApi.yml"), _logger);
+
+            Assert.False(isValid);
+        }
+
+        [Fact]
+        public async Task CancellingValidationReturnsNull()
+        {
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+            var isValid = await OpenApiService.ValidateOpenApiDocument(Path.Combine("UtilityFiles", "SampleOpenApi.yml"), _logger, cts.Token);
+
+            Assert.Null(isValid);
+        }
 
         [Fact]
         public async Task TransformCommandConvertsOpenApi()

--- a/test/Microsoft.OpenApi.Hidi.Tests/UtilityFiles/InvalidSampleOpenApi.yml
+++ b/test/Microsoft.OpenApi.Hidi.Tests/UtilityFiles/InvalidSampleOpenApi.yml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+info:
+  title: Sample OpenApi
+  version: 1.0.0
+paths:
+  /api/editresource:
+    get:
+      operationId: api.ListEditresource
+    patch:
+      operationId: api.UpdateEditresource
+      responses:
+        '200':
+          description: OK
+  /api/viewresource:
+    get:
+      operationId: api.ListViewresource
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
The previous related PR #1145 did return an exit code, but it did not use the result of the validation. This PR fixes this behavior.

This properly fixes #900 and #1141.