### PR TITLE
Fix OpenApiFilterService.CreateFilteredDocument failing when the Components field is missing.

### DIFF
--- a/src/Microsoft.OpenApi/Services/OpenApiFilterService.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiFilterService.cs
@@ -61,6 +61,10 @@ namespace Microsoft.OpenApi.Services
         public static OpenApiDocument CreateFilteredDocument(OpenApiDocument source, Func<string, OperationType?, OpenApiOperation, bool> predicate)
         {
             // Fetch and copy title, graphVersion and server info from OpenApiDoc
+            var components = source.Components is null 
+                ? null 
+                : new OpenApiComponents() { SecuritySchemes = source.Components.SecuritySchemes };
+
             var subset = new OpenApiDocument
             {
                 Info = new()
@@ -74,7 +78,7 @@ namespace Microsoft.OpenApi.Services
                     Extensions = source.Info.Extensions
                 },
 
-                Components = new() { SecuritySchemes = source.Components.SecuritySchemes },
+                Components = components,
                 SecurityRequirements = source.SecurityRequirements,
                 Servers = source.Servers
             };

--- a/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
+++ b/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiServiceTests.cs
@@ -65,6 +65,46 @@ namespace Microsoft.OpenApi.Hidi.Tests
             Assert.Equal(expectedPathCount, subsetOpenApiDocument.Paths.Count);
         }
 
+        [Fact]
+        public void CreateFilteredDocumentOnMinimalOpenApi()
+        {
+            // Arrange
+
+            // We create a minimal OpenApiDocument with a single path and operation.
+            var openApiDoc = new OpenApiDocument
+            {
+                Info = new()
+                {
+                    Title = "Test",
+                    Version = "1.0.0"
+                },
+                Paths = new()
+                {
+                    ["/test"] = new OpenApiPathItem()
+                    {
+                        Operations = new Dictionary<OperationType, OpenApiOperation>
+                        {
+                            [OperationType.Get] = new OpenApiOperation()
+                        }
+                    }
+                }
+            };
+
+            // Act
+            var requestUrls = new Dictionary<string, List<string>>()
+            {
+                { "/test", ["GET"] }
+            };
+            var filterPredicate = OpenApiFilterService.CreatePredicate(null, null, requestUrls, openApiDoc);
+            var filteredDocument = OpenApiFilterService.CreateFilteredDocument(openApiDoc, filterPredicate);
+
+            // Assert
+            Assert.NotNull(filteredDocument);
+            Assert.NotNull(filteredDocument.Paths);
+            Assert.Single(filteredDocument.Paths);
+        }
+
+
         [Theory]
         [InlineData("UtilityFiles/appsettingstest.json")]
         [InlineData(null)]


### PR DESCRIPTION
Closes #1732.

## Summary

Before this, callingOpenApiFilterService.CreateFilteredDocument on a document that does not contain the optional field OpenApiDocument.Components produces a NullReferenceException.