### PR TITLE
Fix copy constructor for arrays and objects

### DIFF
--- a/src/Microsoft.OpenApi/Any/OpenApiAnyCloneHelper.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiAnyCloneHelper.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using System.Reflection;
-
 namespace Microsoft.OpenApi.Any
 {
     /// <summary>

--- a/src/Microsoft.OpenApi/Any/OpenApiArray.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiArray.cs
@@ -27,6 +27,10 @@ namespace Microsoft.OpenApi.Any
         public OpenApiArray(OpenApiArray array)
         {
             AnyType = array.AnyType;
+            foreach (var item in array)
+            {
+                Add(OpenApiAnyCloneHelper.CloneFromCopyConstructor(item));
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Any/OpenApiObject.cs
+++ b/src/Microsoft.OpenApi/Any/OpenApiObject.cs
@@ -27,6 +27,10 @@ namespace Microsoft.OpenApi.Any
         public OpenApiObject(OpenApiObject obj)
         {
             AnyType = obj.AnyType;
+            foreach (var key in obj.Keys)
+            {
+                this[key] = OpenApiAnyCloneHelper.CloneFromCopyConstructor(obj[key]);
+            }
         }
 
         /// <summary>

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
@@ -483,6 +481,45 @@ namespace Microsoft.OpenApi.Tests.Models
             Assert.Equal("string", actualSchema.Type);
             Assert.Equal("date", actualSchema.Format);
             Assert.True(actualSchema.Nullable);
+        }
+
+        public static TheoryData<IOpenApiAny> SchemaExamples()
+        {
+            return new()
+            {
+                new OpenApiArray() { new OpenApiString("example") },
+                new OpenApiBinary([0, 1, 2]),
+                new OpenApiBoolean(true),
+                new OpenApiByte(42),
+                new OpenApiDate(new(2024, 07, 19, 12, 34, 56)),
+                new OpenApiDateTime(new(2024, 07, 19, 12, 34, 56, new(01, 00, 00))),
+                new OpenApiDouble(42.37),
+                new OpenApiFloat(42.37f),
+                new OpenApiInteger(42),
+                new OpenApiLong(42),
+                new OpenApiNull(),
+                new OpenApiObject() { ["prop"] = new OpenApiString("example") },
+                new OpenApiPassword("secret"),
+                new OpenApiString("example"),
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(SchemaExamples))]
+        public void CloningSchemaExamplesWorks(IOpenApiAny example)
+        {
+            // Arrange
+            var schema = new OpenApiSchema
+            {
+                Example = example
+            };
+
+            // Act && Assert
+            var schemaCopy = new OpenApiSchema(schema);
+            Assert.NotNull(schemaCopy.Example);
+
+            // Act && Assert
+            Assert.Equivalent(schema.Example, schemaCopy.Example);
         }
 
         [Fact]


### PR DESCRIPTION
- Fix `OpenApiArray` and `OpenApiObject` not copying their items when they are copied to a new instance.
- Add tests for all built-in `IOpenApiAny` types with schema examples.

Found as part of https://github.com/dotnet/aspnetcore/issues/56318#issuecomment-2238704199.
