### PR TITLE
Fix securityScheme/securityRequirement serialization

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiReference.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiReference.cs
@@ -148,13 +148,6 @@ namespace Microsoft.OpenApi.Models
                 return;
             }
 
-            if (Type == ReferenceType.SecurityScheme)
-            {
-                // Write the string as property name
-                writer.WritePropertyName(ReferenceV3);
-                return;
-            }
-
             writer.WriteStartObject();
 
             // $ref

--- a/src/Microsoft.OpenApi/Models/OpenApiSecurityRequirement.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSecurityRequirement.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OpenApi.Models
                     continue;
                 }
 
-                securityScheme.SerializeAsV3(writer);
+                writer.WritePropertyName(securityScheme.Reference.ReferenceV3);
 
                 writer.WriteStartArray();
 

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSecurityRequirementTests.SerializeSecurityRequirementAsV3JsonWorksAsync_produceTerseOutput=False.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSecurityRequirementTests.SerializeSecurityRequirementAsV3JsonWorksAsync_produceTerseOutput=False.verified.txt
@@ -1,0 +1,12 @@
+﻿{
+  "scheme1": [
+    "scope1",
+    "scope2",
+    "scope3"
+  ],
+  "scheme2": [
+    "scope4",
+    "scope5"
+  ],
+  "scheme3": [ ]
+}

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSecurityRequirementTests.SerializeSecurityRequirementAsV3JsonWorksAsync_produceTerseOutput=True.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSecurityRequirementTests.SerializeSecurityRequirementAsV3JsonWorksAsync_produceTerseOutput=True.verified.txt
@@ -1,0 +1,1 @@
+﻿{"scheme1":["scope1","scope2","scope3"],"scheme2":["scope4","scope5"],"scheme3":[ ]}

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSecurityRequirementTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSecurityRequirementTests.cs
@@ -3,9 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using VerifyXunit;
 using Xunit;
 
 namespace Microsoft.OpenApi.Tests.Models
@@ -93,6 +98,23 @@ namespace Microsoft.OpenApi.Tests.Models
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
             actual.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task SerializeSecurityRequirementAsV3JsonWorksAsync(bool produceTerseOutput)
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiJsonWriter(outputStringWriter, new() { Terse = produceTerseOutput });
+
+            // Act
+            SecurityRequirementWithReferencedSecurityScheme.SerializeAsV3(writer);
+            writer.Flush();
+
+            // Assert
+            await Verifier.Verify(outputStringWriter).UseParameters(produceTerseOutput);
         }
 
         [Fact]

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSecuritySchemeTests.SerializeReferencedSecuritySchemeAsV3JsonWorksAsync_produceTerseOutput=False.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSecuritySchemeTests.SerializeReferencedSecuritySchemeAsV3JsonWorksAsync_produceTerseOutput=False.verified.txt
@@ -1,3 +1,3 @@
 {
-  "sampleSecurityScheme": null
+  "$ref": "sampleSecurityScheme"
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSecuritySchemeTests.SerializeReferencedSecuritySchemeAsV3JsonWorksAsync_produceTerseOutput=True.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSecuritySchemeTests.SerializeReferencedSecuritySchemeAsV3JsonWorksAsync_produceTerseOutput=True.verified.txt
@@ -1,1 +1,1 @@
-{"sampleSecurityScheme":null}
+{"$ref":"sampleSecurityScheme"}

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSecuritySchemeTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSecuritySchemeTests.cs
@@ -314,12 +314,7 @@ namespace Microsoft.OpenApi.Tests.Models
             var writer = new OpenApiJsonWriter(outputStringWriter, new() { Terse = produceTerseOutput });
 
             // Act
-            // Add dummy start object, value, and end object to allow SerializeAsV3 to output security scheme
-            // as property name.
-            writer.WriteStartObject();
             ReferencedSecurityScheme.SerializeAsV3(writer);
-            writer.WriteNull();
-            writer.WriteEndObject();
             writer.Flush();
 
             // Assert


### PR DESCRIPTION
Fixes the invalid serialization of the securityScheme reference from issue #1506 

The security requirement should not use the full serialization of a securityScheme as those are not the same. The securityRequirement only needs the reference to the securityScheme, not the complete object.