### PR TITLE
Disable VisualStudio.Threading analyzers to eliminate build failures downstream

### DIFF
--- a/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+++ b/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>1.6.19</Version>
+        <Version>1.6.20</Version>
         <Description>OpenAPI.NET Readers for JSON and YAML documents</Description>
         <SignAssembly>true</SignAssembly>
         <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#embeduntrackedsources -->
@@ -21,6 +21,13 @@
         <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.11.20" />
         <PackageReference Include="SharpYaml" Version="2.1.1" />
     </ItemGroup>
+
+    <!-- Workaround to disable Microsoft.VisualStudio.Threading.Analyzers -->
+    <Target Name="DisableVSAnalyzers" BeforeTargets="CoreCompile" Condition=" '$(RunStaticAnalysis)' == '' OR '$(RunStaticAnalysis)' == 'false' ">
+        <ItemGroup>
+            <Analyzer Remove="@(Analyzer)" Condition=" '%(Filename)' == 'Microsoft.VisualStudio.Threading.Analyzers' OR '%(Filename)' == 'Microsoft.VisualStudio.Threading.Analyzers.CSharp' " />
+        </ItemGroup>
+    </Target>
 
     <ItemGroup>
         <ProjectReference Include="..\Microsoft.OpenApi\Microsoft.OpenApi.csproj" />

--- a/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+++ b/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
@@ -18,16 +18,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.11.20" />
+        <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.11.20">
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+
         <PackageReference Include="SharpYaml" Version="2.1.1" />
     </ItemGroup>
-
-    <!-- Workaround to disable Microsoft.VisualStudio.Threading.Analyzers -->
-    <Target Name="DisableVSAnalyzers" BeforeTargets="CoreCompile" Condition=" '$(RunStaticAnalysis)' == '' OR '$(RunStaticAnalysis)' == 'false' ">
-        <ItemGroup>
-            <Analyzer Remove="@(Analyzer)" Condition=" '%(Filename)' == 'Microsoft.VisualStudio.Threading.Analyzers' OR '%(Filename)' == 'Microsoft.VisualStudio.Threading.Analyzers.CSharp' " />
-        </ItemGroup>
-    </Target>
 
     <ItemGroup>
         <ProjectReference Include="..\Microsoft.OpenApi\Microsoft.OpenApi.csproj" />

--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>Latest</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>1.6.19</Version>
+        <Version>1.6.20</Version>
         <Description>.NET models with JSON and YAML writers for OpenAPI specification</Description>
         <SignAssembly>true</SignAssembly>
         <!-- https://github.com/dotnet/sourcelink/blob/main/docs/README.md#embeduntrackedsources -->
@@ -39,4 +39,11 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.11.20" />
     </ItemGroup>
+
+    <!-- Workaround to disable Microsoft.VisualStudio.Threading.Analyzers -->
+    <Target Name="DisableVSAnalyzers" BeforeTargets="CoreCompile" Condition=" '$(RunStaticAnalysis)' == '' OR '$(RunStaticAnalysis)' == 'false' ">
+        <ItemGroup>
+            <Analyzer Remove="@(Analyzer)" Condition=" '%(Filename)' == 'Microsoft.VisualStudio.Threading.Analyzers' OR '%(Filename)' == 'Microsoft.VisualStudio.Threading.Analyzers.CSharp' " />
+        </ItemGroup>
+    </Target>
 </Project>

--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -37,13 +37,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.11.20" />
+      <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.11.20" >
+          <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
     </ItemGroup>
-
-    <!-- Workaround to disable Microsoft.VisualStudio.Threading.Analyzers -->
-    <Target Name="DisableVSAnalyzers" BeforeTargets="CoreCompile" Condition=" '$(RunStaticAnalysis)' == '' OR '$(RunStaticAnalysis)' == 'false' ">
-        <ItemGroup>
-            <Analyzer Remove="@(Analyzer)" Condition=" '%(Filename)' == 'Microsoft.VisualStudio.Threading.Analyzers' OR '%(Filename)' == 'Microsoft.VisualStudio.Threading.Analyzers.CSharp' " />
-        </ItemGroup>
-    </Target>
 </Project>


### PR DESCRIPTION
Fixes #1810