### PR TITLE
Set workspace baseUrl when creating a workspace 

### DIFF
--- a/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
@@ -192,7 +192,9 @@ namespace Microsoft.OpenApi.Reader
         private async Task<OpenApiDiagnostic> LoadExternalRefs(OpenApiDocument document, CancellationToken cancellationToken, OpenApiReaderSettings settings, string format = null)
         {
             // Create workspace for all documents to live in.
-            var openApiWorkSpace = new OpenApiWorkspace();
+            var baseUrl = settings.BaseUrl ?? new Uri(OpenApiConstants.BaseRegistryUri);
+
+            var openApiWorkSpace = new OpenApiWorkspace(baseUrl);
 
             // Load this root document into the workspace
             var streamLoader = new DefaultStreamLoader(settings.BaseUrl);

--- a/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
@@ -193,7 +193,6 @@ namespace Microsoft.OpenApi.Reader
         {
             // Create workspace for all documents to live in.
             var baseUrl = settings.BaseUrl ?? new Uri(OpenApiConstants.BaseRegistryUri);
-
             var openApiWorkSpace = new OpenApiWorkspace(baseUrl);
 
             // Load this root document into the workspace

--- a/src/Microsoft.OpenApi/Reader/Services/DefaultStreamLoader.cs
+++ b/src/Microsoft.OpenApi/Reader/Services/DefaultStreamLoader.cs
@@ -56,7 +56,16 @@ namespace Microsoft.OpenApi.Reader.Services
         /// <exception cref="ArgumentException"></exception>
         public async Task<Stream> LoadAsync(Uri uri)
         {
-            var absoluteUri = new Uri(baseUrl, uri);
+            Uri absoluteUri;
+            if (baseUrl.Equals(OpenApiConstants.BaseRegistryUri))
+            {
+                // use current working directory
+                absoluteUri = new Uri(Directory.GetCurrentDirectory() + uri);
+            }
+            else
+            {
+                absoluteUri = new Uri(baseUrl, uri);
+            }
 
             switch (absoluteUri.Scheme)
             {

--- a/src/Microsoft.OpenApi/Reader/Services/DefaultStreamLoader.cs
+++ b/src/Microsoft.OpenApi/Reader/Services/DefaultStreamLoader.cs
@@ -57,15 +57,8 @@ namespace Microsoft.OpenApi.Reader.Services
         public async Task<Stream> LoadAsync(Uri uri)
         {
             Uri absoluteUri;
-            if (baseUrl.Equals(OpenApiConstants.BaseRegistryUri))
-            {
-                // use current working directory
-                absoluteUri = new Uri(Directory.GetCurrentDirectory() + uri);
-            }
-            else
-            {
-                absoluteUri = new Uri(baseUrl, uri);
-            }
+            absoluteUri = baseUrl.AbsoluteUri.Equals(OpenApiConstants.BaseRegistryUri) ? new Uri(Directory.GetCurrentDirectory() + uri) 
+                : new Uri(baseUrl, uri);
 
             switch (absoluteUri.Scheme)
             {


### PR DESCRIPTION
- Sets the workspace baseUrl when creating a workspace using the BaseUrl passed in settings. If not default to `OpenApiConstants.BaseRegistryUrl`
- Use current working directory to resolve file paths if baseUrl matches the default BaseRegistryUrl

Fixes:
- #1838
- #1839