### PR TITLE
Avoid buffering JSON data into a new MemoryStream during parsing

### DIFF
--- a/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
@@ -100,7 +100,7 @@ namespace Microsoft.OpenApi.Reader
 
             Stream preparedStream;
 
-            // Avoid buffering for JSON format
+            // Avoid buffering for JSON documents
             if (input is MemoryStream || format.Equals(OpenApiConstants.Json, StringComparison.OrdinalIgnoreCase))
             {
                 preparedStream = input;


### PR DESCRIPTION
JSON data can be read asynchronously, which means that when you receive a stream of JSON data (e.g., from a file, network, or database), you can process the data directly without needing to load it all into memory first.
This increases efficiency by reducing memory usage and allowing the program to respond faster, especially in cases with large or streaming data.

In contrast, YAML does not support asynchronous reading in most libraries, requiring the data to be fully buffered before processing it synchronously.

Fixes #1853