### PR TITLE
Fix: loading the document requires knowing the format in advance

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ var httpClient = new HttpClient
 var stream = await httpClient.GetStreamAsync("master/examples/v3.0/petstore.yaml");
 
 // Read V3 as YAML
-var openApiDocument = new OpenApiStreamReader().Read(stream, out var diagnostic);
+var openApiDocument = OpenApiDocument.LoadAsync(stream).OpenApiDocument;
 
 // Write V2 as JSON
 var outputString = openApiDocument.Serialize(OpenApiSpecVersion.OpenApi2_0, OpenApiFormat.Json);

--- a/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
+++ b/src/Microsoft.OpenApi.Hidi/OpenApiService.cs
@@ -97,7 +97,7 @@ namespace Microsoft.OpenApi.Hidi
                 }
 
                 // Load OpenAPI document
-                var format = await OpenApiModelFactory.GetFormatAsync(options.OpenApi).ConfigureAwait(false);
+                var format = await OpenApiModelFactory.GetFormatAsync(options.OpenApi, cancellationToken).ConfigureAwait(false);
                 var document = await GetOpenApiAsync(options, format, logger, options.MetadataVersion, cancellationToken).ConfigureAwait(false);
 
                 if (options.FilterOptions != null)
@@ -586,7 +586,7 @@ namespace Microsoft.OpenApi.Hidi
                     throw new ArgumentException("Please input a file path or URL");
                 }
 
-                var format = await OpenApiModelFactory.GetFormatAsync(options.OpenApi).ConfigureAwait(false);
+                var format = await OpenApiModelFactory.GetFormatAsync(options.OpenApi, cancellationToken).ConfigureAwait(false);
                 var document = await GetOpenApiAsync(options, format, logger, null, cancellationToken).ConfigureAwait(false);
 
                 using (logger.BeginScope("Creating diagram"))
@@ -748,7 +748,7 @@ namespace Microsoft.OpenApi.Hidi
             }
 
             // Load OpenAPI document
-            var format = await OpenApiModelFactory.GetFormatAsync(options.OpenApi).ConfigureAwait(false);
+            var format = await OpenApiModelFactory.GetFormatAsync(options.OpenApi, cancellationToken).ConfigureAwait(false);
             var document = await GetOpenApiAsync(options, format, logger, options.MetadataVersion, cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();   

--- a/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
@@ -46,10 +46,9 @@ namespace Microsoft.OpenApi.Readers
         }
 
         /// <inheritdoc/>
-        public T ReadFragment<T>(TextReader input,
-                                 OpenApiSpecVersion version,
-                                 out OpenApiDiagnostic diagnostic,
-                                 OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public async Task<ReadFragmentResult> ReadFragmentAsync<T>(TextReader input,
+                                                                   OpenApiSpecVersion version,
+                                                                   OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
             JsonNode jsonNode;
 
@@ -60,12 +59,12 @@ namespace Microsoft.OpenApi.Readers
             }
             catch (JsonException ex)
             {
-                diagnostic = new();
+                var diagnostic = new OpenApiDiagnostic();
                 diagnostic.Errors.Add(new($"#line={ex.LineNumber}", ex.Message));
                 return default;
             }
 
-            return ReadFragment<T>(jsonNode, version, out diagnostic);
+            return await ReadFragmentAsync<T>(jsonNode, version, settings);
         }
 
         /// <summary>
@@ -88,9 +87,9 @@ namespace Microsoft.OpenApi.Readers
         }
 
         /// <inheritdoc/>
-        public T ReadFragment<T>(JsonNode input, OpenApiSpecVersion version, out OpenApiDiagnostic diagnostic, OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public async Task<ReadFragmentResult> ReadFragmentAsync<T>(JsonNode input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
-            return OpenApiReaderRegistry.DefaultReader.ReadFragment<T>(input, version, out diagnostic);
+            return await OpenApiReaderRegistry.DefaultReader.ReadFragmentAsync<T>(input, version, settings);
         }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.IO;
@@ -47,7 +47,7 @@ namespace Microsoft.OpenApi.Readers
         /// <inheritdoc/>
         public async Task<ReadFragmentResult<T>> ReadFragmentAsync<T>(TextReader input,
                                                                       OpenApiSpecVersion version,
-                                                                      OpenApiReaderSettings settings = null) where T : IOpenApiElement
+                                                                      OpenApiReaderSettings settings = null,
                                                                       CancellationToken token = default) where T : IOpenApiElement
         {
             JsonNode jsonNode;
@@ -55,7 +55,7 @@ namespace Microsoft.OpenApi.Readers
             // Parse the YAML
             try
             {
-                jsonNode = LoadJsonNodesFromYamlDocument(input);
+                jsonNode = await Task.Run(() => LoadJsonNodesFromYamlDocument(input));
             }
             catch (JsonException ex)
             {

--- a/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.IO;
@@ -63,7 +63,7 @@ namespace Microsoft.OpenApi.Readers
                 return default;
             }
 
-            return await ReadFragmentAsync<T>(jsonNode, version, settings);
+            return ReadFragment<T>(jsonNode, version, settings);
         }
 
         /// <summary>
@@ -86,9 +86,9 @@ namespace Microsoft.OpenApi.Readers
         }
 
         /// <inheritdoc/>
-        public async Task<ReadFragmentResult<T>> ReadFragmentAsync<T>(JsonNode input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public ReadFragmentResult<T> ReadFragment<T>(JsonNode input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
-            return await OpenApiReaderRegistry.DefaultReader.ReadFragmentAsync<T>(input, version, settings);
+            return OpenApiReaderRegistry.DefaultReader.ReadFragment<T>(input, version, settings);
         }
     }
 }

--- a/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
@@ -10,7 +10,6 @@ using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Reader;
 using SharpYaml.Serialization;
 using System.Linq;
-using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Readers
 {
@@ -46,9 +45,9 @@ namespace Microsoft.OpenApi.Readers
         }
 
         /// <inheritdoc/>
-        public async Task<ReadFragmentResult> ReadFragmentAsync<T>(TextReader input,
-                                                                   OpenApiSpecVersion version,
-                                                                   OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public async Task<ReadFragmentResult<T>> ReadFragmentAsync<T>(TextReader input,
+                                                                      OpenApiSpecVersion version,
+                                                                      OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
             JsonNode jsonNode;
 
@@ -81,13 +80,13 @@ namespace Microsoft.OpenApi.Readers
         }
 
         /// <inheritdoc/>        
-        public async Task<ReadResult> ReadAsync(JsonNode jsonNode, OpenApiReaderSettings settings, string format = null, CancellationToken cancellationToken = default)
+        public async Task<ReadResult> ReadAsync(JsonNode jsonNode, OpenApiReaderSettings settings, CancellationToken cancellationToken = default)
         {
-            return await OpenApiReaderRegistry.DefaultReader.ReadAsync(jsonNode, settings, OpenApiConstants.Yaml, cancellationToken);
+            return await OpenApiReaderRegistry.DefaultReader.ReadAsync(jsonNode, settings, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task<ReadFragmentResult> ReadFragmentAsync<T>(JsonNode input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public async Task<ReadFragmentResult<T>> ReadFragmentAsync<T>(JsonNode input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
             return await OpenApiReaderRegistry.DefaultReader.ReadFragmentAsync<T>(input, version, settings);
         }

--- a/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
@@ -48,6 +48,7 @@ namespace Microsoft.OpenApi.Readers
         public async Task<ReadFragmentResult<T>> ReadFragmentAsync<T>(TextReader input,
                                                                       OpenApiSpecVersion version,
                                                                       OpenApiReaderSettings settings = null) where T : IOpenApiElement
+                                                                      CancellationToken token = default) where T : IOpenApiElement
         {
             JsonNode jsonNode;
 

--- a/src/Microsoft.OpenApi.Workbench/MainModel.cs
+++ b/src/Microsoft.OpenApi.Workbench/MainModel.cs
@@ -257,8 +257,7 @@ namespace Microsoft.OpenApi.Workbench
                     }
                 }
 
-                var format = OpenApiModelFactory.GetFormat(_inputFile);
-                var readResult = await OpenApiDocument.LoadAsync(stream, format);
+                var readResult = await OpenApiDocument.LoadAsync(stream);
                 var document = readResult.OpenApiDocument;
                 var context = readResult.OpenApiDiagnostic;
 

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiReader.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
 using System.IO;
@@ -38,8 +38,9 @@ namespace Microsoft.OpenApi.Interfaces
         /// <param name="input">TextReader containing OpenAPI description to parse.</param>
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
         /// <param name="settings">The OpenApiReader settings.</param>
+        /// <param name="token"></param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
-        Task<ReadFragmentResult<T>> ReadFragmentAsync<T>(TextReader input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T: IOpenApiElement;
+        Task<ReadFragmentResult<T>> ReadFragmentAsync<T>(TextReader input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null, CancellationToken token = default) where T : IOpenApiElement;
 
         /// <summary>
         /// Reads the JsonNode input and parses the fragment of an OpenAPI description into an Open API Element.

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiReader.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiReader.cs
@@ -29,9 +29,8 @@ namespace Microsoft.OpenApi.Interfaces
         /// <param name="jsonNode">The JsonNode input.</param>
         /// <param name="settings">The Reader settings to be used during parsing.</param>
         /// <param name="cancellationToken">Propagates notifications that operations should be cancelled.</param>
-        /// <param name="format">The OpenAPI format.</param>
         /// <returns></returns>
-        Task<ReadResult> ReadAsync(JsonNode jsonNode, OpenApiReaderSettings settings, string format = null, CancellationToken cancellationToken = default);
+        Task<ReadResult> ReadAsync(JsonNode jsonNode, OpenApiReaderSettings settings, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Reads the TextReader input and parses the fragment of an OpenAPI description into an Open API Element.
@@ -40,7 +39,7 @@ namespace Microsoft.OpenApi.Interfaces
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
         /// <param name="settings">The OpenApiReader settings.</param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
-        Task<ReadFragmentResult> ReadFragmentAsync<T>(TextReader input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T: IOpenApiElement;
+        Task<ReadFragmentResult<T>> ReadFragmentAsync<T>(TextReader input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T: IOpenApiElement;
 
         /// <summary>
         /// Reads the JsonNode input and parses the fragment of an OpenAPI description into an Open API Element.
@@ -49,6 +48,6 @@ namespace Microsoft.OpenApi.Interfaces
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
         /// <param name="settings">The OpenApiReader settings.</param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
-        Task<ReadFragmentResult> ReadFragmentAsync<T>(JsonNode input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T: IOpenApiElement;
+        Task<ReadFragmentResult<T>> ReadFragmentAsync<T>(JsonNode input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T: IOpenApiElement;
     }
 }

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiReader.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiReader.cs
@@ -38,19 +38,17 @@ namespace Microsoft.OpenApi.Interfaces
         /// </summary>
         /// <param name="input">TextReader containing OpenAPI description to parse.</param>
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
-        /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing.</param>
         /// <param name="settings">The OpenApiReader settings.</param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
-        T ReadFragment<T>(TextReader input, OpenApiSpecVersion version, out OpenApiDiagnostic diagnostic, OpenApiReaderSettings settings = null) where T : IOpenApiElement;
+        Task<ReadFragmentResult> ReadFragmentAsync<T>(TextReader input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T: IOpenApiElement;
 
         /// <summary>
         /// Reads the JsonNode input and parses the fragment of an OpenAPI description into an Open API Element.
         /// </summary>
         /// <param name="input">TextReader containing OpenAPI description to parse.</param>
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
-        /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing.</param>
         /// <param name="settings">The OpenApiReader settings.</param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
-        T ReadFragment<T>(JsonNode input, OpenApiSpecVersion version, out OpenApiDiagnostic diagnostic, OpenApiReaderSettings settings = null) where T : IOpenApiElement;
+        Task<ReadFragmentResult> ReadFragmentAsync<T>(JsonNode input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T: IOpenApiElement;
     }
 }

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiReader.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
 using System.IO;
@@ -48,6 +48,6 @@ namespace Microsoft.OpenApi.Interfaces
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
         /// <param name="settings">The OpenApiReader settings.</param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
-        Task<ReadFragmentResult<T>> ReadFragmentAsync<T>(JsonNode input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T: IOpenApiElement;
+        ReadFragmentResult<T> ReadFragment<T>(JsonNode input, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T: IOpenApiElement;
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -539,45 +539,6 @@ namespace Microsoft.OpenApi.Models
         /// Parses a local file path or Url into an Open API document.
         /// </summary>
         /// <param name="url"> The path to the OpenAPI file.</param>
-        /// <param name="settings"></param>
-        /// <returns></returns>
-        public static ReadResult Load(string url, OpenApiReaderSettings? settings = null)
-        {
-            return OpenApiModelFactory.Load(url, settings);
-        }
-
-        /// <summary>
-        /// Reads the stream input and parses it into an Open API document.
-        /// </summary>
-        /// <param name="stream">Stream containing OpenAPI description to parse.</param>
-        /// <param name="format">The OpenAPI format to use during parsing.</param>
-        /// <param name="settings">The OpenApi reader settings.</param>
-        /// <returns></returns>
-        public static ReadResult Load(Stream stream,
-                                      string format,
-                                      OpenApiReaderSettings? settings = null)
-        {
-            return OpenApiModelFactory.Load(stream, format, settings);
-        }
-
-        /// <summary>
-        /// Reads the text reader content and parses it into an Open API document.
-        /// </summary>
-        /// <param name="input">TextReader containing OpenAPI description to parse.</param>
-        /// <param name="format"> The OpenAPI format to use during parsing.</param>
-        /// <param name="settings">The OpenApi reader settings.</param>
-        /// <returns></returns>
-        public static ReadResult Load(TextReader input,
-                                           string format,
-                                           OpenApiReaderSettings? settings = null)
-        {
-            return OpenApiModelFactory.Load(input, format, settings);
-        }
-
-        /// <summary>
-        /// Parses a local file path or Url into an Open API document.
-        /// </summary>
-        /// <param name="url"> The path to the OpenAPI file.</param>
         /// <param name="settings">The OpenApi reader settings.</param>
         /// <returns></returns>
         public static async Task<ReadResult> LoadAsync(string url, OpenApiReaderSettings? settings = null)
@@ -589,39 +550,35 @@ namespace Microsoft.OpenApi.Models
         /// Reads the stream input and parses it into an Open API document.
         /// </summary>
         /// <param name="stream">Stream containing OpenAPI description to parse.</param>
-        /// <param name="format">The OpenAPI format to use during parsing.</param>
         /// <param name="settings">The OpenApi reader settings.</param>
         /// <param name="cancellationToken">Propagates information about operation cancelling.</param>
         /// <returns></returns>
-        public static async Task<ReadResult> LoadAsync(Stream stream, string format, OpenApiReaderSettings? settings = null, CancellationToken cancellationToken = default)
+        public static async Task<ReadResult> LoadAsync(Stream stream, OpenApiReaderSettings? settings = null, CancellationToken cancellationToken = default)
         {
-            return await OpenApiModelFactory.LoadAsync(stream, format, settings, cancellationToken);
+            return await OpenApiModelFactory.LoadAsync(stream, settings: settings, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Reads the text reader content and parses it into an Open API document.
         /// </summary>
         /// <param name="input">TextReader containing OpenAPI description to parse.</param>
-        /// <param name="format"> The OpenAPI format to use during parsing.</param>
         /// <param name="settings">The OpenApi reader settings.</param>
         /// <returns></returns>
-        public static async Task<ReadResult> LoadAsync(TextReader input, string format, OpenApiReaderSettings? settings = null)
+        public static async Task<ReadResult> LoadAsync(TextReader input, OpenApiReaderSettings? settings = null)
         {
-            return await OpenApiModelFactory.LoadAsync(input, format, settings);
+            return await OpenApiModelFactory.LoadAsync(input, settings: settings);
         }
 
         /// <summary>
         /// Parses a string into a <see cref="OpenApiDocument"/> object.
         /// </summary>
         /// <param name="input"> The string input.</param>
-        /// <param name="format"></param>
         /// <param name="settings"></param>
         /// <returns></returns>
-        public static ReadResult Parse(string input,
-                                       string? format = null,
-                                       OpenApiReaderSettings? settings = null)
+        public static async Task<ReadResult> ParseAsync(string input,
+                                                        OpenApiReaderSettings? settings = null)
         {
-            return OpenApiModelFactory.Parse(input, format, settings);
+            return await OpenApiModelFactory.ParseAsync(input, settings);
         }
     }
 

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -540,10 +540,11 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         /// <param name="url"> The path to the OpenAPI file.</param>
         /// <param name="settings">The OpenApi reader settings.</param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task<ReadResult> LoadAsync(string url, OpenApiReaderSettings? settings = null)
+        public static async Task<ReadResult> LoadAsync(string url, OpenApiReaderSettings? settings = null, CancellationToken cancellationToken = default)
         {
-            return await OpenApiModelFactory.LoadAsync(url, settings);
+            return await OpenApiModelFactory.LoadAsync(url, settings, cancellationToken);
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.IO;
@@ -139,13 +139,13 @@ namespace Microsoft.OpenApi.Reader
                 return default;
             }
 
-            return await ReadFragmentAsync<T>(jsonNode, version, settings);
+            return ReadFragment<T>(jsonNode, version, settings);
         }
 
         /// <inheritdoc/>
-        public async Task<ReadFragmentResult<T>> ReadFragmentAsync<T>(JsonNode input,
-                                                                   OpenApiSpecVersion version,
-                                                                   OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public ReadFragmentResult<T> ReadFragment<T>(JsonNode input,
+                                                     OpenApiSpecVersion version,
+                                                     OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
             var diagnostic = new OpenApiDiagnostic();
             settings ??= new OpenApiReaderSettings();

--- a/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.IO;
@@ -41,7 +41,7 @@ namespace Microsoft.OpenApi.Reader
             // Parse the JSON text in the TextReader into JsonNodes
             try
             {
-                jsonNode = await LoadJsonNodesAsync(input);
+                jsonNode = await LoadJsonNodesAsync(input, cancellationToken);
             }
             catch (JsonException ex)
             {
@@ -123,14 +123,15 @@ namespace Microsoft.OpenApi.Reader
         /// <inheritdoc/>
         public async Task<ReadFragmentResult<T>> ReadFragmentAsync<T>(TextReader input,
                                                                       OpenApiSpecVersion version,
-                                                                      OpenApiReaderSettings settings = null) where T: IOpenApiElement
+                                                                      OpenApiReaderSettings settings = null,
+                                                                      CancellationToken token = default) where T: IOpenApiElement
         {
             JsonNode jsonNode;
 
             // Parse the JSON
             try
             {
-                jsonNode = await LoadJsonNodesAsync(input);
+                jsonNode = await LoadJsonNodesAsync(input, token);
             }
             catch (JsonException ex)
             {
@@ -182,9 +183,13 @@ namespace Microsoft.OpenApi.Reader
             };
         }
 
-        private async Task<JsonNode> LoadJsonNodesAsync(TextReader input)
+        private async Task<JsonNode> LoadJsonNodesAsync(TextReader input, CancellationToken token = default)
         {
+#if NETSTANDARD2_0
             var content = await input.ReadToEndAsync();
+#else
+    var content = await input.ReadToEndAsync(token);
+#endif            
             return JsonNode.Parse(content);
         }
 

--- a/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
@@ -158,7 +158,7 @@ namespace Microsoft.OpenApi.Reader
             try
             {
                 // Parse the OpenAPI element asynchronously
-                element = await Task.Run(() => context.ParseFragment<T>(input, version));
+                element = context.ParseFragment<T>(input, version);
             }
             catch (OpenApiException ex)
             {

--- a/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
@@ -315,7 +315,7 @@ namespace Microsoft.OpenApi.Reader
 
         private static string InspectInputFormat(string input)
         {
-            return input.StartsWith("{") || input.StartsWith("[") ? OpenApiConstants.Json : OpenApiConstants.Yaml;
+            return input.StartsWith("{", StringComparison.OrdinalIgnoreCase) || input.StartsWith("[", StringComparison.OrdinalIgnoreCase) ? OpenApiConstants.Json : OpenApiConstants.Yaml;
         }
 
         private static async Task<Stream> GetStreamAsync(string url)

--- a/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
@@ -92,7 +92,7 @@ namespace Microsoft.OpenApi.Reader
         public static async Task<ReadResult> ParseAsync(string input,
                                                         OpenApiReaderSettings settings = null)
         {
-            var format = input.StartsWith("{") || input.StartsWith("[") ? OpenApiConstants.Json : OpenApiConstants.Yaml;
+            var format = InspectInputFormat(input);
             settings ??= new OpenApiReaderSettings();
             using var reader = new StringReader(input);
             return await LoadAsync(reader, format, settings);
@@ -109,7 +109,7 @@ namespace Microsoft.OpenApi.Reader
                                                                       OpenApiSpecVersion version,
                                                                       OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
-            var format = input.StartsWith("{") || input.StartsWith("[") ? OpenApiConstants.Json : OpenApiConstants.Yaml;
+            var format = InspectInputFormat(input);
             settings ??= new OpenApiReaderSettings();
             using var reader = new StringReader(input);
             return await LoadAsync<T>(reader, version, format, settings);
@@ -305,6 +305,11 @@ namespace Microsoft.OpenApi.Reader
         {
             // Read the first line or a few characters from the input
             var input = reader.ReadLine().Trim();
+            return InspectInputFormat(input);
+        }
+
+        private static string InspectInputFormat(string input)
+        {
             return input.StartsWith("{") || input.StartsWith("[") ? OpenApiConstants.Json : OpenApiConstants.Yaml;
         }
 

--- a/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 
@@ -28,67 +29,12 @@ namespace Microsoft.OpenApi.Reader
         /// <summary>
         /// Loads the input URL and parses it into an Open API document.
         /// </summary>
-        /// <param name="url">The path to the OpenAPI file.</param>
-        /// <param name="settings"> The OpenApi reader settings.</param>
-        /// <returns>An OpenAPI document instance.</returns>
-        public static ReadResult Load(string url, OpenApiReaderSettings settings = null)
-        {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            return LoadAsync(url, settings).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-        }
-
-        /// <summary>
-        /// Loads the input stream and parses it into an Open API document.
-        /// </summary>
-        /// <param name="stream"> The input stream.</param>
-        /// <param name="settings"> The OpenApi reader settings.</param>
-        /// <param name="format">The OpenAPI format.</param>
-        /// <returns>An OpenAPI document instance.</returns>
-        public static ReadResult Load(Stream stream,
-                                      string format,
-                                      OpenApiReaderSettings settings = null)
-        {
-            settings ??= new OpenApiReaderSettings();
-
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            var result = LoadAsync(stream, format, settings).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-
-            if (!settings.LeaveStreamOpen)
-            {
-                stream.Dispose();
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Loads the TextReader input and parses it into an Open API document.
-        /// </summary>
-        /// <param name="input">The TextReader input.</param>
-        /// <param name="settings"> The OpenApi reader settings.</param>
-        /// <param name="format">The Open API format</param>
-        /// <returns>An OpenAPI document instance.</returns>
-        public static ReadResult Load(TextReader input,
-                                      string format,
-                                      OpenApiReaderSettings settings = null)
-        {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            var result = LoadAsync(input, format, settings).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-            return result;
-        }
-
-        /// <summary>
-        /// Loads the input URL and parses it into an Open API document.
-        /// </summary>
         /// <param name="url">The path to the OpenAPI file</param>
         /// <param name="settings"> The OpenApi reader settings.</param>
         /// <returns></returns>
         public static async Task<ReadResult> LoadAsync(string url, OpenApiReaderSettings settings = null)
         {
-            var format = GetFormat(url);
+            var format = await GetFormatAsync(url);
             var stream = await GetStreamAsync(url);
             return await LoadAsync(stream, format, settings);
         }
@@ -123,7 +69,13 @@ namespace Microsoft.OpenApi.Reader
 
             // Use StreamReader to process the prepared stream (buffered for YAML, direct for JSON)
             using var reader = new StreamReader(preparedStream, default, true, -1, settings.LeaveStreamOpen);
-            return await LoadAsync(reader, format, settings, cancellationToken);
+            var result = await LoadAsync(reader, format, settings, cancellationToken);
+
+            if (!settings.LeaveStreamOpen)
+            {
+                input.Dispose();
+            }
+            return result;
         }
 
 
@@ -135,7 +87,7 @@ namespace Microsoft.OpenApi.Reader
         /// <param name="settings"> The OpenApi reader settings.</param>
         /// <param name="cancellationToken">Propagates notification that operations should be cancelled.</param>
         /// <returns></returns>
-        public static async Task<ReadResult> LoadAsync(TextReader input, string format, OpenApiReaderSettings settings = null, CancellationToken cancellationToken = default)
+        public static async Task<ReadResult> LoadAsync(TextReader input, string format = null, OpenApiReaderSettings settings = null, CancellationToken cancellationToken = default)
         {
             format ??= InspectTextReaderFormat(input);
             var reader = OpenApiReaderRegistry.GetReader(format);
@@ -145,35 +97,11 @@ namespace Microsoft.OpenApi.Reader
         /// <summary>
         /// Reads the input string and parses it into an Open API document.
         /// </summary>
-        /// <param name="input">The input string.</param>
-        /// <param name="format">The Open API format</param>
-        /// <param name="settings">The OpenApi reader settings.</param>
-        /// <returns>An OpenAPI document instance.</returns>
-        public static ReadResult Parse(string input,
-                                       string format = null,
-                                       OpenApiReaderSettings settings = null)
-        {
-            format ??= OpenApiConstants.Json;
-            settings ??= new OpenApiReaderSettings();
-            using var reader = new StringReader(input);
-
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            return ParseAsync(input, reader, format, settings).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-        }
-
-        /// <summary>
-        /// An Async method to prevent synchornously blocking the calling thread.
-        /// </summary>
         /// <param name="input"></param>
-        /// <param name="reader"></param>
-        /// <param name="format"></param>
         /// <param name="settings"></param>
         /// <returns></returns>
         public static async Task<ReadResult> ParseAsync(string input,
-                                       StringReader reader,
-                                       string format = null,
-                                       OpenApiReaderSettings settings = null)
+                                                        OpenApiReaderSettings settings = null)
         {
             var format = input.StartsWith("{") || input.StartsWith("[") ? OpenApiConstants.Json : OpenApiConstants.Yaml;
             settings ??= new OpenApiReaderSettings();
@@ -186,90 +114,79 @@ namespace Microsoft.OpenApi.Reader
         /// </summary>
         /// <param name="input">The input string.</param>
         /// <param name="version"></param>
-        /// <param name="diagnostic">The diagnostic entity containing information from the reading process.</param>
-        /// <param name="format">The Open API format</param>
         /// <param name="settings">The OpenApi reader settings.</param>
         /// <returns>An OpenAPI document instance.</returns>
-        public static T Parse<T>(string input,
-                                 OpenApiSpecVersion version,
-                                 out OpenApiDiagnostic diagnostic,
-                                 string format = null,
-                                 OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public static async Task<ReadFragmentResult> ParseAsync<T>(string input,
+                                                  OpenApiSpecVersion version,
+                                                  OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
-            format ??= OpenApiConstants.Json;
+            var format = input.StartsWith("{") || input.StartsWith("[") ? OpenApiConstants.Json : OpenApiConstants.Yaml;
             settings ??= new OpenApiReaderSettings();
             using var reader = new StringReader(input);
-            return Load<T>(reader, version, out diagnostic, format, settings);
+            return await LoadAsync<T>(reader, version, format, settings);
         }
 
         /// <summary>
         /// Reads the stream input and parses the fragment of an OpenAPI description into an Open API Element.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="url">The path to the OpenAPI file</param>
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
-        /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing.</param>
         /// <param name="settings">The OpenApiReader settings.</param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
         /// <returns>The OpenAPI element.</returns>
-        public static T Load<T>(string url, OpenApiSpecVersion version, out OpenApiDiagnostic diagnostic, OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public static async Task<ReadFragmentResult> LoadAsync<T>(string url, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
-            var format = GetFormat(url);
+            var format = await GetFormatAsync(url);
             settings ??= new OpenApiReaderSettings();
-
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-            var stream = GetStreamAsync(url).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-
-            return Load<T>(stream, version, format, out diagnostic, settings);
+            var stream = await  GetStreamAsync(url);
+            return await LoadAsync<T>(stream, version, format, settings);
         }
 
         /// <summary>
         /// Reads the stream input and parses the fragment of an OpenAPI description into an Open API Element.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="input">Stream containing OpenAPI description to parse.</param>
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
         /// <param name="format"></param>
-        /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing.</param>
         /// <param name="settings">The OpenApiReader settings.</param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
         /// <returns>The OpenAPI element.</returns>
-        public static T Load<T>(Stream input, OpenApiSpecVersion version, string format, out OpenApiDiagnostic diagnostic, OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public static async Task<ReadFragmentResult> LoadAsync<T>(Stream input,
+                                                                  OpenApiSpecVersion version,
+                                                                  string format = null,
+                                                                  OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
-            format ??= OpenApiConstants.Json;
+            format ??= InspectStreamFormat(input);
             using var reader = new StreamReader(input);
-            return Load<T>(reader, version, out diagnostic, format, settings);
+            return await LoadAsync<T>(reader, version, format, settings);
         }
 
         /// <summary>
         /// Reads the TextReader input and parses the fragment of an OpenAPI description into an Open API Element.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <param name="input">TextReader containing OpenAPI description to parse.</param>
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
         /// <param name="format">The OpenAPI format.</param>
-        /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing.</param>
         /// <param name="settings">The OpenApiReader settings.</param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
         /// <returns>The OpenAPI element.</returns>
-        public static T Load<T>(TextReader input, OpenApiSpecVersion version, out OpenApiDiagnostic diagnostic, string format, OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public static async Task<ReadFragmentResult> LoadAsync<T>(TextReader input,
+                                                                  OpenApiSpecVersion version,
+                                                                  string format = null,
+                                                                  OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
             format ??= InspectTextReaderFormat(input);
             return await OpenApiReaderRegistry.GetReader(format).ReadFragmentAsync<T>(input, version, settings);
         }
 
-
-        private static string GetContentType(string url)
+        private static async Task<string> GetContentTypeAsync(string url)
         {
             if (!string.IsNullOrEmpty(url))
             {
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-                var response = _httpClient.GetAsync(url).GetAwaiter().GetResult();
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
-
+                var response = await _httpClient.GetAsync(url);
                 var mediaType = response.Content.Headers.ContentType.MediaType;
-                return mediaType.Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).First();
+                var contentType = mediaType.Split(";".ToCharArray(), StringSplitOptions.RemoveEmptyEntries).First();
+                return contentType;
             }
 
             return null;
@@ -280,17 +197,26 @@ namespace Microsoft.OpenApi.Reader
         /// </summary>
         /// <param name="url">The input URL.</param>
         /// <returns>The OpenAPI format.</returns>
-        public static string GetFormat(string url)
+        public static async Task<string> GetFormatAsync(string url)
         {
             if (!string.IsNullOrEmpty(url))
             {
-                if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase) || url.StartsWith("https", StringComparison.OrdinalIgnoreCase))
+                if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase) || 
+                    url.StartsWith("https", StringComparison.OrdinalIgnoreCase))
                 {
                     // URL examples ---> https://example.com/path/to/file.json, https://example.com/path/to/file.yaml
                     var path = new Uri(url);
-                    var urlSuffix = path.Segments[path.Segments.Length - 1].Split('.').LastOrDefault();
+                    var urlSuffix = path.Segments.LastOrDefault().Split('.').LastOrDefault();
 
-                    return !string.IsNullOrEmpty(urlSuffix) ? urlSuffix : GetContentType(url).Split('/').LastOrDefault();
+                    if (!string.IsNullOrEmpty(urlSuffix))
+                    {
+                        return urlSuffix;
+                    }
+                    else
+                    {
+                        var contentType = await GetContentTypeAsync(url);
+                        return contentType.Split('/').LastOrDefault();
+                    }
                 }
                 else
                 {

--- a/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
@@ -31,11 +31,12 @@ namespace Microsoft.OpenApi.Reader
         /// </summary>
         /// <param name="url">The path to the OpenAPI file</param>
         /// <param name="settings"> The OpenApi reader settings.</param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task<ReadResult> LoadAsync(string url, OpenApiReaderSettings settings = null)
+        public static async Task<ReadResult> LoadAsync(string url, OpenApiReaderSettings settings = null, CancellationToken cancellationToken = default)
         {
             var format = await GetFormatAsync(url);
-            var stream = await GetStreamAsync(url);
+            var stream = await GetStreamAsync(url, cancellationToken);
             return await LoadAsync(stream, format, settings);
         }
 
@@ -132,13 +133,17 @@ namespace Microsoft.OpenApi.Reader
         /// <param name="url">The path to the OpenAPI file</param>
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
         /// <param name="settings">The OpenApiReader settings.</param>
+        /// <param name="cancellationToken"></param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
         /// <returns>The OpenAPI element.</returns>
-        public static async Task<ReadFragmentResult> LoadAsync<T>(string url, OpenApiSpecVersion version, OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public static async Task<ReadFragmentResult> LoadAsync<T>(string url,
+                                                                  OpenApiSpecVersion version,
+                                                                  OpenApiReaderSettings settings = null,
+                                                                  CancellationToken cancellationToken = default) where T : IOpenApiElement
         {
             var format = await GetFormatAsync(url);
             settings ??= new OpenApiReaderSettings();
-            var stream = await  GetStreamAsync(url);
+            var stream = await GetStreamAsync(url, cancellationToken);
             return await LoadAsync<T>(stream, version, format, settings);
         }
 
@@ -278,7 +283,7 @@ namespace Microsoft.OpenApi.Reader
             return input.StartsWith("{") || input.StartsWith("[") ? OpenApiConstants.Json : OpenApiConstants.Yaml;
         }
 
-        private static async Task<Stream> GetStreamAsync(string url)
+        private static async Task<Stream> GetStreamAsync(string url, CancellationToken cancellationToken = default)
         {
             Stream stream;
             if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase) || url.StartsWith("https", StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -117,9 +117,9 @@ namespace Microsoft.OpenApi.Reader
         /// <param name="version"></param>
         /// <param name="settings">The OpenApi reader settings.</param>
         /// <returns>An OpenAPI document instance.</returns>
-        public static async Task<ReadFragmentResult> ParseAsync<T>(string input,
-                                                                   OpenApiSpecVersion version,
-                                                                   OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public static async Task<ReadFragmentResult<T>> ParseAsync<T>(string input,
+                                                                      OpenApiSpecVersion version,
+                                                                      OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
             var format = input.StartsWith("{") || input.StartsWith("[") ? OpenApiConstants.Json : OpenApiConstants.Yaml;
             settings ??= new OpenApiReaderSettings();
@@ -136,10 +136,10 @@ namespace Microsoft.OpenApi.Reader
         /// <param name="cancellationToken"></param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
         /// <returns>The OpenAPI element.</returns>
-        public static async Task<ReadFragmentResult> LoadAsync<T>(string url,
-                                                                  OpenApiSpecVersion version,
-                                                                  OpenApiReaderSettings settings = null,
-                                                                  CancellationToken cancellationToken = default) where T : IOpenApiElement
+        public static async Task<ReadFragmentResult<T>> LoadAsync<T>(string url,
+                                                                     OpenApiSpecVersion version,
+                                                                     OpenApiReaderSettings settings = null,
+                                                                     CancellationToken cancellationToken = default) where T : IOpenApiElement
         {
             var format = await GetFormatAsync(url);
             settings ??= new OpenApiReaderSettings();
@@ -156,10 +156,10 @@ namespace Microsoft.OpenApi.Reader
         /// <param name="settings">The OpenApiReader settings.</param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
         /// <returns>The OpenAPI element.</returns>
-        public static async Task<ReadFragmentResult> LoadAsync<T>(Stream input,
-                                                                  OpenApiSpecVersion version,
-                                                                  string format = null,
-                                                                  OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public static async Task<ReadFragmentResult<T>> LoadAsync<T>(Stream input,
+                                                                     OpenApiSpecVersion version,
+                                                                     string format = null,
+                                                                     OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
             format ??= InspectStreamFormat(input);
             using var reader = new StreamReader(input);
@@ -175,10 +175,10 @@ namespace Microsoft.OpenApi.Reader
         /// <param name="settings">The OpenApiReader settings.</param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
         /// <returns>The OpenAPI element.</returns>
-        public static async Task<ReadFragmentResult> LoadAsync<T>(TextReader input,
-                                                                  OpenApiSpecVersion version,
-                                                                  string format = null,
-                                                                  OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public static async Task<ReadFragmentResult<T>> LoadAsync<T>(TextReader input,
+                                                                     OpenApiSpecVersion version,
+                                                                     string format = null,
+                                                                     OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
             format ??= InspectTextReaderFormat(input);
             return await OpenApiReaderRegistry.GetReader(format).ReadFragmentAsync<T>(input, version, settings);

--- a/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -36,7 +36,7 @@ namespace Microsoft.OpenApi.Reader
         public static async Task<ReadResult> LoadAsync(string url, OpenApiReaderSettings settings = null, CancellationToken cancellationToken = default)
         {
             var format = await GetFormatAsync(url);
-            var stream = await GetStreamAsync(url, cancellationToken);
+            var stream = await GetStreamAsync(url);
             return await LoadAsync(stream, format, settings);
         }
 
@@ -131,7 +131,7 @@ namespace Microsoft.OpenApi.Reader
         {
             var format = await GetFormatAsync(url);
             settings ??= new OpenApiReaderSettings();
-            var stream = await GetStreamAsync(url, cancellationToken);
+            var stream = await GetStreamAsync(url);
             return await LoadAsync<T>(stream, version, format, settings);
         }
 
@@ -308,7 +308,7 @@ namespace Microsoft.OpenApi.Reader
             return input.StartsWith("{") || input.StartsWith("[") ? OpenApiConstants.Json : OpenApiConstants.Yaml;
         }
 
-        private static async Task<Stream> GetStreamAsync(string url, CancellationToken cancellationToken = default)
+        private static async Task<Stream> GetStreamAsync(string url)
         {
             Stream stream;
             if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase) || url.StartsWith("https", StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
@@ -117,8 +117,8 @@ namespace Microsoft.OpenApi.Reader
         /// <param name="settings">The OpenApi reader settings.</param>
         /// <returns>An OpenAPI document instance.</returns>
         public static async Task<ReadFragmentResult> ParseAsync<T>(string input,
-                                                  OpenApiSpecVersion version,
-                                                  OpenApiReaderSettings settings = null) where T : IOpenApiElement
+                                                                   OpenApiSpecVersion version,
+                                                                   OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
             var format = input.StartsWith("{") || input.StartsWith("[") ? OpenApiConstants.Json : OpenApiConstants.Yaml;
             settings ??= new OpenApiReaderSettings();

--- a/src/Microsoft.OpenApi/Reader/OpenApiReaderSettings.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiReaderSettings.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json.Nodes;
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.MicrosoftExtensions;
 using Microsoft.OpenApi.Validations;
@@ -77,7 +76,7 @@ namespace Microsoft.OpenApi.Reader
 
         /// <summary>
         /// Whether to leave the <see cref="Stream"/> object open after reading
-        /// from an OpenApiStreamReader object.
+        /// from a StreamReader object.
         /// </summary>
         public bool LeaveStreamOpen { get; set; }
 

--- a/src/Microsoft.OpenApi/Reader/ReadResult.cs
+++ b/src/Microsoft.OpenApi/Reader/ReadResult.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 
 namespace Microsoft.OpenApi.Reader
@@ -13,7 +14,23 @@ namespace Microsoft.OpenApi.Reader
         /// <summary>
         /// The parsed OpenApiDocument.  Null will be returned if the document could not be parsed.
         /// </summary>
-        public OpenApiDocument OpenApiDocument { set; get; }
+        public OpenApiDocument OpenApiDocument { get; set; }
+        /// <summary>
+        /// OpenApiDiagnostic contains the Errors reported while parsing
+        /// </summary>
+        public OpenApiDiagnostic OpenApiDiagnostic { get; set; }
+    }
+
+    /// <summary>
+    /// Container object used for returning the result of reading an OpenAPI fragment
+    /// </summary>
+    public class ReadFragmentResult
+    {
+        /// <summary>
+        /// The parsed fragment.
+        /// </summary>
+        public IOpenApiElement Element { get; set; }
+
         /// <summary>
         /// OpenApiDiagnostic contains the Errors reported while parsing
         /// </summary>

--- a/src/Microsoft.OpenApi/Reader/ReadResult.cs
+++ b/src/Microsoft.OpenApi/Reader/ReadResult.cs
@@ -24,12 +24,12 @@ namespace Microsoft.OpenApi.Reader
     /// <summary>
     /// Container object used for returning the result of reading an OpenAPI fragment
     /// </summary>
-    public class ReadFragmentResult
+    public class ReadFragmentResult<T> where T: IOpenApiElement
     {
         /// <summary>
         /// The parsed fragment.
         /// </summary>
-        public IOpenApiElement Element { get; set; }
+        public T Element { get; set; }
 
         /// <summary>
         /// OpenApiDiagnostic contains the Errors reported while parsing

--- a/src/Microsoft.OpenApi/Reader/Services/OpenApiWorkspaceLoader.cs
+++ b/src/Microsoft.OpenApi/Reader/Services/OpenApiWorkspaceLoader.cs
@@ -22,7 +22,6 @@ namespace Microsoft.OpenApi.Reader.Services
 
         internal async Task<OpenApiDiagnostic> LoadAsync(OpenApiReference reference,
                                                          OpenApiDocument document,
-                                                         string format = null,
                                                          OpenApiDiagnostic diagnostic = null,
                                                          CancellationToken cancellationToken = default)
         {
@@ -46,7 +45,7 @@ namespace Microsoft.OpenApi.Reader.Services
                 if (!_workspace.Contains(item.ExternalResource))
                 {
                     var input = await _loader.LoadAsync(new(item.ExternalResource, UriKind.RelativeOrAbsolute));
-                    var result = await OpenApiDocument.LoadAsync(input, format, _readerSettings, cancellationToken);
+                    var result = await OpenApiDocument.LoadAsync(input, _readerSettings, cancellationToken);
                     // Merge diagnostics
                     if (result.OpenApiDiagnostic != null)
                     {
@@ -54,7 +53,7 @@ namespace Microsoft.OpenApi.Reader.Services
                     }
                     if (result.OpenApiDocument != null)
                     {
-                        var loadDiagnostic = await LoadAsync(item, result.OpenApiDocument, format, diagnostic, cancellationToken);
+                        var loadDiagnostic = await LoadAsync(item, result.OpenApiDocument, diagnostic, cancellationToken);
                         diagnostic = loadDiagnostic;
                     }
                 }

--- a/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiFilterServiceTests.cs
+++ b/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiFilterServiceTests.cs
@@ -224,7 +224,7 @@ namespace Microsoft.OpenApi.Hidi.Tests
         }
 
         [Fact]
-        public void CopiesOverAllReferencedComponentsToTheSubsetDocumentCorrectly()
+        public async Task CopiesOverAllReferencedComponentsToTheSubsetDocumentCorrectly()
         {
             // Arrange
             var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "UtilityFiles", "docWithReusableHeadersAndExamples.yaml");
@@ -232,10 +232,10 @@ namespace Microsoft.OpenApi.Hidi.Tests
 
             // Act
             using var stream = File.OpenRead(filePath);
-            var doc = OpenApiDocument.Load(stream, "yaml").OpenApiDocument;
+            var res = await OpenApiDocument.LoadAsync(stream);
             
             var predicate = OpenApiFilterService.CreatePredicate(operationIds: operationIds);
-            var subsetOpenApiDocument = OpenApiFilterService.CreateFilteredDocument(doc, predicate);
+            var subsetOpenApiDocument = OpenApiFilterService.CreateFilteredDocument(res.OpenApiDocument, predicate);
 
             var response = subsetOpenApiDocument.Paths["/items"].Operations[OperationType.Get]?.Responses?["200"];
             var responseHeader = response?.Headers["x-custom-header"];
@@ -244,7 +244,7 @@ namespace Microsoft.OpenApi.Hidi.Tests
             var targetExamples = subsetOpenApiDocument.Components?.Examples;
 
             // Assert
-            Assert.Same(doc.Servers, subsetOpenApiDocument.Servers);
+            Assert.Same(res.OpenApiDocument.Servers, subsetOpenApiDocument.Servers);
             Assert.False(responseHeader?.UnresolvedReference);
             Assert.False(mediaTypeExample?.UnresolvedReference);
             Assert.NotNull(targetHeaders);

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiDiagnosticTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiDiagnosticTests.cs
@@ -23,18 +23,18 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
         }
 
         [Fact]
-        public void DetectedSpecificationVersionShouldBeV2_0()
+        public async Task DetectedSpecificationVersionShouldBeV2_0()
         {
-            var actual = OpenApiDocument.Load("V2Tests/Samples/basic.v2.yaml");
+            var actual = await OpenApiDocument.LoadAsync("V2Tests/Samples/basic.v2.yaml");
 
             actual.OpenApiDiagnostic.Should().NotBeNull();
             actual.OpenApiDiagnostic.SpecificationVersion.Should().Be(OpenApiSpecVersion.OpenApi2_0);
         }
 
         [Fact]
-        public void DetectedSpecificationVersionShouldBeV3_0()
+        public async Task DetectedSpecificationVersionShouldBeV3_0()
         {
-            var actual = OpenApiDocument.Load("V3Tests/Samples/OpenApiDocument/minimalDocument.yaml");
+            var actual = await OpenApiDocument.LoadAsync("V3Tests/Samples/OpenApiDocument/minimalDocument.yaml");
 
             actual.OpenApiDiagnostic.Should().NotBeNull();
             actual.OpenApiDiagnostic.SpecificationVersion.Should().Be(OpenApiSpecVersion.OpenApi3_0);

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiStreamReaderTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiStreamReaderTests.cs
@@ -11,11 +11,11 @@ using Xunit;
 
 namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
 {
-    public class OpenApiStreamReaderTests
+    public class OpenApiDocumentLoadTests
     {
         private const string SampleFolderPath = "V3Tests/Samples/OpenApiDocument/";
 
-        public OpenApiStreamReaderTests()
+        public OpenApiDocumentLoadTests()
         {
             OpenApiReaderRegistry.RegisterReader("yaml", new OpenApiYamlReader());
         }

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiStreamReaderTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiStreamReaderTests.cs
@@ -21,20 +21,20 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
         }
 
         [Fact]
-        public void StreamShouldCloseIfLeaveStreamOpenSettingEqualsFalse()
+        public async Task StreamShouldCloseIfLeaveStreamOpenSettingEqualsFalse()
         {
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "petStore.yaml"));
             var settings = new OpenApiReaderSettings { LeaveStreamOpen = false };
-            _ = OpenApiDocument.Load(stream, "yaml", settings);
+            _ = await OpenApiDocument.LoadAsync(stream, settings);
             Assert.False(stream.CanRead);
         }
 
         [Fact]
-        public void StreamShouldNotCloseIfLeaveStreamOpenSettingEqualsTrue()
+        public async Task StreamShouldNotCloseIfLeaveStreamOpenSettingEqualsTrue()
         {
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "petStore.yaml"));
             var settings = new OpenApiReaderSettings { LeaveStreamOpen = true };
-            _ = OpenApiDocument.Load(stream, "yaml", settings);
+            _ = await OpenApiDocument.LoadAsync(stream, settings);
             Assert.True(stream.CanRead);
         }
 
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
             memoryStream.Position = 0;
             var stream = memoryStream;
 
-            var result = OpenApiDocument.Load(stream, "yaml", new OpenApiReaderSettings { LeaveStreamOpen = true });
+            var result = await OpenApiDocument.LoadAsync(stream, new OpenApiReaderSettings { LeaveStreamOpen = true });
             stream.Seek(0, SeekOrigin.Begin); // does not throw an object disposed exception
             Assert.True(stream.CanRead);
         }
@@ -64,7 +64,7 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
             var stream = await httpClient.GetStreamAsync("20fe7a7b720a0e48e5842d002ac418b12a8201df/tests/v3.0/pass/petstore.yaml");
 
             // Read V3 as YAML
-            var result = OpenApiDocument.Load(stream, "yaml");
+            var result = await OpenApiDocument.LoadAsync(stream);
             Assert.NotNull(result.OpenApiDocument);
         }
     }

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/UnsupportedSpecVersionTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/UnsupportedSpecVersionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Models;
@@ -12,11 +13,11 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
     public class UnsupportedSpecVersionTests
     {
         [Fact]
-        public void ThrowOpenApiUnsupportedSpecVersionException()
+        public async Task ThrowOpenApiUnsupportedSpecVersionException()
         {
             try
             {
-                _ = OpenApiDocument.Load("OpenApiReaderTests/Samples/unsupported.v1.yaml");
+                _ = await OpenApiDocument.LoadAsync("OpenApiReaderTests/Samples/unsupported.v1.yaml");
             }
             catch (OpenApiUnsupportedSpecVersionException exception)
             {

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiWorkspaceTests/OpenApiWorkspaceStreamTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiWorkspaceTests/OpenApiWorkspaceStreamTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Interfaces;
@@ -44,7 +44,7 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiWorkspaceTests
             await wr.FlushAsync();
             stream.Position = 0;
 
-            var result = await OpenApiDocument.LoadAsync(stream, OpenApiConstants.Yaml, settings: settings);
+            var result = await OpenApiDocument.LoadAsync(stream, settings: settings);
 
             Assert.NotNull(result.OpenApiDocument.Workspace);
         }

--- a/test/Microsoft.OpenApi.Readers.Tests/ParseNodeTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ParseNodeTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Models;
@@ -19,7 +20,7 @@ namespace Microsoft.OpenApi.Tests
         }
 
         [Fact]
-        public void BrokenSimpleList()
+        public async Task BrokenSimpleList()
         {
             var input =
                 """
@@ -31,7 +32,7 @@ namespace Microsoft.OpenApi.Tests
                 paths: { }
                 """;
 
-            var result = OpenApiDocument.Parse(input, "yaml");
+            var result = await OpenApiDocument.ParseAsync(input);
 
             result.OpenApiDiagnostic.Errors.Should().BeEquivalentTo(new List<OpenApiError>() {
                 new OpenApiError(new OpenApiReaderException("Expected a value.")),
@@ -40,7 +41,7 @@ namespace Microsoft.OpenApi.Tests
         }
 
         [Fact]
-        public void BadSchema()
+        public async Task BadSchema()
         {
             var input = """
                         openapi: 3.0.0
@@ -58,7 +59,7 @@ namespace Microsoft.OpenApi.Tests
                                       schema: asdasd
                         """;
 
-            var res= OpenApiDocument.Parse(input, "yaml");
+            var res = await OpenApiDocument.ParseAsync(input);
 
             res.OpenApiDiagnostic.Errors.Should().BeEquivalentTo(new List<OpenApiError>
             {

--- a/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/TryLoadReferenceV2Tests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/TryLoadReferenceV2Tests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.References;
@@ -22,10 +23,10 @@ namespace Microsoft.OpenApi.Readers.Tests.ReferenceService
         }
 
         [Fact]
-        public void LoadParameterReference()
+        public async Task LoadParameterReference()
         {
             // Arrange
-            var result = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "multipleReferences.v2.yaml"));
+            var result = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "multipleReferences.v2.yaml"));
             var reference = new OpenApiParameterReference("skipParam", result.OpenApiDocument);
 
             // Assert
@@ -47,9 +48,9 @@ namespace Microsoft.OpenApi.Readers.Tests.ReferenceService
         }
 
         [Fact]
-        public void LoadSecuritySchemeReference()
+        public async Task LoadSecuritySchemeReference()
         {
-            var result = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "multipleReferences.v2.yaml"));
+            var result = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "multipleReferences.v2.yaml"));
 
             var reference = new OpenApiSecuritySchemeReference("api_key_sample", result.OpenApiDocument);
 
@@ -65,9 +66,9 @@ namespace Microsoft.OpenApi.Readers.Tests.ReferenceService
         }
 
         [Fact]
-        public void LoadResponseReference()
+        public async Task LoadResponseReference()
         {
-            var result = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "multipleReferences.v2.yaml"));
+            var result = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "multipleReferences.v2.yaml"));
 
             var reference = new OpenApiResponseReference("NotFound", result.OpenApiDocument);
 
@@ -85,9 +86,9 @@ namespace Microsoft.OpenApi.Readers.Tests.ReferenceService
         }
 
         [Fact]
-        public void LoadResponseAndSchemaReference()
+        public async Task LoadResponseAndSchemaReference()
         {
-            var result = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "multipleReferences.v2.yaml"));
+            var result = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "multipleReferences.v2.yaml"));
             var reference = new OpenApiResponseReference("GeneralError", result.OpenApiDocument);
 
             // Assert

--- a/test/Microsoft.OpenApi.Readers.Tests/TestCustomExtension.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/TestCustomExtension.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Text.Json.Nodes;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
@@ -14,7 +15,7 @@ namespace Microsoft.OpenApi.Readers.Tests
     public class TestCustomExtension
     {
         [Fact]
-        public void ParseCustomExtension()
+        public async Task ParseCustomExtension()
         {
             var description =
                 """
@@ -40,7 +41,7 @@ namespace Microsoft.OpenApi.Readers.Tests
 
             OpenApiReaderRegistry.RegisterReader("yaml", new OpenApiYamlReader());
             var diag = new OpenApiDiagnostic();
-            var actual = OpenApiDocument.Parse(description, "yaml", settings: settings);
+            var actual = await OpenApiDocument.ParseAsync(description, settings: settings);
 
             var fooExtension = actual.OpenApiDocument.Info.Extensions["x-foo"] as FooExtension;
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/ComparisonTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/ComparisonTests.cs
@@ -1,7 +1,8 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.IO;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
@@ -18,13 +19,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         [InlineData("minimal")]
         [InlineData("basic")]
         //[InlineData("definitions")]  //Currently broken due to V3 references not behaving the same as V2
-        public void EquivalentV2AndV3DocumentsShouldProduceEquivalentObjects(string fileName)
+        public async Task EquivalentV2AndV3DocumentsShouldProduceEquivalentObjects(string fileName)
         {
             OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
             using var streamV2 = Resources.GetStream(Path.Combine(SampleFolderPath, $"{fileName}.v2.yaml"));
             using var streamV3 = Resources.GetStream(Path.Combine(SampleFolderPath, $"{fileName}.v3.yaml"));
-            var result1 = OpenApiDocument.Load(Path.Combine(SampleFolderPath, $"{fileName}.v2.yaml"));
-            var result2 = OpenApiDocument.Load(Path.Combine(SampleFolderPath, $"{fileName}.v3.yaml"));
+            var result1 = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, $"{fileName}.v2.yaml"));
+            var result2 = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, $"{fileName}.v3.yaml"));
 
             result2.OpenApiDocument.Should().BeEquivalentTo(result1.OpenApiDocument,
                 options => options.Excluding(x => x.Workspace).Excluding(y => y.BaseUri));

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiContactTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiContactTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
@@ -11,7 +12,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
     public class OpenApiContactTests
     {
         [Fact]
-        public void ParseStringContactFragmentShouldSucceed()
+        public async Task ParseStringContactFragmentShouldSucceed()
         {
             var input =
                 """
@@ -23,12 +24,12 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 """;
 
             // Act
-            var contact = OpenApiModelFactory.Parse<OpenApiContact>(input, OpenApiSpecVersion.OpenApi2_0, out var diagnostic);
+            var contact = await OpenApiModelFactory.ParseAsync<OpenApiContact>(input, OpenApiSpecVersion.OpenApi2_0);
 
             // Assert
-            diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());
+            contact.OpenApiDiagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());
 
-            contact.Should().BeEquivalentTo(
+            contact.Element.Should().BeEquivalentTo(
                 new OpenApiContact
                 {
                     Email = "support@swagger.io",

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiServerTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiServerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
@@ -14,7 +15,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         }
 
         [Fact]
-        public void NoServer()
+        public async Task NoServer()
         {
             var input =
                 """
@@ -25,13 +26,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 paths: {}
                 """;
 
-            var result = OpenApiDocument.Parse(input, "yaml");
+            var result = await OpenApiDocument.ParseAsync(input);
 
             Assert.Empty(result.OpenApiDocument.Servers);
         }
 
         [Fact]
-        public void JustSchemeNoDefault()
+        public async Task JustSchemeNoDefault()
         {
             var input =
                 """
@@ -43,13 +44,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                   - http
                 paths: {}
                 """;
-            var result = OpenApiDocument.Parse(input, "yaml");
+            var result = await OpenApiDocument.ParseAsync(input);
 
             Assert.Empty(result.OpenApiDocument.Servers);
         }
 
         [Fact]
-        public void JustHostNoDefault()
+        public async Task JustHostNoDefault()
         {
             var input =
                 """
@@ -60,7 +61,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 host: www.foo.com
                 paths: {}
                 """;
-            var result = OpenApiDocument.Parse(input, "yaml");
+            var result = await OpenApiDocument.ParseAsync(input);
 
             var server = result.OpenApiDocument.Servers.First();
             Assert.Single(result.OpenApiDocument.Servers);
@@ -68,7 +69,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         }
 
         [Fact]
-        public void NoBasePath()
+        public async Task NoBasePath()
         {
             var input =
                 """
@@ -86,14 +87,14 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 BaseUrl = new("https://www.foo.com/spec.yaml")
             };
 
-            var result = OpenApiDocument.Parse(input, "yaml", settings);
+            var result = await OpenApiDocument.ParseAsync(input, settings);
             var server = result.OpenApiDocument.Servers.First();
             Assert.Single(result.OpenApiDocument.Servers);
             Assert.Equal("http://www.foo.com", server.Url);
         }
 
         [Fact]
-        public void JustBasePathNoDefault()
+        public async Task JustBasePathNoDefault()
         {
             var input =
                 """
@@ -104,7 +105,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 basePath: /baz
                 paths: {}
                 """;
-            var result = OpenApiDocument.Parse(input, "yaml");
+            var result = await OpenApiDocument.ParseAsync(input);
 
             var server = result.OpenApiDocument.Servers.First();
             Assert.Single(result.OpenApiDocument.Servers);
@@ -112,7 +113,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         }
 
         [Fact]
-        public void JustSchemeWithCustomHost()
+        public async Task JustSchemeWithCustomHost()
         {
             var input =
                 """
@@ -129,7 +130,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 BaseUrl = new("https://bing.com/foo")
             };
 
-            var result = OpenApiDocument.Parse(input, "yaml", settings);
+            var result = await OpenApiDocument.ParseAsync(input, settings);
 
             var server = result.OpenApiDocument.Servers.First();
             Assert.Single(result.OpenApiDocument.Servers);
@@ -137,7 +138,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         }
 
         [Fact]
-        public void JustSchemeWithCustomHostWithEmptyPath()
+        public async Task JustSchemeWithCustomHostWithEmptyPath()
         {
             var input =
                 """
@@ -154,7 +155,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 BaseUrl = new("https://bing.com")
             };
 
-            var result = OpenApiDocument.Parse(input, "yaml", settings);
+            var result = await OpenApiDocument.ParseAsync(input, settings);
 
             var server = result.OpenApiDocument.Servers.First();
             Assert.Single(result.OpenApiDocument.Servers);
@@ -162,7 +163,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         }
 
         [Fact]
-        public void JustBasePathWithCustomHost()
+        public async Task JustBasePathWithCustomHost()
         {
             var input =
                 """
@@ -178,7 +179,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 BaseUrl = new("https://bing.com")
             };
 
-            var result = OpenApiDocument.Parse(input, "yaml", settings);
+            var result = await OpenApiDocument.ParseAsync(input, settings);
 
             var server = result.OpenApiDocument.Servers.First();
             Assert.Single(result.OpenApiDocument.Servers);
@@ -186,7 +187,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         }
 
         [Fact]
-        public void JustHostWithCustomHost()
+        public async Task JustHostWithCustomHost()
         {
             var input =
                 """
@@ -202,7 +203,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 BaseUrl = new("https://bing.com")
             };
 
-            var result = OpenApiDocument.Parse(input, "yaml", settings);
+            var result = await OpenApiDocument.ParseAsync(input, settings);
 
             var server = result.OpenApiDocument.Servers.First();
             Assert.Single(result.OpenApiDocument.Servers);
@@ -210,7 +211,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         }
 
         [Fact]
-        public void JustHostWithCustomHostWithApi()
+        public async Task JustHostWithCustomHostWithApi()
         {
             var input =
                 """
@@ -227,14 +228,14 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 BaseUrl = new("https://dev.bing.com/api/description.yaml")
             };
 
-            var result = OpenApiDocument.Parse(input, "yaml", settings);
+            var result = await OpenApiDocument.ParseAsync(input, settings);
             var server = result.OpenApiDocument.Servers.First();
             Assert.Single(result.OpenApiDocument.Servers);
             Assert.Equal("https://prod.bing.com", server.Url);
         }
 
         [Fact]
-        public void MultipleServers()
+        public async Task MultipleServers()
         {
             var input =
                 """
@@ -253,7 +254,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 BaseUrl = new("https://dev.bing.com/api")
             };
 
-            var result = OpenApiDocument.Parse(input, "yaml", settings);
+            var result = await OpenApiDocument.ParseAsync(input, settings);
             var server = result.OpenApiDocument.Servers.First();
             Assert.Equal(2, result.OpenApiDocument.Servers.Count);
             Assert.Equal("http://dev.bing.com/api", server.Url);
@@ -261,7 +262,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         }
 
         [Fact]
-        public void LocalHostWithCustomHost()
+        public async Task LocalHostWithCustomHost()
         {
             var input =
                 """
@@ -278,7 +279,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 BaseUrl = new("https://bing.com")
             };
 
-            var result = OpenApiDocument.Parse(input, "yaml", settings);
+            var result = await OpenApiDocument.ParseAsync(input, settings);
 
             var server = result.OpenApiDocument.Servers.First();
             Assert.Single(result.OpenApiDocument.Servers);
@@ -286,7 +287,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
         }
 
         [Fact]
-        public void InvalidHostShouldYieldError()
+        public async Task InvalidHostShouldYieldError()
         {
             var input =
                 """
@@ -303,7 +304,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 BaseUrl = new("https://bing.com")
             };
 
-            var result = OpenApiDocument.Parse(input, "yaml", settings);
+            var result = await OpenApiDocument.ParseAsync(input, settings);
             result.OpenApiDocument.Servers.Count.Should().Be(0);
             result.OpenApiDiagnostic.Should().BeEquivalentTo(
                 new OpenApiDiagnostic

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiDocumentTests.cs
@@ -26,10 +26,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
         }
 
         [Fact]
-        public void ParseDocumentWithWebhooksShouldSucceed()
+        public async Task ParseDocumentWithWebhooksShouldSucceed()
         {
             // Arrange and Act
-            var actual = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "documentWithWebhooks.yaml"));
+            var actual = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "documentWithWebhooks.yaml"));
             var petSchema = new OpenApiSchemaReference("petSchema", actual.OpenApiDocument);
 
             var newPetSchema = new OpenApiSchemaReference("newPetSchema", actual.OpenApiDocument);
@@ -205,10 +205,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
         }
 
         [Fact]
-        public void ParseDocumentsWithReusablePathItemInWebhooksSucceeds()
+        public async Task ParseDocumentsWithReusablePathItemInWebhooksSucceeds()
         {
             // Arrange && Act
-            var actual = OpenApiDocument.Load("V31Tests/Samples/OpenApiDocument/documentWithReusablePaths.yaml");
+            var actual = await OpenApiDocument.LoadAsync("V31Tests/Samples/OpenApiDocument/documentWithReusablePaths.yaml");
 
             var components = new OpenApiComponents
             {
@@ -401,14 +401,14 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
         }
 
         [Fact]
-        public void ParseDocumentWithExampleInSchemaShouldSucceed()
+        public async Task ParseDocumentWithExampleInSchemaShouldSucceed()
         {
             // Arrange
             var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
             var writer = new OpenApiJsonWriter(outputStringWriter, new OpenApiJsonWriterSettings { Terse = false });
 
             // Act
-            var actual = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "docWithExample.yaml"));
+            var actual = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "docWithExample.yaml"));
             actual.OpenApiDocument.SerializeAsV31(writer);
 
             // Assert
@@ -416,10 +416,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
         }
 
         [Fact]
-        public void ParseDocumentWithPatternPropertiesInSchemaWorks()
+        public async Task ParseDocumentWithPatternPropertiesInSchemaWorks()
         {
             // Arrange and Act
-            var result = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "docWithPatternPropertiesInSchema.yaml"));
+            var result = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "docWithPatternPropertiesInSchema.yaml"));
             var actualSchema = result.OpenApiDocument.Paths["/example"].Operations[OperationType.Get].Responses["200"].Content["application/json"].Schema;
 
             var expectedSchema = new OpenApiSchema
@@ -473,10 +473,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
         }
 
         [Fact]
-        public void ParseDocumentWithReferenceByIdGetsResolved()
+        public async Task ParseDocumentWithReferenceByIdGetsResolved()
         {
             // Arrange and Act
-            var result = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "docWithReferenceById.yaml"));
+            var result = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "docWithReferenceById.yaml"));
 
             var responseSchema = result.OpenApiDocument.Paths["/resource"].Operations[OperationType.Get].Responses["200"].Content["application/json"].Schema;
             var requestBodySchema = result.OpenApiDocument.Paths["/resource"].Operations[OperationType.Post].RequestBody.Content["application/json"].Schema;
@@ -523,10 +523,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
 
             // Act
             var result = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "externalRefById.yaml"), settings);
-            var doc2 = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "externalResource.yaml")).OpenApiDocument;
+            var result2 = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "externalResource.yaml"));
 
             var requestBodySchema = result.OpenApiDocument.Paths["/resource"].Operations[OperationType.Get].Parameters.First().Schema;
-            result.OpenApiDocument.Workspace.RegisterComponents(doc2);
+            result.OpenApiDocument.Workspace.RegisterComponents(result2.OpenApiDocument);
 
             // Assert
             requestBodySchema.Properties.Count.Should().Be(2); // reference has been resolved
@@ -536,9 +536,9 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
         public async Task ParseDocumentWith31PropertiesWorks()
         {
             var path = Path.Combine(SampleFolderPath, "documentWith31Properties.yaml");
-            var doc = OpenApiDocument.Load(path).OpenApiDocument;
+            var res = await OpenApiDocument.LoadAsync(path);
             var outputStringWriter = new StringWriter();
-            doc.SerializeAsV31(new OpenApiYamlWriter(outputStringWriter));
+            res.OpenApiDocument.SerializeAsV31(new OpenApiYamlWriter(outputStringWriter));
             outputStringWriter.Flush();
             var actual = outputStringWriter.GetStringBuilder().ToString();
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiCallbackTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiCallbackTests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Expressions;
 using Microsoft.OpenApi.Models;
@@ -21,15 +22,15 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseBasicCallbackShouldSucceed()
+        public async Task ParseBasicCallbackShouldSucceed()
         {
             // Act
-            var callback = OpenApiModelFactory.Load<OpenApiCallback>(Path.Combine(SampleFolderPath, "basicCallback.yaml"), OpenApiSpecVersion.OpenApi3_0, out var diagnostic);
+            var callback = await OpenApiModelFactory.LoadAsync<OpenApiCallback>(Path.Combine(SampleFolderPath, "basicCallback.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());
+            callback.OpenApiDiagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());
 
-            callback.Should().BeEquivalentTo(
+            callback.Element.Should().BeEquivalentTo(
                 new OpenApiCallback
                 {
                     PathItems =
@@ -64,12 +65,12 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseCallbackWithReferenceShouldSucceed()
+        public async Task ParseCallbackWithReferenceShouldSucceed()
         {
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "callbackWithReference.yaml"));
 
             // Act
-            var result = OpenApiModelFactory.Load(stream, OpenApiConstants.Yaml);
+            var result = await OpenApiModelFactory.LoadAsync(stream);
 
             // Assert
             var path = result.OpenApiDocument.Paths.First().Value;
@@ -122,10 +123,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseMultipleCallbacksWithReferenceShouldSucceed()
+        public async Task ParseMultipleCallbacksWithReferenceShouldSucceed()
         {
             // Act
-            var result = OpenApiModelFactory.Load(Path.Combine(SampleFolderPath, "multipleCallbacksWithReference.yaml"));
+            var result = await OpenApiModelFactory.LoadAsync(Path.Combine(SampleFolderPath, "multipleCallbacksWithReference.yaml"));
 
             // Assert
             var path = result.OpenApiDocument.Paths.First().Value;

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiContactTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiContactTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
@@ -11,7 +12,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
     public class OpenApiContactTests
     {
         [Fact]
-        public void ParseStringContactFragmentShouldSucceed()
+        public async Task ParseStringContactFragmentShouldSucceed()
         {
             var input =
                 """
@@ -23,12 +24,12 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 """;
 
             // Act
-            var contact = OpenApiModelFactory.Parse<OpenApiContact>(input, OpenApiSpecVersion.OpenApi3_0, out var diagnostic, OpenApiConstants.Json);
+            var contact = await OpenApiModelFactory.ParseAsync<OpenApiContact>(input, OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());
+            contact.OpenApiDiagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());
 
-            contact.Should().BeEquivalentTo(
+            contact.Element.Should().BeEquivalentTo(
                 new OpenApiContact
                 {
                     Email = "support@swagger.io",

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDiscriminatorTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDiscriminatorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.IO;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
@@ -20,16 +21,16 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseBasicDiscriminatorShouldSucceed()
+        public async Task ParseBasicDiscriminatorShouldSucceed()
         {
             // Arrange
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "basicDiscriminator.yaml"));
 
             // Act
-            var discriminator = OpenApiModelFactory.Load<OpenApiDiscriminator>(stream, OpenApiSpecVersion.OpenApi3_0, OpenApiConstants.Yaml, out var diagnostic);
+            var discriminator = await OpenApiModelFactory.LoadAsync<OpenApiDiscriminator>(stream, OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            discriminator.Should().BeEquivalentTo(
+            discriminator.Element.Should().BeEquivalentTo(
                 new OpenApiDiscriminator
                 {
                     PropertyName = "pet_type",

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiEncodingTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiEncodingTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.IO;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
@@ -20,13 +21,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseBasicEncodingShouldSucceed()
+        public async Task ParseBasicEncodingShouldSucceed()
         {
             // Act
-            var encoding = OpenApiModelFactory.Load<OpenApiEncoding>(Path.Combine(SampleFolderPath, "basicEncoding.yaml"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var encoding = await OpenApiModelFactory.LoadAsync<OpenApiEncoding>(Path.Combine(SampleFolderPath, "basicEncoding.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            encoding.Should().BeEquivalentTo(
+            encoding.Element.Should().BeEquivalentTo(
                 new OpenApiEncoding
                 {
                     ContentType = "application/xml; charset=utf-8"
@@ -34,15 +35,15 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseAdvancedEncodingShouldSucceed()
+        public async Task ParseAdvancedEncodingShouldSucceed()
         {
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "advancedEncoding.yaml"));
 
             // Act
-            var encoding = OpenApiModelFactory.Load<OpenApiEncoding>(stream, OpenApiSpecVersion.OpenApi3_0, OpenApiConstants.Yaml, out _);
+            var encoding = await OpenApiModelFactory.LoadAsync<OpenApiEncoding>(stream, OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            encoding.Should().BeEquivalentTo(
+            encoding.Element.Should().BeEquivalentTo(
                 new OpenApiEncoding
                 {
                     ContentType = "image/png, image/jpeg",

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiExampleTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiExampleTests.cs
@@ -3,8 +3,8 @@
 
 using System.IO;
 using System.Text.Json.Nodes;
+using System.Threading.Tasks;
 using FluentAssertions;
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
 using Xunit;
@@ -22,9 +22,9 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseAdvancedExampleShouldSucceed()
+        public async Task ParseAdvancedExampleShouldSucceed()
         {
-            var example = OpenApiModelFactory.Load<OpenApiExample>(Path.Combine(SampleFolderPath, "advancedExample.yaml"), OpenApiSpecVersion.OpenApi3_0, out var diagnostic);
+            var result = await OpenApiModelFactory.LoadAsync<OpenApiExample>(Path.Combine(SampleFolderPath, "advancedExample.yaml"), OpenApiSpecVersion.OpenApi3_0);
             var expected = new OpenApiExample
             {
                 Value = new JsonObject
@@ -62,12 +62,12 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 }
             };
 
-            var actualRoot = example.Value["versions"][0]["status"].Root;
+            var actualRoot = result.Element.Value["versions"][0]["status"].Root;
             var expectedRoot = expected.Value["versions"][0]["status"].Root;
 
-            diagnostic.Errors.Should().BeEmpty();
+            result.OpenApiDiagnostic.Errors.Should().BeEmpty();
 
-            example.Should().BeEquivalentTo(expected, options => options.IgnoringCyclicReferences()
+            result.Element.Should().BeEquivalentTo(expected, options => options.IgnoringCyclicReferences()
             .Excluding(e => e.Value["versions"][0]["status"].Root)
             .Excluding(e => e.Value["versions"][0]["id"].Root)
             .Excluding(e => e.Value["versions"][0]["links"][0]["href"].Root)
@@ -79,9 +79,9 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseExampleForcedStringSucceed()
+        public async Task ParseExampleForcedStringSucceed()
         {
-            var result= OpenApiDocument.Load(Path.Combine(SampleFolderPath, "explicitString.yaml"));
+            var result= await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "explicitString.yaml"));
             result.OpenApiDiagnostic.Errors.Should().BeEmpty();
         }
     }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiInfoTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiInfoTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Text.Json.Nodes;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
@@ -23,13 +24,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseAdvancedInfoShouldSucceed()
+        public async Task ParseAdvancedInfoShouldSucceed()
         {
             // Act
-            var openApiInfo = OpenApiModelFactory.Load<OpenApiInfo>(Path.Combine(SampleFolderPath, "advancedInfo.yaml"), OpenApiSpecVersion.OpenApi3_0, out var diagnostic);
+            var openApiInfo = await OpenApiModelFactory.LoadAsync<OpenApiInfo>(Path.Combine(SampleFolderPath, "advancedInfo.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            openApiInfo.Should().BeEquivalentTo(
+            openApiInfo.Element.Should().BeEquivalentTo(
                 new OpenApiInfo
                 {
                     Title = "Advanced Info",
@@ -80,13 +81,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseBasicInfoShouldSucceed()
+        public async Task ParseBasicInfoShouldSucceed()
         {
             // Act
-            var openApiInfo = OpenApiModelFactory.Load<OpenApiInfo>(Path.Combine(SampleFolderPath, "basicInfo.yaml"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var openApiInfo = await OpenApiModelFactory.LoadAsync<OpenApiInfo>(Path.Combine(SampleFolderPath, "basicInfo.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            openApiInfo.Should().BeEquivalentTo(
+            openApiInfo.Element.Should().BeEquivalentTo(
                 new OpenApiInfo
                 {
                     Title = "Basic Info",
@@ -108,15 +109,15 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseMinimalInfoShouldSucceed()
+        public async Task ParseMinimalInfoShouldSucceed()
         {
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "minimalInfo.yaml"));
 
             // Act
-            var openApiInfo = OpenApiModelFactory.Load<OpenApiInfo>(stream, OpenApiSpecVersion.OpenApi3_0, "yaml", out _);
+            var openApiInfo = await OpenApiModelFactory.LoadAsync<OpenApiInfo>(stream, OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            openApiInfo.Should().BeEquivalentTo(
+            openApiInfo.Element.Should().BeEquivalentTo(
                 new OpenApiInfo
                 {
                     Title = "Minimal Info",

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiMediaTypeTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiMediaTypeTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.IO;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
@@ -24,13 +25,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseMediaTypeWithExampleShouldSucceed()
+        public async Task ParseMediaTypeWithExampleShouldSucceed()
         {
             // Act
-            var mediaType = OpenApiModelFactory.Load<OpenApiMediaType>(Path.Combine(SampleFolderPath, "mediaTypeWithExample.yaml"), OpenApiSpecVersion.OpenApi3_0, out var diagnostic);
+            var mediaType = await OpenApiModelFactory.LoadAsync<OpenApiMediaType>(Path.Combine(SampleFolderPath, "mediaTypeWithExample.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            mediaType.Should().BeEquivalentTo(
+            mediaType.Element.Should().BeEquivalentTo(
                 new OpenApiMediaType
                 {
                     Example = 5,
@@ -45,13 +46,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseMediaTypeWithExamplesShouldSucceed()
+        public async Task ParseMediaTypeWithExamplesShouldSucceed()
         {
             // Act
-            var mediaType = OpenApiModelFactory.Load<OpenApiMediaType>(Path.Combine(SampleFolderPath, "mediaTypeWithExamples.yaml"), OpenApiSpecVersion.OpenApi3_0, out var diagnostic);
+            var mediaType = await OpenApiModelFactory.LoadAsync<OpenApiMediaType>(Path.Combine(SampleFolderPath, "mediaTypeWithExamples.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            mediaType.Should().BeEquivalentTo(
+            mediaType.Element.Should().BeEquivalentTo(
                 new OpenApiMediaType
                 {
                     Examples =

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiOperationTests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.References;
@@ -21,9 +22,9 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void OperationWithSecurityRequirementShouldReferenceSecurityScheme()
+        public async Task OperationWithSecurityRequirementShouldReferenceSecurityScheme()
         {
-            var result = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "securedOperation.yaml"));
+            var result = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "securedOperation.yaml"));
 
             var securityScheme = result.OpenApiDocument.Paths["/"].Operations[OperationType.Get].Security.First().Keys.First();
 
@@ -32,10 +33,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseOperationWithParameterWithNoLocationShouldSucceed()
+        public async Task ParseOperationWithParameterWithNoLocationShouldSucceed()
         {
             // Act
-            var operation = OpenApiModelFactory.Load<OpenApiOperation>(Path.Combine(SampleFolderPath, "operationWithParameterWithNoLocation.json"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var operation = await OpenApiModelFactory.LoadAsync<OpenApiOperation>(Path.Combine(SampleFolderPath, "operationWithParameterWithNoLocation.json"), OpenApiSpecVersion.OpenApi3_0);
             var expectedOp = new OpenApiOperation
             {
                 Tags =
@@ -72,7 +73,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             };
 
             // Assert
-            expectedOp.Should().BeEquivalentTo(operation, 
+            expectedOp.Should().BeEquivalentTo(operation.Element, 
                 options => options.Excluding(x => x.Tags[0].Reference.HostDocument)
                 .Excluding(x => x.Tags[0].Extensions));
         }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiParameterTests.cs
@@ -11,6 +11,7 @@ using Microsoft.OpenApi.Reader;
 using Xunit;
 using Microsoft.OpenApi.Reader.V3;
 using Microsoft.OpenApi.Services;
+using System.Threading.Tasks;
 
 namespace Microsoft.OpenApi.Readers.Tests.V3Tests
 {
@@ -25,16 +26,16 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParsePathParameterShouldSucceed()
+        public async Task ParsePathParameterShouldSucceed()
         {
             // Arrange
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "pathParameter.yaml"));
 
             // Act
-            var parameter = OpenApiModelFactory.Load<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0, "yaml", out _);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            parameter.Should().BeEquivalentTo(
+            parameter.Element.Should().BeEquivalentTo(
                 new OpenApiParameter
                 {
                     In = ParameterLocation.Path,
@@ -49,13 +50,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseQueryParameterShouldSucceed()
+        public async Task ParseQueryParameterShouldSucceed()
         {
             // Act
-            var parameter = OpenApiModelFactory.Load<OpenApiParameter>(Path.Combine(SampleFolderPath, "queryParameter.yaml"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "queryParameter.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            parameter.Should().BeEquivalentTo(
+            parameter.Element.Should().BeEquivalentTo(
                 new OpenApiParameter
                 {
                     In = ParameterLocation.Query,
@@ -76,13 +77,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseQueryParameterWithObjectTypeShouldSucceed()
+        public async Task ParseQueryParameterWithObjectTypeShouldSucceed()
         {
             // Act
-            var parameter = OpenApiModelFactory.Load<OpenApiParameter>(Path.Combine(SampleFolderPath, "queryParameterWithObjectType.yaml"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "queryParameterWithObjectType.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            parameter.Should().BeEquivalentTo(
+            parameter.Element.Should().BeEquivalentTo(
                 new OpenApiParameter
                 {
                     In = ParameterLocation.Query,
@@ -100,16 +101,16 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseQueryParameterWithObjectTypeAndContentShouldSucceed()
+        public async Task ParseQueryParameterWithObjectTypeAndContentShouldSucceed()
         {
             // Arrange
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "queryParameterWithObjectTypeAndContent.yaml"));
 
             // Act
-            var parameter = OpenApiModelFactory.Load<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0, "yaml", out _);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            parameter.Should().BeEquivalentTo(
+            parameter.Element.Should().BeEquivalentTo(
                 new OpenApiParameter
                 {
                     In = ParameterLocation.Query,
@@ -144,13 +145,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseHeaderParameterShouldSucceed()
+        public async Task ParseHeaderParameterShouldSucceed()
         {
             // Act
-            var parameter = OpenApiModelFactory.Load<OpenApiParameter>(Path.Combine(SampleFolderPath, "headerParameter.yaml"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "headerParameter.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            parameter.Should().BeEquivalentTo(
+            parameter.Element.Should().BeEquivalentTo(
                 new OpenApiParameter
                 {
                     In = ParameterLocation.Header,
@@ -172,13 +173,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseParameterWithNullLocationShouldSucceed()
+        public async Task ParseParameterWithNullLocationShouldSucceed()
         {
             // Act
-            var parameter = OpenApiModelFactory.Load<OpenApiParameter>(Path.Combine(SampleFolderPath, "parameterWithNullLocation.yaml"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "parameterWithNullLocation.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            parameter.Should().BeEquivalentTo(
+            parameter.Element.Should().BeEquivalentTo(
                 new OpenApiParameter
                 {
                     In = null,
@@ -193,16 +194,16 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseParameterWithNoLocationShouldSucceed()
+        public async Task ParseParameterWithNoLocationShouldSucceed()
         {
             // Arrange
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "parameterWithNoLocation.yaml"));
 
             // Act
-            var parameter = OpenApiModelFactory.Load<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0, "yaml", out _);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            parameter.Should().BeEquivalentTo(
+            parameter.Element.Should().BeEquivalentTo(
                 new OpenApiParameter
                 {
                     In = null,
@@ -217,16 +218,16 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseParameterWithUnknownLocationShouldSucceed()
+        public async Task ParseParameterWithUnknownLocationShouldSucceed()
         {
             // Arrange
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "parameterWithUnknownLocation.yaml"));
 
             // Act
-            var parameter = OpenApiModelFactory.Load<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0, "yaml", out _);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            parameter.Should().BeEquivalentTo(
+            parameter.Element.Should().BeEquivalentTo(
                 new OpenApiParameter
                 {
                     In = null,
@@ -241,13 +242,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseParameterWithExampleShouldSucceed()
+        public async Task ParseParameterWithExampleShouldSucceed()
         {
             // Act
-            var parameter = OpenApiModelFactory.Load<OpenApiParameter>(Path.Combine(SampleFolderPath, "parameterWithExample.yaml"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "parameterWithExample.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            parameter.Should().BeEquivalentTo(
+            parameter.Element.Should().BeEquivalentTo(
                 new OpenApiParameter
                 {
                     In = null,
@@ -264,13 +265,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseParameterWithExamplesShouldSucceed()
+        public async Task ParseParameterWithExamplesShouldSucceed()
         {
             // Act
-            var parameter = OpenApiModelFactory.Load<OpenApiParameter>(Path.Combine(SampleFolderPath, "parameterWithExamples.yaml"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "parameterWithExamples.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            parameter.Should().BeEquivalentTo(
+            parameter.Element.Should().BeEquivalentTo(
                 new OpenApiParameter
                 {
                     In = null,

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiResponseTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiResponseTests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
@@ -21,9 +22,9 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ResponseWithReferencedHeaderShouldReferenceComponent()
+        public async Task ResponseWithReferencedHeaderShouldReferenceComponent()
         {
-            var result = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "responseWithHeaderReference.yaml"));
+            var result = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "responseWithHeaderReference.yaml"));
 
             var response = result.OpenApiDocument.Components.Responses["Test"];
             var expected = response.Headers.First().Value;

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
@@ -16,6 +16,7 @@ using Microsoft.OpenApi.Reader.ParseNodes;
 using Microsoft.OpenApi.Reader.V3;
 using FluentAssertions.Equivalency;
 using Microsoft.OpenApi.Models.References;
+using System.Threading.Tasks;
 
 namespace Microsoft.OpenApi.Readers.Tests.V3Tests
 {
@@ -58,7 +59,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }       
 
         [Fact]
-        public void ParseExampleStringFragmentShouldSucceed()
+        public async Task ParseExampleStringFragmentShouldSucceed()
         {
             var input = @"
 { 
@@ -68,12 +69,12 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             var diagnostic = new OpenApiDiagnostic();
 
             // Act
-            var openApiAny = OpenApiModelFactory.Parse<OpenApiAny>(input, OpenApiSpecVersion.OpenApi3_0, out diagnostic);
+            var openApiAny = await OpenApiModelFactory.ParseAsync<OpenApiAny>(input, OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
             diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());
 
-            openApiAny.Should().BeEquivalentTo(new OpenApiAny(
+            openApiAny.Element.Should().BeEquivalentTo(new OpenApiAny(
                 new JsonObject
                 {
                     ["foo"] = "bar",
@@ -82,7 +83,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseEnumFragmentShouldSucceed()
+        public async Task ParseEnumFragmentShouldSucceed()
         {
             var input = @"
 [ 
@@ -92,12 +93,12 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             var diagnostic = new OpenApiDiagnostic();
 
             // Act
-            var openApiAny = OpenApiModelFactory.Parse<OpenApiAny>(input, OpenApiSpecVersion.OpenApi3_0, out diagnostic);
+            var openApiAny = await OpenApiModelFactory.ParseAsync<OpenApiAny>(input, OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
             diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());
 
-            openApiAny.Should().BeEquivalentTo(new OpenApiAny(
+            openApiAny.Element.Should().BeEquivalentTo(new OpenApiAny(
                 new JsonArray
                 {
                     "foo",
@@ -106,7 +107,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParsePathFragmentShouldSucceed()
+        public async Task ParsePathFragmentShouldSucceed()
         {
             var input = @"
 summary: externally referenced path item
@@ -118,12 +119,12 @@ get:
             var diagnostic = new OpenApiDiagnostic();
 
             // Act
-            var openApiAny = OpenApiModelFactory.Parse<OpenApiPathItem>(input, OpenApiSpecVersion.OpenApi3_0, out diagnostic, "yaml");
+            var openApiAny = await OpenApiModelFactory.ParseAsync<OpenApiPathItem>(input, OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
             diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());
 
-            openApiAny.Should().BeEquivalentTo(
+            openApiAny.Element.Should().BeEquivalentTo(
                 new OpenApiPathItem
                 {
                     Summary = "externally referenced path item",
@@ -230,10 +231,10 @@ get:
         }
 
         [Fact]
-        public void ParseBasicSchemaWithReferenceShouldSucceed()
+        public async Task ParseBasicSchemaWithReferenceShouldSucceed()
         {
             // Act
-            var result = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "basicSchemaWithReference.yaml"));
+            var result = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "basicSchemaWithReference.yaml"));
 
             // Assert
             var components = result.OpenApiDocument.Components;
@@ -300,10 +301,10 @@ get:
         }
 
         [Fact]
-        public void ParseAdvancedSchemaWithReferenceShouldSucceed()
+        public async Task ParseAdvancedSchemaWithReferenceShouldSucceed()
         {
             // Act
-            var result = OpenApiDocument.Load(Path.Combine(SampleFolderPath, "advancedSchemaWithReference.yaml"));
+            var result = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "advancedSchemaWithReference.yaml"));
 
             var expectedComponents = new OpenApiComponents
             {

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSecuritySchemeTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSecuritySchemeTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
@@ -20,13 +21,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseHttpSecuritySchemeShouldSucceed()
+        public async Task ParseHttpSecuritySchemeShouldSucceed()
         {
             // Act
-            var securityScheme = OpenApiModelFactory.Load<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "httpSecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "httpSecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            securityScheme.Should().BeEquivalentTo(
+            securityScheme.Element.Should().BeEquivalentTo(
                 new OpenApiSecurityScheme
                 {
                     Type = SecuritySchemeType.Http,
@@ -35,13 +36,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseApiKeySecuritySchemeShouldSucceed()
+        public async Task ParseApiKeySecuritySchemeShouldSucceed()
         {
             // Act
-            var securityScheme = OpenApiModelFactory.Load<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "apiKeySecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "apiKeySecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            securityScheme.Should().BeEquivalentTo(
+            securityScheme.Element.Should().BeEquivalentTo(
                 new OpenApiSecurityScheme
                 {
                     Type = SecuritySchemeType.ApiKey,
@@ -51,13 +52,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseBearerSecuritySchemeShouldSucceed()
+        public async Task ParseBearerSecuritySchemeShouldSucceed()
         {
             // Act
-            var securityScheme = OpenApiModelFactory.Load<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "bearerSecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "bearerSecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            securityScheme.Should().BeEquivalentTo(
+            securityScheme.Element.Should().BeEquivalentTo(
                 new OpenApiSecurityScheme
                 {
                     Type = SecuritySchemeType.Http,
@@ -67,13 +68,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseOAuth2SecuritySchemeShouldSucceed()
+        public async Task ParseOAuth2SecuritySchemeShouldSucceed()
         {
             // Act
-            var securityScheme = OpenApiModelFactory.Load<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "oauth2SecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "oauth2SecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            securityScheme.Should().BeEquivalentTo(
+            securityScheme.Element.Should().BeEquivalentTo(
                 new OpenApiSecurityScheme
                 {
                     Type = SecuritySchemeType.OAuth2,
@@ -93,13 +94,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseOpenIdConnectSecuritySchemeShouldSucceed()
+        public async Task ParseOpenIdConnectSecuritySchemeShouldSucceed()
         {
             // Act
-            var securityScheme = OpenApiModelFactory.Load<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "openIdConnectSecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0, out _);
+            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "openIdConnectSecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            securityScheme.Should().BeEquivalentTo(
+            securityScheme.Element.Should().BeEquivalentTo(
                 new OpenApiSecurityScheme
                 {
                     Type = SecuritySchemeType.OpenIdConnect,

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiXmlTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiXmlTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
@@ -21,13 +22,13 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         }
 
         [Fact]
-        public void ParseBasicXmlShouldSucceed()
+        public async Task ParseBasicXmlShouldSucceed()
         {
             // Act
-            var xml = OpenApiModelFactory.Load<OpenApiXml>(Resources.GetStream(Path.Combine(SampleFolderPath, "basicXml.yaml")), OpenApiSpecVersion.OpenApi3_0, "yaml", out _);
+            var xml = await OpenApiModelFactory.LoadAsync<OpenApiXml>(Resources.GetStream(Path.Combine(SampleFolderPath, "basicXml.yaml")), OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            xml.Should().BeEquivalentTo(
+            xml.Element.Should().BeEquivalentTo(
                 new OpenApiXml
                 {
                     Name = "name1",

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
@@ -1684,14 +1684,14 @@ paths: { }";
         }
 
         [Fact]
-        public void TestHashCodesForSimilarOpenApiDocuments()
+        public async Task TestHashCodesForSimilarOpenApiDocuments()
         {
             // Arrange
             var sampleFolderPath = "Models/Samples/";
 
-            var doc1 = ParseInputFile(Path.Combine(sampleFolderPath, "sampleDocument.yaml"));
-            var doc2 = ParseInputFile(Path.Combine(sampleFolderPath, "sampleDocument.yaml"));
-            var doc3 = ParseInputFile(Path.Combine(sampleFolderPath, "sampleDocumentWithWhiteSpaces.yaml"));
+            var doc1 = await ParseInputFileAsync(Path.Combine(sampleFolderPath, "sampleDocument.yaml"));
+            var doc2 = await ParseInputFileAsync(Path.Combine(sampleFolderPath, "sampleDocument.yaml"));
+            var doc3 = await ParseInputFileAsync(Path.Combine(sampleFolderPath, "sampleDocumentWithWhiteSpaces.yaml"));
 
             // Act && Assert
             /*
@@ -1702,14 +1702,13 @@ paths: { }";
             Assert.Equal(doc1.HashCode, doc3.HashCode);
         }
 
-        private static OpenApiDocument ParseInputFile(string filePath)
+        private static async Task<OpenApiDocument> ParseInputFileAsync(string filePath)
         {
             // Read in the input yaml file
             using FileStream stream = File.OpenRead(filePath);
-            var format = OpenApiModelFactory.GetFormat(filePath);
-            var openApiDoc = OpenApiDocument.Load(stream, format).OpenApiDocument;
+            var result = await OpenApiDocument.LoadAsync(stream);
 
-            return openApiDoc;
+            return result.OpenApiDocument;
         }
 
         [Fact]
@@ -1999,7 +1998,7 @@ paths: { }";
         }
 
         [Fact]
-        public void SerializeV31DocumentWithRefsInWebhooksWorks()
+        public async Task SerializeV31DocumentWithRefsInWebhooksWorks()
         {
             var expected = @"description: Returns all pets from the system that the user has access to
 operationId: findPets
@@ -2013,11 +2012,11 @@ responses:
           items:
             type: object";
 
-            var doc = OpenApiDocument.Load("Models/Samples/docWithReusableWebhooks.yaml").OpenApiDocument;
+            var result = await OpenApiDocument.LoadAsync("Models/Samples/docWithReusableWebhooks.yaml");
 
             var stringWriter = new StringWriter();
             var writer = new OpenApiYamlWriter(stringWriter, new OpenApiWriterSettings { InlineLocalReferences = true });
-            var webhooks = doc.Webhooks["pets"].Operations;
+            var webhooks = result.OpenApiDocument.Webhooks["pets"].Operations;
 
             webhooks[OperationType.Get].SerializeAsV31(writer);
             var actual = stringWriter.ToString();
@@ -2025,7 +2024,7 @@ responses:
         }
 
         [Fact]
-        public void SerializeDocWithDollarIdInDollarRefSucceeds()
+        public async Task SerializeDocWithDollarIdInDollarRefSucceeds()
         {
             var expected = @"openapi: '3.1.1'
 info:
@@ -2067,9 +2066,9 @@ components:
         radius:
           type: number
 ";
-            var doc = OpenApiDocument.Load("Models/Samples/docWithDollarId.yaml").OpenApiDocument;
+            var result = await OpenApiDocument.LoadAsync("Models/Samples/docWithDollarId.yaml");
 
-            var actual = doc.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_1);
+            var actual = result.OpenApiDocument.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_1);
             actual.MakeLineBreaksEnvironmentNeutral().Should().BeEquivalentTo(expected.MakeLineBreaksEnvironmentNeutral());
         }
     }

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiCallbackReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiCallbackReferenceTests.cs
@@ -134,8 +134,8 @@ components:
         public OpenApiCallbackReferenceTests()
         {
             OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            OpenApiDocument openApiDoc = OpenApiDocument.Parse(OpenApi, OpenApiConstants.Yaml).OpenApiDocument;
-            OpenApiDocument openApiDoc_2 = OpenApiDocument.Parse(OpenApi_2, OpenApiConstants.Yaml).OpenApiDocument;
+            OpenApiDocument openApiDoc = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult().OpenApiDocument;
+            OpenApiDocument openApiDoc_2 = OpenApiDocument.ParseAsync(OpenApi_2).GetAwaiter().GetResult().OpenApiDocument;
             openApiDoc.Workspace.AddDocumentId("https://myserver.com/beta", openApiDoc_2.BaseUri);
             openApiDoc.Workspace.RegisterComponents(openApiDoc_2);
             _externalCallbackReference = new("callbackEvent", openApiDoc, "https://myserver.com/beta");

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiCallbackReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiCallbackReferenceTests.cs
@@ -9,7 +9,6 @@ using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Readers;
-using Microsoft.OpenApi.Services;
 using Microsoft.OpenApi.Writers;
 using VerifyXunit;
 using Xunit;

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiExampleReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiExampleReferenceTests.cs
@@ -113,8 +113,8 @@ components:
         public OpenApiExampleReferenceTests()
         {
             OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            _openApiDoc = OpenApiDocument.Parse(OpenApi, OpenApiConstants.Yaml).OpenApiDocument;
-            _openApiDoc_2 = OpenApiDocument.Parse(OpenApi_2, OpenApiConstants.Yaml).OpenApiDocument;
+            _openApiDoc = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult().OpenApiDocument;
+            _openApiDoc_2 = OpenApiDocument.ParseAsync(OpenApi_2).GetAwaiter().GetResult().OpenApiDocument;
             _openApiDoc.Workspace.AddDocumentId("https://myserver.com/beta", _openApiDoc_2.BaseUri);
             _openApiDoc.Workspace.RegisterComponents(_openApiDoc_2);
 

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiHeaderReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiHeaderReferenceTests.cs
@@ -10,14 +10,13 @@ using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Readers;
 using Microsoft.OpenApi.Writers;
-using Microsoft.OpenApi.Services;
 using VerifyXunit;
 using Xunit;
 
 namespace Microsoft.OpenApi.Tests.Models.References
 {
     [Collection("DefaultSettings")]
-    public class OpenApiHeaderReferenceTests
+    public class OpenApiHeaderReferenceTests : IAsyncLifetime
     {
         // OpenApi doc with external $ref
         private const string OpenApi= @"
@@ -74,16 +73,20 @@ components:
         type: string
 ";
 
-        private readonly OpenApiHeaderReference _localHeaderReference;
-        private readonly OpenApiHeaderReference _externalHeaderReference;
-        private readonly OpenApiDocument _openApiDoc;
-        private readonly OpenApiDocument _openApiDoc_2;
+        private OpenApiHeaderReference _localHeaderReference;
+        private OpenApiHeaderReference _externalHeaderReference;
+        private OpenApiDocument _openApiDoc;
+        private OpenApiDocument _openApiDoc_2;
 
         public OpenApiHeaderReferenceTests()
         {
-            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            _openApiDoc = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult().OpenApiDocument;
-            _openApiDoc_2 = OpenApiDocument.ParseAsync(OpenApi_2).GetAwaiter().GetResult().OpenApiDocument;
+            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader()); 
+        }
+        
+        public async Task InitializeAsync()
+        {
+            _openApiDoc = (await OpenApiDocument.ParseAsync(OpenApi)).OpenApiDocument;
+            _openApiDoc_2 = (await OpenApiDocument.ParseAsync(OpenApi_2)).OpenApiDocument;
             _openApiDoc.Workspace.AddDocumentId("https://myserver.com/beta", _openApiDoc_2.BaseUri);
             _openApiDoc.Workspace.RegisterComponents(_openApiDoc_2);
 
@@ -97,6 +100,7 @@ components:
                 Description = "Location of the externally referenced post"
             };
         }
+        
 
         [Fact]
         public void HeaderReferenceResolutionWorks()
@@ -158,6 +162,11 @@ components:
 
             // Assert
             await Verifier.Verify(outputStringWriter).UseParameters(produceTerseOutput);
+        }        
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiHeaderReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiHeaderReferenceTests.cs
@@ -82,8 +82,8 @@ components:
         public OpenApiHeaderReferenceTests()
         {
             OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            _openApiDoc = OpenApiDocument.Parse(OpenApi, OpenApiConstants.Yaml).OpenApiDocument;
-            _openApiDoc_2 = OpenApiDocument.Parse(OpenApi_2, OpenApiConstants.Yaml).OpenApiDocument;
+            _openApiDoc = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult().OpenApiDocument;
+            _openApiDoc_2 = OpenApiDocument.ParseAsync(OpenApi_2).GetAwaiter().GetResult().OpenApiDocument;
             _openApiDoc.Workspace.AddDocumentId("https://myserver.com/beta", _openApiDoc_2.BaseUri);
             _openApiDoc.Workspace.RegisterComponents(_openApiDoc_2);
 

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiLinkReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiLinkReferenceTests.cs
@@ -10,14 +10,13 @@ using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Readers;
 using Microsoft.OpenApi.Writers;
-using Microsoft.OpenApi.Services;
 using VerifyXunit;
 using Xunit;
 
 namespace Microsoft.OpenApi.Tests.Models.References
 {
     [Collection("DefaultSettings")]
-    public class OpenApiLinkReferenceTests
+    public class OpenApiLinkReferenceTests : IAsyncLifetime
     {
         // OpenApi doc with external $ref
         private const string OpenApi = @"
@@ -117,16 +116,20 @@ components:
           type: string
 ";
 
-        private readonly OpenApiLinkReference _localLinkReference;
-        private readonly OpenApiLinkReference _externalLinkReference;
-        private readonly OpenApiDocument _openApiDoc;
-        private readonly OpenApiDocument _openApiDoc_2;
+        private OpenApiLinkReference _localLinkReference;
+        private OpenApiLinkReference _externalLinkReference;
+        private OpenApiDocument _openApiDoc;
+        private OpenApiDocument _openApiDoc_2;
 
         public OpenApiLinkReferenceTests()
         {
-            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            _openApiDoc = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult().OpenApiDocument;
-            _openApiDoc_2 = OpenApiDocument.ParseAsync(OpenApi_2).GetAwaiter().GetResult().OpenApiDocument;
+            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());            
+        }
+
+        public async Task InitializeAsync()
+        {
+            _openApiDoc = (await OpenApiDocument.ParseAsync(OpenApi)).OpenApiDocument;
+            _openApiDoc_2 = (await OpenApiDocument.ParseAsync(OpenApi_2)).OpenApiDocument;
             _openApiDoc.Workspace.AddDocumentId("https://myserver.com/beta", _openApiDoc_2.BaseUri);
             _openApiDoc.Workspace.RegisterComponents(_openApiDoc_2);
 
@@ -190,6 +193,11 @@ components:
 
             // Assert
             await Verifier.Verify(outputStringWriter).UseParameters(produceTerseOutput);
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiLinkReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiLinkReferenceTests.cs
@@ -125,8 +125,8 @@ components:
         public OpenApiLinkReferenceTests()
         {
             OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            _openApiDoc = OpenApiDocument.Parse(OpenApi, OpenApiConstants.Yaml).OpenApiDocument;
-            _openApiDoc_2 = OpenApiDocument.Parse(OpenApi_2, OpenApiConstants.Yaml).OpenApiDocument;
+            _openApiDoc = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult().OpenApiDocument;
+            _openApiDoc_2 = OpenApiDocument.ParseAsync(OpenApi_2).GetAwaiter().GetResult().OpenApiDocument;
             _openApiDoc.Workspace.AddDocumentId("https://myserver.com/beta", _openApiDoc_2.BaseUri);
             _openApiDoc.Workspace.RegisterComponents(_openApiDoc_2);
 

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiParameterReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiParameterReferenceTests.cs
@@ -10,14 +10,13 @@ using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Readers;
 using Microsoft.OpenApi.Writers;
-using Microsoft.OpenApi.Services;
 using VerifyXunit;
 using Xunit;
 
 namespace Microsoft.OpenApi.Tests.Models.References
 {
     [Collection("DefaultSettings")]
-    public class OpenApiParameterReferenceTests
+    public class OpenApiParameterReferenceTests : IAsyncLifetime
     {
         // OpenApi doc with external $ref
         private const string OpenApi = @"
@@ -75,16 +74,20 @@ components:
         minimum: 1
         maximum: 100
 ";
-        private readonly OpenApiParameterReference _localParameterReference;
-        private readonly OpenApiParameterReference _externalParameterReference;
-        private readonly OpenApiDocument _openApiDoc;
-        private readonly OpenApiDocument _openApiDoc_2;
+        private OpenApiParameterReference _localParameterReference;
+        private OpenApiParameterReference _externalParameterReference;
+        private OpenApiDocument _openApiDoc;
+        private OpenApiDocument _openApiDoc_2;
 
         public OpenApiParameterReferenceTests()
         {
-            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            _openApiDoc = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult().OpenApiDocument;
-            _openApiDoc_2 = OpenApiDocument.ParseAsync(OpenApi_2).GetAwaiter().GetResult().OpenApiDocument;
+            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());            
+        }
+
+        public async Task InitializeAsync()
+        {
+            _openApiDoc = (await OpenApiDocument.ParseAsync(OpenApi)).OpenApiDocument;
+            _openApiDoc_2 = (await OpenApiDocument.ParseAsync(OpenApi_2)).OpenApiDocument;
             _openApiDoc.Workspace.AddDocumentId("https://myserver.com/beta", _openApiDoc_2.BaseUri);
             _openApiDoc.Workspace.RegisterComponents(_openApiDoc_2);
 
@@ -160,6 +163,11 @@ components:
 
             // Assert
             await Verifier.Verify(outputStringWriter).UseParameters(produceTerseOutput);
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiParameterReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiParameterReferenceTests.cs
@@ -83,8 +83,8 @@ components:
         public OpenApiParameterReferenceTests()
         {
             OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            _openApiDoc = OpenApiDocument.Parse(OpenApi, OpenApiConstants.Yaml).OpenApiDocument;
-            _openApiDoc_2 = OpenApiDocument.Parse(OpenApi_2, OpenApiConstants.Yaml).OpenApiDocument;
+            _openApiDoc = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult().OpenApiDocument;
+            _openApiDoc_2 = OpenApiDocument.ParseAsync(OpenApi_2).GetAwaiter().GetResult().OpenApiDocument;
             _openApiDoc.Workspace.AddDocumentId("https://myserver.com/beta", _openApiDoc_2.BaseUri);
             _openApiDoc.Workspace.RegisterComponents(_openApiDoc_2);
 

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiPathItemReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiPathItemReferenceTests.cs
@@ -80,8 +80,8 @@ components:
         public OpenApiPathItemReferenceTests()
         {
             OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            _openApiDoc = OpenApiDocument.Parse(OpenApi, OpenApiConstants.Yaml).OpenApiDocument;
-            _openApiDoc_2 = OpenApiDocument.Parse(OpenApi_2, OpenApiConstants.Yaml).OpenApiDocument;
+            _openApiDoc = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult().OpenApiDocument;
+            _openApiDoc_2 = OpenApiDocument.ParseAsync(OpenApi_2).GetAwaiter().GetResult().OpenApiDocument;
             _openApiDoc.Workspace.AddDocumentId("https://myserver.com/beta", _openApiDoc_2.BaseUri);
             _openApiDoc.Workspace.RegisterComponents(_openApiDoc_2);
             _openApiDoc_2.Workspace.RegisterComponents(_openApiDoc_2);

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiPathItemReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiPathItemReferenceTests.cs
@@ -10,14 +10,13 @@ using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Readers;
 using Microsoft.OpenApi.Writers;
-using Microsoft.OpenApi.Services;
 using VerifyXunit;
 using Xunit;
 
 namespace Microsoft.OpenApi.Tests.Models.References
 {
     [Collection("DefaultSettings")]
-    public class OpenApiPathItemReferenceTests
+    public class OpenApiPathItemReferenceTests : IAsyncLifetime
     {
         private const string OpenApi = @"
 openapi: 3.1.1
@@ -72,16 +71,20 @@ components:
             description: User deleted successfully
 ";
 
-        private readonly OpenApiPathItemReference _localPathItemReference;
-        private readonly OpenApiPathItemReference _externalPathItemReference;
-        private readonly OpenApiDocument _openApiDoc;
-        private readonly OpenApiDocument _openApiDoc_2;
+        private OpenApiPathItemReference _localPathItemReference;
+        private OpenApiPathItemReference _externalPathItemReference;
+        private OpenApiDocument _openApiDoc;
+        private OpenApiDocument _openApiDoc_2;
 
         public OpenApiPathItemReferenceTests()
         {
-            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            _openApiDoc = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult().OpenApiDocument;
-            _openApiDoc_2 = OpenApiDocument.ParseAsync(OpenApi_2).GetAwaiter().GetResult().OpenApiDocument;
+            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());            
+        }
+
+        public async Task InitializeAsync()
+        {
+            _openApiDoc = (await OpenApiDocument.ParseAsync(OpenApi)).OpenApiDocument;
+            _openApiDoc_2 = (await OpenApiDocument.ParseAsync(OpenApi_2)).OpenApiDocument;
             _openApiDoc.Workspace.AddDocumentId("https://myserver.com/beta", _openApiDoc_2.BaseUri);
             _openApiDoc.Workspace.RegisterComponents(_openApiDoc_2);
             _openApiDoc_2.Workspace.RegisterComponents(_openApiDoc_2);
@@ -134,6 +137,11 @@ components:
 
             // Assert
             await Verifier.Verify(outputStringWriter).UseParameters(produceTerseOutput);
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiRequestBodyReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiRequestBodyReferenceTests.cs
@@ -88,8 +88,8 @@ components:
         public OpenApiRequestBodyReferenceTests()
         {
             OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            _openApiDoc = OpenApiDocument.Parse(OpenApi, OpenApiConstants.Yaml).OpenApiDocument;
-            _openApiDoc_2 = OpenApiDocument.Parse(OpenApi_2, OpenApiConstants.Yaml).OpenApiDocument;
+            _openApiDoc = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult().OpenApiDocument;
+            _openApiDoc_2 = OpenApiDocument.ParseAsync(OpenApi_2).GetAwaiter().GetResult().OpenApiDocument;
             _openApiDoc.Workspace.AddDocumentId("https://myserver.com/beta", _openApiDoc_2.BaseUri);
             _openApiDoc.Workspace.RegisterComponents(_openApiDoc_2);
 

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiResponseReferenceTest.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiResponseReferenceTest.cs
@@ -71,8 +71,8 @@ components:
         public OpenApiResponseReferenceTest()
         {
             OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            _openApiDoc = OpenApiDocument.Parse(OpenApi, OpenApiConstants.Yaml).OpenApiDocument;
-            _openApiDoc_2 = OpenApiDocument.Parse(OpenApi_2, OpenApiConstants.Yaml).OpenApiDocument;
+            _openApiDoc = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult().OpenApiDocument;
+            _openApiDoc_2 = OpenApiDocument.ParseAsync(OpenApi_2).GetAwaiter().GetResult().OpenApiDocument;
             _openApiDoc.Workspace.AddDocumentId("https://myserver.com/beta", _openApiDoc_2.BaseUri);
             _openApiDoc.Workspace.RegisterComponents(_openApiDoc_2);
 

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiResponseReferenceTest.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiResponseReferenceTest.cs
@@ -10,14 +10,13 @@ using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Readers;
 using Microsoft.OpenApi.Writers;
-using Microsoft.OpenApi.Services;
 using VerifyXunit;
 using Xunit;
 
 namespace Microsoft.OpenApi.Tests.Models.References
 {
     [Collection("DefaultSettings")]
-    public class OpenApiResponseReferenceTest
+    public class OpenApiResponseReferenceTest : IAsyncLifetime
     {
         private const string OpenApi = @"
 openapi: 3.0.0
@@ -63,16 +62,20 @@ components:
           type: string
 ";
 
-        private readonly OpenApiResponseReference _localResponseReference;
-        private readonly OpenApiResponseReference _externalResponseReference;
-        private readonly OpenApiDocument _openApiDoc;
-        private readonly OpenApiDocument _openApiDoc_2;
+        private OpenApiResponseReference _localResponseReference;
+        private OpenApiResponseReference _externalResponseReference;
+        private OpenApiDocument _openApiDoc;
+        private OpenApiDocument _openApiDoc_2;
 
         public OpenApiResponseReferenceTest()
         {
-            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            _openApiDoc = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult().OpenApiDocument;
-            _openApiDoc_2 = OpenApiDocument.ParseAsync(OpenApi_2).GetAwaiter().GetResult().OpenApiDocument;
+            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());            
+        }
+
+        public async Task InitializeAsync()
+        {
+            _openApiDoc = (await OpenApiDocument.ParseAsync(OpenApi)).OpenApiDocument;
+            _openApiDoc_2 = (await OpenApiDocument.ParseAsync(OpenApi_2)).OpenApiDocument;
             _openApiDoc.Workspace.AddDocumentId("https://myserver.com/beta", _openApiDoc_2.BaseUri);
             _openApiDoc.Workspace.RegisterComponents(_openApiDoc_2);
 
@@ -136,6 +139,11 @@ components:
 
             // Assert
             await Verifier.Verify(outputStringWriter).UseParameters(produceTerseOutput);
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiSecuritySchemeReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiSecuritySchemeReferenceTests.cs
@@ -44,7 +44,7 @@ components:
         public OpenApiSecuritySchemeReferenceTests()
         {
             OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            var result = OpenApiDocument.Parse(OpenApi, "yaml");
+            var result = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult();
             _openApiSecuritySchemeReference = new("mySecurityScheme", result.OpenApiDocument);
         }
 

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiSecuritySchemeReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiSecuritySchemeReferenceTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace Microsoft.OpenApi.Tests.Models.References
 {
     [Collection("DefaultSettings")]
-    public class OpenApiSecuritySchemeReferenceTests
+    public class OpenApiSecuritySchemeReferenceTests :  IAsyncLifetime
     {
         private const string OpenApi = @"
 openapi: 3.0.3
@@ -39,12 +39,16 @@ components:
       in: header
 ";
 
-        readonly OpenApiSecuritySchemeReference _openApiSecuritySchemeReference;
+        OpenApiSecuritySchemeReference _openApiSecuritySchemeReference;
 
         public OpenApiSecuritySchemeReferenceTests()
         {
             OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            var result = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult();
+        }
+
+        public async Task InitializeAsync()
+        {
+            var result = (await OpenApiDocument.ParseAsync(OpenApi));
             _openApiSecuritySchemeReference = new("mySecurityScheme", result.OpenApiDocument);
         }
 
@@ -88,6 +92,10 @@ components:
 
             // Assert
             await Verifier.Verify(outputStringWriter).UseParameters(produceTerseOutput);
+        }
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiTagReferenceTest.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiTagReferenceTest.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace Microsoft.OpenApi.Tests.Models.References
 {
     [Collection("DefaultSettings")]
-    public class OpenApiTagReferenceTest
+    public class OpenApiTagReferenceTest : IAsyncLifetime
     {
         private const string OpenApi = @"openapi: 3.0.3
 info:
@@ -58,12 +58,16 @@ tags:
     description: Operations about users.
 ";
 
-        readonly OpenApiTagReference _openApiTagReference;
+        OpenApiTagReference _openApiTagReference;
 
         public OpenApiTagReferenceTest()
         {
-            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            var result = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult();
+            OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());            
+        }
+
+        public async Task InitializeAsync()
+        {
+            var result = (await OpenApiDocument.ParseAsync(OpenApi));
             _openApiTagReference = new("user", result.OpenApiDocument)
             {
                 Description = "Users operations"
@@ -110,6 +114,10 @@ tags:
 
             // Assert
             await Verifier.Verify(outputStringWriter).UseParameters(produceTerseOutput);
+        }
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiTagReferenceTest.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiTagReferenceTest.cs
@@ -63,7 +63,7 @@ tags:
         public OpenApiTagReferenceTest()
         {
             OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
-            var result = OpenApiDocument.Parse(OpenApi, "yaml");
+            var result = OpenApiDocument.ParseAsync(OpenApi).GetAwaiter().GetResult();
             _openApiTagReference = new("user", result.OpenApiDocument)
             {
                 Description = "Users operations"

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -220,9 +220,9 @@ namespace Microsoft.OpenApi.Interfaces
     {
         System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.IO.TextReader input, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.Text.Json.Nodes.JsonNode jsonNode, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> ReadFragmentAsync<T>(System.IO.TextReader input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        Microsoft.OpenApi.Reader.ReadFragmentResult<T> ReadFragment<T>(System.Text.Json.Nodes.JsonNode input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement;
-        System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> ReadFragmentAsync<T>(System.Text.Json.Nodes.JsonNode input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> ReadFragmentAsync<T>(System.IO.TextReader input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken token = default)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement;
     }
     public interface IOpenApiReferenceable : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
@@ -1310,14 +1310,14 @@ namespace Microsoft.OpenApi.Reader
         public OpenApiJsonReader() { }
         public System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.IO.TextReader input, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.Text.Json.Nodes.JsonNode jsonNode, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> ReadFragmentAsync<T>(System.IO.TextReader input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        public Microsoft.OpenApi.Reader.ReadFragmentResult<T> ReadFragment<T>(System.Text.Json.Nodes.JsonNode input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
-        public System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> ReadFragmentAsync<T>(System.Text.Json.Nodes.JsonNode input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        public System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> ReadFragmentAsync<T>(System.IO.TextReader input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken token = default)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
     }
     public static class OpenApiModelFactory
     {
-        public static System.Threading.Tasks.Task<string> GetFormatAsync(string url) { }
+        public static System.Threading.Tasks.Task<string> GetFormatAsync(string url, System.Threading.CancellationToken token = default) { }
         public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(string url, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(System.IO.Stream input, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(System.IO.TextReader input, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default) { }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -219,10 +219,10 @@ namespace Microsoft.OpenApi.Interfaces
     public interface IOpenApiReader
     {
         System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.IO.TextReader input, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.Text.Json.Nodes.JsonNode jsonNode, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings, string format = null, System.Threading.CancellationToken cancellationToken = default);
-        T ReadFragment<T>(System.IO.TextReader input, Microsoft.OpenApi.OpenApiSpecVersion version, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.Text.Json.Nodes.JsonNode jsonNode, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> ReadFragmentAsync<T>(System.IO.TextReader input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement;
-        T ReadFragment<T>(System.Text.Json.Nodes.JsonNode input, Microsoft.OpenApi.OpenApiSpecVersion version, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> ReadFragmentAsync<T>(System.Text.Json.Nodes.JsonNode input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement;
     }
     public interface IOpenApiReferenceable : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
@@ -575,13 +575,10 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SetReferenceHostDocument() { }
         public static string GenerateHashValue(Microsoft.OpenApi.Models.OpenApiDocument doc) { }
-        public static Microsoft.OpenApi.Reader.ReadResult Load(string url, Microsoft.OpenApi.Reader.OpenApiReaderSettings? settings = null) { }
-        public static Microsoft.OpenApi.Reader.ReadResult Load(System.IO.Stream stream, string format, Microsoft.OpenApi.Reader.OpenApiReaderSettings? settings = null) { }
-        public static Microsoft.OpenApi.Reader.ReadResult Load(System.IO.TextReader input, string format, Microsoft.OpenApi.Reader.OpenApiReaderSettings? settings = null) { }
-        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(string url, Microsoft.OpenApi.Reader.OpenApiReaderSettings? settings = null) { }
-        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(System.IO.TextReader input, string format, Microsoft.OpenApi.Reader.OpenApiReaderSettings? settings = null) { }
-        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(System.IO.Stream stream, string format, Microsoft.OpenApi.Reader.OpenApiReaderSettings? settings = null, System.Threading.CancellationToken cancellationToken = default) { }
-        public static Microsoft.OpenApi.Reader.ReadResult Parse(string input, string? format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings? settings = null) { }
+        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(System.IO.TextReader input, Microsoft.OpenApi.Reader.OpenApiReaderSettings? settings = null) { }
+        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(System.IO.Stream stream, Microsoft.OpenApi.Reader.OpenApiReaderSettings? settings = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(string url, Microsoft.OpenApi.Reader.OpenApiReaderSettings? settings = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ParseAsync(string input, Microsoft.OpenApi.Reader.OpenApiReaderSettings? settings = null) { }
     }
     public class OpenApiEncoding : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
@@ -1312,31 +1309,27 @@ namespace Microsoft.OpenApi.Reader
     {
         public OpenApiJsonReader() { }
         public System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.IO.TextReader input, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default) { }
-        public System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.Text.Json.Nodes.JsonNode jsonNode, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings, string format = null, System.Threading.CancellationToken cancellationToken = default) { }
-        public T ReadFragment<T>(System.IO.TextReader input, Microsoft.OpenApi.OpenApiSpecVersion version, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        public System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.Text.Json.Nodes.JsonNode jsonNode, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> ReadFragmentAsync<T>(System.IO.TextReader input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
-        public T ReadFragment<T>(System.Text.Json.Nodes.JsonNode input, Microsoft.OpenApi.OpenApiSpecVersion version, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        public System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> ReadFragmentAsync<T>(System.Text.Json.Nodes.JsonNode input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
     }
     public static class OpenApiModelFactory
     {
-        public static string GetFormat(string url) { }
-        public static Microsoft.OpenApi.Reader.ReadResult Load(string url, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null) { }
-        public static Microsoft.OpenApi.Reader.ReadResult Load(System.IO.Stream stream, string format, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null) { }
-        public static Microsoft.OpenApi.Reader.ReadResult Load(System.IO.TextReader input, string format, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null) { }
-        public static T Load<T>(string url, Microsoft.OpenApi.OpenApiSpecVersion version, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        public static System.Threading.Tasks.Task<string> GetFormatAsync(string url) { }
+        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(string url, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(System.IO.Stream input, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(System.IO.TextReader input, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> LoadAsync<T>(System.IO.Stream input, Microsoft.OpenApi.OpenApiSpecVersion version, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
-        public static T Load<T>(System.IO.Stream input, Microsoft.OpenApi.OpenApiSpecVersion version, string format, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> LoadAsync<T>(System.IO.TextReader input, Microsoft.OpenApi.OpenApiSpecVersion version, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
-        public static T Load<T>(System.IO.TextReader input, Microsoft.OpenApi.OpenApiSpecVersion version, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, string format, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> LoadAsync<T>(string url, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
-        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(string url, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null) { }
-        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(System.IO.Stream input, string format, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default) { }
-        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(System.IO.TextReader input, string format, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default) { }
-        public static Microsoft.OpenApi.Reader.ReadResult Parse(string input, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null) { }
-        public static T Parse<T>(string input, Microsoft.OpenApi.OpenApiSpecVersion version, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ParseAsync(string input, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null) { }
+        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadFragmentResult<T>> ParseAsync<T>(string input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
-        public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ParseAsync(string input, System.IO.StringReader reader, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null) { }
     }
     public static class OpenApiReaderRegistry
     {
@@ -1380,6 +1373,13 @@ namespace Microsoft.OpenApi.Reader
         public bool PushLoop(string loopId, string key) { }
         public void SetTempStorage(string key, object value, object scope = null) { }
         public void StartObject(string objectName) { }
+    }
+    public class ReadFragmentResult<T>
+        where T : Microsoft.OpenApi.Interfaces.IOpenApiElement
+    {
+        public ReadFragmentResult() { }
+        public T Element { get; set; }
+        public Microsoft.OpenApi.Reader.OpenApiDiagnostic OpenApiDiagnostic { get; set; }
     }
     public class ReadResult
     {


### PR DESCRIPTION
This PR:
- Adds logic for inspecting the first character of the stream we receive during document loading to know whether its in JSON or YAML. This helps avoid a regression in functionality where users are required to pass the format of the document when loading an OpenAPI document
- Replaces sync methods with async ones to prevent deadlocks
- Passes a cancellation token to `OpenApiModelFactory.GetStreamAsync` to allow for cancellation of tasks/requests
- Updates tests with new loading pattern

Fixes #1917, #1918