### PR TITLE
chore/linting

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/StatsVisitor.cs
+++ b/src/Microsoft.OpenApi.Hidi/StatsVisitor.cs
@@ -61,7 +61,7 @@ namespace Microsoft.OpenApi.Hidi
 
         public int LinkCount { get; set; }
 
-        public override void Visit(OpenApiLink operation)
+        public override void Visit(OpenApiLink link)
         {
             LinkCount++;
         }

--- a/src/Microsoft.OpenApi.Workbench/StatsVisitor.cs
+++ b/src/Microsoft.OpenApi.Workbench/StatsVisitor.cs
@@ -61,7 +61,7 @@ namespace Microsoft.OpenApi.Workbench
 
         public int LinkCount { get; set; }
 
-        public override void Visit(OpenApiLink operation)
+        public override void Visit(OpenApiLink link)
         {
             LinkCount++;
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
@@ -18,12 +18,16 @@ namespace Microsoft.OpenApi.Models
         where T : IOpenApiSerializable
     {
         /// <summary>
+        /// Parameterless constructor
+        /// </summary>
+        protected OpenApiExtensibleDictionary():this(null) { }
+        /// <summary>
         /// Initializes a copy of <see cref="OpenApiExtensibleDictionary{T}"/> class.
         /// </summary>
         /// <param name="dictionary">The generic dictionary.</param>
         /// <param name="extensions">The dictionary of <see cref="IOpenApiExtension"/>.</param>
         protected OpenApiExtensibleDictionary(
-            Dictionary<string, T> dictionary = null,
+            Dictionary<string, T> dictionary,
             IDictionary<string, IOpenApiExtension> extensions = null) : base(dictionary is null ? [] : dictionary)
         {
             Extensions = extensions != null ? new Dictionary<string, IOpenApiExtension>(extensions) : [];

--- a/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
@@ -18,18 +18,13 @@ namespace Microsoft.OpenApi.Models
         where T : IOpenApiSerializable
     {
         /// <summary>
-        /// Parameterless constructor
-        /// </summary>
-        protected OpenApiExtensibleDictionary() { }
-
-        /// <summary>
         /// Initializes a copy of <see cref="OpenApiExtensibleDictionary{T}"/> class.
         /// </summary>
         /// <param name="dictionary">The generic dictionary.</param>
         /// <param name="extensions">The dictionary of <see cref="IOpenApiExtension"/>.</param>
         protected OpenApiExtensibleDictionary(
             Dictionary<string, T> dictionary = null,
-            IDictionary<string, IOpenApiExtension> extensions = null) : base(dictionary)
+            IDictionary<string, IOpenApiExtension> extensions = null) : base(dictionary is null ? [] : dictionary)
         {
             Extensions = extensions != null ? new Dictionary<string, IOpenApiExtension>(extensions) : null;
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
@@ -26,13 +26,13 @@ namespace Microsoft.OpenApi.Models
             Dictionary<string, T> dictionary = null,
             IDictionary<string, IOpenApiExtension> extensions = null) : base(dictionary is null ? [] : dictionary)
         {
-            Extensions = extensions != null ? new Dictionary<string, IOpenApiExtension>(extensions) : null;
+            Extensions = extensions != null ? new Dictionary<string, IOpenApiExtension>(extensions) : [];
         }
 
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public IDictionary<string, IOpenApiExtension> Extensions { get; set; } = new Dictionary<string, IOpenApiExtension>();
+        public IDictionary<string, IOpenApiExtension> Extensions { get; set; }
 
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Services/OpenApiReferenceError.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiReferenceError.cs
@@ -11,7 +11,10 @@ namespace Microsoft.OpenApi.Services
     /// </summary>
     public class OpenApiReferenceError : OpenApiError
     {
-        private OpenApiReference _reference;
+        /// <summary>
+        /// The reference that caused the error.
+        /// </summary>
+        public readonly OpenApiReference Reference;
         /// <summary>
         /// Initializes the <see cref="OpenApiError"/> class using the message and pointer from the given exception.
         /// </summary>
@@ -26,7 +29,7 @@ namespace Microsoft.OpenApi.Services
         /// <param name="message"></param>
         public OpenApiReferenceError(OpenApiReference reference, string message) : base("", message)
         {
-            _reference = reference;
+            Reference = reference;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
+++ b/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
@@ -67,219 +67,108 @@ namespace Microsoft.OpenApi.Validations
             _warnings.Add(warning);
         }
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiDocument"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiDocument item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiDocument doc) => Validate(doc);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiInfo"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiInfo item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiInfo info) => Validate(info);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiContact"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiContact item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiContact contact) => Validate(contact);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiComponents"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiComponents item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiComponents components) => Validate(components);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiHeader"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiHeader item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiHeader header) => Validate(header);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiResponse"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiResponse item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiResponse response) => Validate(response);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiMediaType"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiMediaType item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiMediaType mediaType) => Validate(mediaType);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiResponses"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiResponses item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiResponses response) => Validate(response);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiExternalDocs"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiExternalDocs item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiExternalDocs externalDocs) => Validate(externalDocs);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiLicense"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiLicense item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiLicense license) => Validate(license);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiOAuthFlow"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiOAuthFlow item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiOAuthFlow openApiOAuthFlow) => Validate(openApiOAuthFlow);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiTag"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiTag item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiTag tag) => Validate(tag);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiParameter"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiParameter item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiParameter parameter) => Validate(parameter);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiSchema"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiSchema item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiSchema schema) => Validate(schema);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiServer"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiServer item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiServer server) => Validate(server);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiEncoding"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiEncoding item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiEncoding encoding) => Validate(encoding);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="OpenApiCallback"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiCallback item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiCallback callback) => Validate(callback);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="IOpenApiExtensible"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(IOpenApiExtensible item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(IOpenApiExtensible openApiExtensible) => Validate(openApiExtensible);
 
-        /// <summary>
-        /// Execute validation rules against an <see cref="IOpenApiExtension"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(IOpenApiExtension item) => Validate(item, item.GetType());
+        /// <inheritdoc/>
+        public override void Visit(IOpenApiExtension openApiExtension) => Validate(openApiExtension, openApiExtension.GetType());
 
-        /// <summary>
-        /// Execute validation rules against a list of <see cref="OpenApiExample"/>
-        /// </summary>
-        /// <param name="items">The object to be validated</param>
-        public override void Visit(IList<OpenApiExample> items) => Validate(items, items.GetType());
+        /// <inheritdoc/>
+        public override void Visit(IList<OpenApiExample> example) => Validate(example, example.GetType());
 
-        /// <summary>
-        /// Execute validation rules against a <see cref="OpenApiPathItem"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiPathItem item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiPathItem pathItem) => Validate(pathItem);
 
-        /// <summary>
-        /// Execute validation rules against a <see cref="OpenApiServerVariable"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiServerVariable item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiServerVariable serverVariable) => Validate(serverVariable);
 
-        /// <summary>
-        /// Execute validation rules against a <see cref="OpenApiSecurityScheme"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiSecurityScheme item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiSecurityScheme securityScheme) => Validate(securityScheme);
 
-        /// <summary>
-        /// Execute validation rules against a <see cref="OpenApiSecurityRequirement"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiSecurityRequirement item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiSecurityRequirement securityRequirement) => Validate(securityRequirement);
 
-        /// <summary>
-        /// Execute validation rules against a <see cref="OpenApiRequestBody"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiRequestBody item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiRequestBody requestBody) => Validate(requestBody);
 
-        /// <summary>
-        /// Execute validation rules against a <see cref="OpenApiPaths"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiPaths item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiPaths paths) => Validate(paths);
 
-        /// <summary>
-        /// Execute validation rules against a <see cref="OpenApiLink"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiLink item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiLink link) => Validate(link);
 
-        /// <summary>
-        /// Execute validation rules against a <see cref="OpenApiExample"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiExample item) => Validate(item);
+        /// <inheritdoc/>
+        public override void Visit(OpenApiExample example) => Validate(example);
 
-        /// <summary>
-        /// Execute validation rules against a <see cref="OpenApiOperation"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(OpenApiOperation item) => Validate(item);
-        /// <summary>
-        /// Execute validation rules against a <see cref="IDictionary{OperationType, OpenApiOperation}"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(IDictionary<OperationType, OpenApiOperation> item) => Validate(item, item.GetType());
-        /// <summary>
-        /// Execute validation rules against a <see cref="IDictionary{String, OpenApiHeader}"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(IDictionary<string, OpenApiHeader> item) => Validate(item, item.GetType());
-        /// <summary>
-        /// Execute validation rules against a <see cref="IDictionary{String, OpenApiCallback}"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(IDictionary<string, OpenApiCallback> item) => Validate(item, item.GetType());
-        /// <summary>
-        /// Execute validation rules against a <see cref="IDictionary{String, OpenApiMediaType}"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(IDictionary<string, OpenApiMediaType> item) => Validate(item, item.GetType());
-        /// <summary>
-        /// Execute validation rules against a <see cref="IDictionary{String, OpenApiExample}"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(IDictionary<string, OpenApiExample> item) => Validate(item, item.GetType());
-        /// <summary>
-        /// Execute validation rules against a <see cref="IDictionary{String, OpenApiLink}"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(IDictionary<string, OpenApiLink> item) => Validate(item, item.GetType());
-        /// <summary>
-        /// Execute validation rules against a <see cref="IDictionary{String, OpenApiServerVariable}"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(IDictionary<string, OpenApiServerVariable> item) => Validate(item, item.GetType());
-        /// <summary>
-        /// Execute validation rules against a <see cref="IDictionary{String, OpenApiEncoding}"/>
-        /// </summary>
-        /// <param name="item">The object to be validated</param>
-        public override void Visit(IDictionary<string, OpenApiEncoding> item) => Validate(item, item.GetType());
+        /// <inheritdoc/>
+        public override void Visit(OpenApiOperation operation) => Validate(operation);
+        /// <inheritdoc/>
+        public override void Visit(IDictionary<OperationType, OpenApiOperation> operations) => Validate(operations, operations.GetType());
+        /// <inheritdoc/>
+        public override void Visit(IDictionary<string, OpenApiHeader> headers) => Validate(headers, headers.GetType());
+        /// <inheritdoc/>
+        public override void Visit(IDictionary<string, OpenApiCallback> callbacks) => Validate(callbacks, callbacks.GetType());
+        /// <inheritdoc/>
+        public override void Visit(IDictionary<string, OpenApiMediaType> content) => Validate(content, content.GetType());
+        /// <inheritdoc/>
+        public override void Visit(IDictionary<string, OpenApiExample> examples) => Validate(examples, examples.GetType());
+        /// <inheritdoc/>
+        public override void Visit(IDictionary<string, OpenApiLink> links) => Validate(links, links.GetType());
+        /// <inheritdoc/>
+        public override void Visit(IDictionary<string, OpenApiServerVariable> serverVariables) => Validate(serverVariables, serverVariables.GetType());
+        /// <inheritdoc/>
+        public override void Visit(IDictionary<string, OpenApiEncoding> encodings) => Validate(encodings, encodings.GetType());
 
         private void Validate<T>(T item)
         {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiComponentsRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiComponentsRules.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OpenApi.Validations.Rules
         /// <summary>
         /// The key regex.
         /// </summary>
-        public static Regex KeyRegex = new(@"^[a-zA-Z0-9\.\-_]+$");
+        public static readonly Regex KeyRegex = new(@"^[a-zA-Z0-9\.\-_]+$");
 
         /// <summary>
         /// All the fixed fields declared above are objects

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiComponentsRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiComponentsRules.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OpenApi.Validations.Rules
         /// <summary>
         /// The key regex.
         /// </summary>
-        public static readonly Regex KeyRegex = new(@"^[a-zA-Z0-9\.\-_]+$");
+        internal static readonly Regex KeyRegex = new(@"^[a-zA-Z0-9\.\-_]+$");
 
         /// <summary>
         /// All the fixed fields declared above are objects

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiExtensionRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiExtensionRules.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Linq;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Properties;
 
@@ -21,13 +22,10 @@ namespace Microsoft.OpenApi.Validations.Rules
                 (context, item) =>
                 {
                     context.Enter("extensions");
-                    foreach (var extensible in item.Extensions)
+                    foreach (var extensible in item.Extensions.Keys.Where(static x => !x.StartsWith("x-", StringComparison.OrdinalIgnoreCase)))
                     {
-                        if (!extensible.Key.StartsWith("x-"))
-                        {
-                            context.CreateError(nameof(ExtensionNameMustStartWithXDash),
-                                String.Format(SRResource.Validation_ExtensionNameMustBeginWithXDash, extensible.Key, context.PathString));
-                        }
+                        context.CreateError(nameof(ExtensionNameMustStartWithXDash),
+                            string.Format(SRResource.Validation_ExtensionNameMustBeginWithXDash, extensible, context.PathString));
                     }
                     context.Exit();
                 });

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -1671,7 +1671,6 @@ namespace Microsoft.OpenApi.Validations.Rules
     [Microsoft.OpenApi.Validations.Rules.OpenApiRule]
     public static class OpenApiComponentsRules
     {
-        public static readonly System.Text.RegularExpressions.Regex KeyRegex;
         public static Microsoft.OpenApi.Validations.ValidationRule<Microsoft.OpenApi.Models.OpenApiComponents> KeyMustBeRegularExpression { get; }
     }
     [Microsoft.OpenApi.Validations.Rules.OpenApiRule]

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -629,7 +629,7 @@ namespace Microsoft.OpenApi.Models
         where T : Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
         protected OpenApiExtensibleDictionary() { }
-        protected OpenApiExtensibleDictionary(System.Collections.Generic.Dictionary<string, T> dictionary = null, System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> extensions = null) { }
+        protected OpenApiExtensibleDictionary(System.Collections.Generic.Dictionary<string, T> dictionary, System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> extensions = null) { }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; set; }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1452,6 +1452,7 @@ namespace Microsoft.OpenApi.Services
     }
     public class OpenApiReferenceError : Microsoft.OpenApi.Models.OpenApiError
     {
+        public readonly Microsoft.OpenApi.Models.OpenApiReference Reference;
         public OpenApiReferenceError(Microsoft.OpenApi.Exceptions.OpenApiException exception) { }
         public OpenApiReferenceError(Microsoft.OpenApi.Models.OpenApiReference reference, string message) { }
     }
@@ -1577,43 +1578,43 @@ namespace Microsoft.OpenApi.Validations
         public System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Validations.OpenApiValidatorWarning> Warnings { get; }
         public void AddError(Microsoft.OpenApi.Validations.OpenApiValidatorError error) { }
         public void AddWarning(Microsoft.OpenApi.Validations.OpenApiValidatorWarning warning) { }
-        public override void Visit(Microsoft.OpenApi.Interfaces.IOpenApiExtensible item) { }
-        public override void Visit(Microsoft.OpenApi.Interfaces.IOpenApiExtension item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiCallback item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiComponents item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiContact item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiDocument item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiEncoding item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiExample item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiExternalDocs item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiHeader item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiInfo item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiLicense item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiLink item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiMediaType item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiOAuthFlow item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiOperation item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiParameter item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiPathItem item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiPaths item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiRequestBody item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiResponse item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiResponses item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiSchema item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiSecurityRequirement item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiSecurityScheme item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiServer item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiServerVariable item) { }
-        public override void Visit(Microsoft.OpenApi.Models.OpenApiTag item) { }
-        public override void Visit(System.Collections.Generic.IDictionary<Microsoft.OpenApi.Models.OperationType, Microsoft.OpenApi.Models.OpenApiOperation> item) { }
-        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiCallback> item) { }
-        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiEncoding> item) { }
-        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiExample> item) { }
-        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiHeader> item) { }
-        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiLink> item) { }
-        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> item) { }
-        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiServerVariable> item) { }
-        public override void Visit(System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiExample> items) { }
+        public override void Visit(Microsoft.OpenApi.Interfaces.IOpenApiExtensible openApiExtensible) { }
+        public override void Visit(Microsoft.OpenApi.Interfaces.IOpenApiExtension openApiExtension) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiCallback callback) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiComponents components) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiContact contact) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiDocument doc) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiEncoding encoding) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiExample example) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiExternalDocs externalDocs) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiHeader header) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiInfo info) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiLicense license) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiLink link) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiMediaType mediaType) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiOAuthFlow openApiOAuthFlow) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiOperation operation) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiParameter parameter) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiPathItem pathItem) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiPaths paths) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiRequestBody requestBody) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiResponse response) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiResponses response) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiSchema schema) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiSecurityRequirement securityRequirement) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiSecurityScheme securityScheme) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiServer server) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiServerVariable serverVariable) { }
+        public override void Visit(Microsoft.OpenApi.Models.OpenApiTag tag) { }
+        public override void Visit(System.Collections.Generic.IDictionary<Microsoft.OpenApi.Models.OperationType, Microsoft.OpenApi.Models.OpenApiOperation> operations) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiCallback> callbacks) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiEncoding> encodings) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiExample> examples) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiHeader> headers) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiLink> links) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> content) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiServerVariable> serverVariables) { }
+        public override void Visit(System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiExample> example) { }
     }
     public class OpenApiValidatorError : Microsoft.OpenApi.Models.OpenApiError
     {
@@ -1670,7 +1671,7 @@ namespace Microsoft.OpenApi.Validations.Rules
     [Microsoft.OpenApi.Validations.Rules.OpenApiRule]
     public static class OpenApiComponentsRules
     {
-        public static System.Text.RegularExpressions.Regex KeyRegex;
+        public static readonly System.Text.RegularExpressions.Regex KeyRegex;
         public static Microsoft.OpenApi.Validations.ValidationRule<Microsoft.OpenApi.Models.OpenApiComponents> KeyMustBeRegularExpression { get; }
     }
     [Microsoft.OpenApi.Validations.Rules.OpenApiRule]


### PR DESCRIPTION
- **chore: exposes unused property so consumers can read the information**
- **chore: aligns parameter names with base definition**
- **chore: aligns parameter names**
- **chore: linting**
- **chore: removes conflicting overload**
