### PR TITLE
fix: specifies encoding for net fx

### DIFF
--- a/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+++ b/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;net6.0;</TargetFrameworks>
+        <!-- net6.0 target is present because of the conditional build in OpenApiYamlReader.Read -->
         <LangVersion>latest</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Version>2.0.0-preview3</Version>

--- a/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
@@ -12,6 +12,7 @@ using SharpYaml.Serialization;
 using System.Linq;
 using Microsoft.OpenApi.Models;
 using System;
+using System.Text;
 
 namespace Microsoft.OpenApi.Readers
 {
@@ -53,7 +54,13 @@ namespace Microsoft.OpenApi.Readers
             // Parse the YAML text in the stream into a sequence of JsonNodes
             try
             {
+#if NET
+// this represents net core, net5 and up
                 using var stream = new StreamReader(input, default, true, -1, settings.LeaveStreamOpen);
+#else
+// the implementation differs and results in a null reference exception in NETFX
+                using var stream = new StreamReader(input, Encoding.UTF8, true, 4096, settings.LeaveStreamOpen);
+#endif
                 jsonNode = LoadJsonNodesFromYamlDocument(stream);
             }
             catch (JsonException ex)


### PR DESCRIPTION
reflection of https://github.com/microsoft/OpenAPI.NET/pull/1744, on a side note, we should probably multi-target our unit tests to include netfx before GA