### PR TITLE
fix: side effects in tag references

### DIFF
--- a/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
@@ -86,6 +86,7 @@ namespace Microsoft.OpenApi.Readers
         /// <inheritdoc/>
         public T ReadFragment<T>(MemoryStream input,
                                  OpenApiSpecVersion version,
+                                 OpenApiDocument openApiDocument,
                                  out OpenApiDiagnostic diagnostic,
                                  OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
@@ -105,13 +106,13 @@ namespace Microsoft.OpenApi.Readers
                 return default;
             }
 
-            return ReadFragment<T>(jsonNode, version, out diagnostic, settings);
+            return ReadFragment<T>(jsonNode, version, openApiDocument, out diagnostic, settings);
         }
 
         /// <inheritdoc/>
-        public static T ReadFragment<T>(JsonNode input, OpenApiSpecVersion version, out OpenApiDiagnostic diagnostic, OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public static T ReadFragment<T>(JsonNode input, OpenApiSpecVersion version, OpenApiDocument openApiDocument, out OpenApiDiagnostic diagnostic, OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
-            return _jsonReader.ReadFragment<T>(input, version, out diagnostic, settings);
+            return _jsonReader.ReadFragment<T>(input, version, openApiDocument, out diagnostic, settings);
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiReader.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiReader.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader;
 
 namespace Microsoft.OpenApi.Interfaces
@@ -36,9 +37,10 @@ namespace Microsoft.OpenApi.Interfaces
         /// </summary>
         /// <param name="input">Memory stream containing OpenAPI description to parse.</param>
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
+        /// <param name="openApiDocument">The OpenApiDocument object to which the fragment belongs, used to lookup references.</param>
         /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing.</param>
         /// <param name="settings">The OpenApiReader settings.</param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
-        T ReadFragment<T>(MemoryStream input, OpenApiSpecVersion version, out OpenApiDiagnostic diagnostic, OpenApiReaderSettings settings = null) where T : IOpenApiElement;
+        T ReadFragment<T>(MemoryStream input, OpenApiSpecVersion version, OpenApiDocument openApiDocument, out OpenApiDiagnostic diagnostic, OpenApiReaderSettings settings = null) where T : IOpenApiElement;
     }
 }

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiVersionService.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiVersionService.cs
@@ -28,7 +28,7 @@ namespace Microsoft.OpenApi.Interfaces
         /// <param name="node">document fragment node</param>
         /// <param name="doc">A host document instance.</param>
         /// <returns>Instance of OpenAPIElement</returns>
-        T LoadElement<T>(ParseNode node, OpenApiDocument doc = null) where T : IOpenApiElement;
+        T LoadElement<T>(ParseNode node, OpenApiDocument doc) where T : IOpenApiElement;
 
         /// <summary>
         /// Converts a generic RootNode instance into a strongly typed OpenApiDocument

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -503,21 +503,6 @@ namespace Microsoft.OpenApi.Models
                 throw new ArgumentException(Properties.SRResource.LocalReferenceRequiresType);
             }
 
-            // Special case for Tag
-            if (reference.Type == ReferenceType.Tag)
-            {
-                foreach (var tag in this.Tags ?? Enumerable.Empty<OpenApiTag>())
-                {
-                    if (tag.Name == reference.Id)
-                    {
-                        tag.Reference = reference;
-                        return tag;
-                    }
-                }
-
-                return null;
-            }
-
             string uriLocation;
             if (reference.Id.Contains("/")) // this means its a URL reference
             {

--- a/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OpenApi.Models
         /// A list of tags for API documentation control.
         /// Tags can be used for logical grouping of operations by resources or any other qualifier.
         /// </summary>
-        public IList<OpenApiTag>? Tags { get; set; } = new List<OpenApiTag>();
+        public IList<OpenApiTagReference>? Tags { get; set; } = [];
 
         /// <summary>
         /// A short summary of what the operation does.
@@ -121,7 +121,7 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         public OpenApiOperation(OpenApiOperation? operation)
         {
-            Tags = operation?.Tags != null ? new List<OpenApiTag>(operation.Tags) : null;
+            Tags = operation?.Tags != null ? new List<OpenApiTagReference>(operation.Tags) : null;
             Summary = operation?.Summary ?? Summary;
             Description = operation?.Description ?? Description;
             ExternalDocs = operation?.ExternalDocs != null ? new(operation?.ExternalDocs) : null;

--- a/src/Microsoft.OpenApi/Models/OpenApiTag.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiTag.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenApi.Models
     /// <summary>
     /// Tag Object.
     /// </summary>
-    public class OpenApiTag : IOpenApiReferenceable, IOpenApiExtensible
+    public class OpenApiTag : IOpenApiSerializable, IOpenApiExtensible
     {
         /// <summary>
         /// The name of the tag.
@@ -39,11 +39,6 @@ namespace Microsoft.OpenApi.Models
         public bool UnresolvedReference { get; set; }
 
         /// <summary>
-        /// Reference.
-        /// </summary>
-        public OpenApiReference Reference { get; set; }
-
-        /// <summary>
         /// Parameterless constructor
         /// </summary>
         public OpenApiTag() { }
@@ -58,7 +53,6 @@ namespace Microsoft.OpenApi.Models
             ExternalDocs = tag?.ExternalDocs != null ? new(tag.ExternalDocs) : null;
             Extensions = tag?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(tag.Extensions) : null;
             UnresolvedReference = tag?.UnresolvedReference ?? UnresolvedReference;
-            Reference = tag?.Reference != null ? new(tag.Reference) : null;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/References/OpenApiTagReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiTagReference.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Writers;
 
@@ -10,21 +12,24 @@ namespace Microsoft.OpenApi.Models.References
     /// <summary>
     /// Tag Object Reference
     /// </summary>
-    public class OpenApiTagReference : OpenApiTag
+    public class OpenApiTagReference : OpenApiTag, IOpenApiReferenceable
     {
         internal OpenApiTag _target;
-        private readonly OpenApiReference _reference;
-        private string _description;
 
-        private OpenApiTag Target
+        /// <summary>
+        /// Reference.
+        /// </summary>
+        public OpenApiReference Reference { get; set; }
+
+        /// <summary>
+        /// Resolved target of the reference.
+        /// </summary>
+        public OpenApiTag Target
         {
             get
             {
-                _target ??= Reference.HostDocument?.ResolveReferenceTo<OpenApiTag>(_reference);
-                _target ??= new OpenApiTag() { Name = _reference.Id };
-                OpenApiTag resolved = new OpenApiTag(_target);
-                if (!string.IsNullOrEmpty(_description)) resolved.Description = _description;
-                return resolved;
+                _target ??= Reference.HostDocument?.Tags.FirstOrDefault(t => StringComparer.Ordinal.Equals(t.Name, Reference.Id));
+                return _target;
             }
         }
 
@@ -37,50 +42,43 @@ namespace Microsoft.OpenApi.Models.References
         {
             Utils.CheckArgumentNullOrEmpty(referenceId);
 
-            _reference = new OpenApiReference()
+            Reference = new OpenApiReference()
             {
                 Id = referenceId,
                 HostDocument = hostDocument,
                 Type = ReferenceType.Tag
             };
-
-            Reference = _reference;
         }
 
-        internal OpenApiTagReference(OpenApiTag target, string referenceId)
+        /// <summary>
+        /// Copy Constructor
+        /// </summary>
+        /// <param name="source">The source to copy information from.</param>
+        public OpenApiTagReference(OpenApiTagReference source):base()
         {
-            _target = target;
-
-            _reference = new OpenApiReference()
-            {
-                Id = referenceId,
-                Type = ReferenceType.Tag,
-            };
+            Reference = source?.Reference != null ? new(source.Reference) : null;
+            _target = source._target;
         }
 
+        private const string ReferenceErrorMessage = "Setting the value from the reference is not supported, use the target property instead.";
         /// <inheritdoc/>
-        public override string Description
-        {
-            get => string.IsNullOrEmpty(_description) ? Target?.Description : _description;
-            set => _description = value;
-        }
+        public override string Description { get => Target.Description; set => throw new InvalidOperationException(ReferenceErrorMessage); }
 
         /// <inheritdoc/>
-        public override OpenApiExternalDocs ExternalDocs { get => Target?.ExternalDocs; set => Target.ExternalDocs = value; }
+        public override OpenApiExternalDocs ExternalDocs { get => Target.ExternalDocs; set => throw new InvalidOperationException(ReferenceErrorMessage); }
 
         /// <inheritdoc/>
-        public override IDictionary<string, IOpenApiExtension> Extensions { get => Target?.Extensions; set => Target.Extensions = value; }
+        public override IDictionary<string, IOpenApiExtension> Extensions { get => Target.Extensions; set => throw new InvalidOperationException(ReferenceErrorMessage); }
 
         /// <inheritdoc/>
-        public override string Name { get => Target?.Name; set => Target.Name = value; }
+        public override string Name { get => Target.Name; set => throw new InvalidOperationException(ReferenceErrorMessage); }
         
         /// <inheritdoc/>
         public override void SerializeAsV3(IOpenApiWriter writer)
         {
-            if (!writer.GetSettings().ShouldInlineReference(_reference))
+            if (!writer.GetSettings().ShouldInlineReference(Reference))
             {
-                _reference.SerializeAsV3(writer);
-                return;
+                Reference.SerializeAsV3(writer);
             }
             else
             {
@@ -91,10 +89,9 @@ namespace Microsoft.OpenApi.Models.References
         /// <inheritdoc/>
         public override void SerializeAsV31(IOpenApiWriter writer)
         {
-            if (!writer.GetSettings().ShouldInlineReference(_reference))
+            if (!writer.GetSettings().ShouldInlineReference(Reference))
             {
-                _reference.SerializeAsV31(writer);
-                return;
+                Reference.SerializeAsV31(writer);
             }
             else
             {
@@ -105,10 +102,9 @@ namespace Microsoft.OpenApi.Models.References
         /// <inheritdoc/>
         public override void SerializeAsV2(IOpenApiWriter writer)
         {
-            if (!writer.GetSettings().ShouldInlineReference(_reference))
+            if (!writer.GetSettings().ShouldInlineReference(Reference))
             {
-                _reference.SerializeAsV2(writer);
-                return;
+                Reference.SerializeAsV2(writer);
             }
             else
             {

--- a/src/Microsoft.OpenApi/Models/References/OpenApiTagReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiTagReference.cs
@@ -57,7 +57,7 @@ namespace Microsoft.OpenApi.Models.References
         public OpenApiTagReference(OpenApiTagReference source):base()
         {
             Reference = source?.Reference != null ? new(source.Reference) : null;
-            _target = source._target;
+            _target = source?._target;
         }
 
         private const string ReferenceErrorMessage = "Setting the value from the reference is not supported, use the target property instead.";

--- a/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
@@ -148,10 +148,12 @@ namespace Microsoft.OpenApi.Reader
         /// <inheritdoc/>
         public T ReadFragment<T>(MemoryStream input,
                                  OpenApiSpecVersion version,
+                                 OpenApiDocument openApiDocument,
                                  out OpenApiDiagnostic diagnostic,
                                  OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
-            if (input is null) throw new ArgumentNullException(nameof(input));
+            Utils.CheckArgumentNull(input);
+            Utils.CheckArgumentNull(openApiDocument);
 
             JsonNode jsonNode;
 
@@ -167,12 +169,13 @@ namespace Microsoft.OpenApi.Reader
                 return default;
             }
 
-            return ReadFragment<T>(jsonNode, version, out diagnostic);
+            return ReadFragment<T>(jsonNode, version, openApiDocument, out diagnostic);
         }
 
         /// <inheritdoc/>
         public T ReadFragment<T>(JsonNode input,
                          OpenApiSpecVersion version,
+                         OpenApiDocument openApiDocument,
                          out OpenApiDiagnostic diagnostic,
                          OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
@@ -187,7 +190,7 @@ namespace Microsoft.OpenApi.Reader
             try
             {
                 // Parse the OpenAPI element
-                element = context.ParseFragment<T>(input, version);
+                element = context.ParseFragment<T>(input, version, openApiDocument);
             }
             catch (OpenApiException ex)
             {

--- a/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiModelFactory.cs
@@ -61,14 +61,15 @@ namespace Microsoft.OpenApi.Reader
         /// <param name="input">Stream containing OpenAPI description to parse.</param>
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
         /// <param name="format"></param>
+        /// <param name="openApiDocument">The OpenApiDocument object to which the fragment belongs, used to lookup references.</param>
         /// <param name="diagnostic">Returns diagnostic object containing errors detected during parsing.</param>
         /// <param name="settings">The OpenApiReader settings.</param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
         /// <returns>The OpenAPI element.</returns>
-        public static T Load<T>(MemoryStream input, OpenApiSpecVersion version, string format, out OpenApiDiagnostic diagnostic, OpenApiReaderSettings settings = null) where T : IOpenApiElement
+        public static T Load<T>(MemoryStream input, OpenApiSpecVersion version, string format, OpenApiDocument openApiDocument, out OpenApiDiagnostic diagnostic, OpenApiReaderSettings settings = null) where T : IOpenApiElement
         {
             format ??= InspectStreamFormat(input);
-            return OpenApiReaderRegistry.GetReader(format).ReadFragment<T>(input, version, out diagnostic, settings);
+            return OpenApiReaderRegistry.GetReader(format).ReadFragment<T>(input, version, openApiDocument, out diagnostic, settings);
         }
 
         /// <summary>
@@ -91,13 +92,14 @@ namespace Microsoft.OpenApi.Reader
         /// <param name="url">The path to the OpenAPI file</param>
         /// <param name="version">Version of the OpenAPI specification that the fragment conforms to.</param>
         /// <param name="settings">The OpenApiReader settings.</param>
+        /// <param name="openApiDocument">The OpenApiDocument object to which the fragment belongs, used to lookup references.</param>
         /// <param name="token"></param>
         /// <returns>Instance of newly created IOpenApiElement.</returns>
         /// <returns>The OpenAPI element.</returns>
-        public static async Task<T> LoadAsync<T>(string url, OpenApiSpecVersion version, OpenApiReaderSettings settings = null, CancellationToken token = default) where T : IOpenApiElement
+        public static async Task<T> LoadAsync<T>(string url, OpenApiSpecVersion version, OpenApiDocument openApiDocument, OpenApiReaderSettings settings = null, CancellationToken token = default) where T : IOpenApiElement
         {
             var (stream, format) = await RetrieveStreamAndFormatAsync(url, token).ConfigureAwait(false);
-            return await LoadAsync<T>(stream, version, format, settings, token);
+            return await LoadAsync<T>(stream, version, openApiDocument, format, settings, token);
         }
 
         /// <summary>
@@ -141,27 +143,30 @@ namespace Microsoft.OpenApi.Reader
         /// <typeparam name="T"></typeparam>
         /// <param name="input"></param>
         /// <param name="version"></param>
+        /// <param name="openApiDocument">The document used to lookup tag or schema references.</param>
         /// <param name="format"></param>
         /// <param name="settings"></param>
         /// <param name="token"></param>
         /// <returns></returns>
         public static async Task<T> LoadAsync<T>(Stream input,
                                                  OpenApiSpecVersion version,
+                                                 OpenApiDocument openApiDocument,
                                                  string format = null,
                                                  OpenApiReaderSettings settings = null,
                                                  CancellationToken token = default) where T : IOpenApiElement
         {
+            Utils.CheckArgumentNull(openApiDocument);
             if (input is null) throw new ArgumentNullException(nameof(input));
             if (input is MemoryStream memoryStream)
             {
-                return Load<T>(memoryStream, version, format, out var _, settings);
+                return Load<T>(memoryStream, version, format, openApiDocument, out var _, settings);
             }
             else
             {
                 memoryStream = new MemoryStream();
                 await input.CopyToAsync(memoryStream, 81920, token).ConfigureAwait(false);
                 memoryStream.Position = 0;
-                return Load<T>(memoryStream, version, format, out var _, settings);
+                return Load<T>(memoryStream, version, format, openApiDocument, out var _, settings);
             }
         }
 
@@ -191,12 +196,14 @@ namespace Microsoft.OpenApi.Reader
         /// </summary>
         /// <param name="input">The input string.</param>
         /// <param name="version"></param>
+        /// <param name="openApiDocument">The OpenApiDocument object to which the fragment belongs, used to lookup references.</param>
         /// <param name="diagnostic">The diagnostic entity containing information from the reading process.</param>
         /// <param name="format">The Open API format</param>
         /// <param name="settings">The OpenApi reader settings.</param>
         /// <returns>An OpenAPI document instance.</returns>
         public static T Parse<T>(string input,
                                  OpenApiSpecVersion version,
+                                 OpenApiDocument openApiDocument,
                                  out OpenApiDiagnostic diagnostic,
                                  string format = null,
                                  OpenApiReaderSettings settings = null) where T : IOpenApiElement
@@ -205,7 +212,7 @@ namespace Microsoft.OpenApi.Reader
             format ??= InspectInputFormat(input);
             settings ??= new OpenApiReaderSettings();
             using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
-            return Load<T>(stream, version, format, out diagnostic, settings);
+            return Load<T>(stream, version, format, openApiDocument, out diagnostic, settings);
         }
 
         private static readonly OpenApiReaderSettings DefaultReaderSettings = new();

--- a/src/Microsoft.OpenApi/Reader/ParseNodes/ListNode.cs
+++ b/src/Microsoft.OpenApi/Reader/ParseNodes/ListNode.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Models;
 
@@ -44,14 +43,14 @@ namespace Microsoft.OpenApi.Reader.ParseNodes
             return list;
         }
 
-        public override List<T> CreateSimpleList<T>(Func<ValueNode, OpenApiDocument, T> map)
+        public override List<T> CreateSimpleList<T>(Func<ValueNode, OpenApiDocument, T> map, OpenApiDocument openApiDocument)
         {
             if (_nodeList == null)
             {
                 throw new OpenApiReaderException($"Expected list while parsing {typeof(T).Name}", _nodeList);
             }
 
-            return _nodeList.Select(n => map(new(Context, n), null)).ToList();
+            return _nodeList.Select(n => map(new(Context, n), openApiDocument)).ToList();
         }
 
         public IEnumerator<ParseNode> GetEnumerator()

--- a/src/Microsoft.OpenApi/Reader/ParseNodes/ParseNode.cs
+++ b/src/Microsoft.OpenApi/Reader/ParseNodes/ParseNode.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Nodes;
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Exceptions;
 using Microsoft.OpenApi.Models;
 
@@ -57,7 +56,7 @@ namespace Microsoft.OpenApi.Reader.ParseNodes
             throw new OpenApiReaderException("Cannot create map from this type of node.", Context);
         }
 
-        public virtual List<T> CreateSimpleList<T>(Func<ValueNode, OpenApiDocument, T> map)
+        public virtual List<T> CreateSimpleList<T>(Func<ValueNode, OpenApiDocument, T> map, OpenApiDocument openApiDocument)
         {
             throw new OpenApiReaderException("Cannot create simple list from this type of node.", Context);
         }

--- a/src/Microsoft.OpenApi/Reader/ParsingContext.cs
+++ b/src/Microsoft.OpenApi/Reader/ParsingContext.cs
@@ -105,8 +105,9 @@ namespace Microsoft.OpenApi.Reader
         /// </summary>
         /// <param name="jsonNode"></param>
         /// <param name="version">OpenAPI version of the fragment</param>
+        /// <param name="openApiDocument">The OpenApiDocument object to which the fragment belongs, used to lookup references.</param>
         /// <returns>An OpenApiDocument populated based on the passed yamlDocument </returns>
-        public T ParseFragment<T>(JsonNode jsonNode, OpenApiSpecVersion version) where T : IOpenApiElement
+        public T ParseFragment<T>(JsonNode jsonNode, OpenApiSpecVersion version, OpenApiDocument openApiDocument) where T : IOpenApiElement
         {
             var node = ParseNode.Create(this, jsonNode);
 
@@ -116,16 +117,16 @@ namespace Microsoft.OpenApi.Reader
             {
                 case OpenApiSpecVersion.OpenApi2_0:
                     VersionService = new OpenApiV2VersionService(Diagnostic);
-                    element = this.VersionService.LoadElement<T>(node);
+                    element = this.VersionService.LoadElement<T>(node, openApiDocument);
                     break;
 
                 case OpenApiSpecVersion.OpenApi3_0:
                     this.VersionService = new OpenApiV3VersionService(Diagnostic);
-                    element = this.VersionService.LoadElement<T>(node);
+                    element = this.VersionService.LoadElement<T>(node, openApiDocument);
                     break;
                 case OpenApiSpecVersion.OpenApi3_1:
                     this.VersionService = new OpenApiV31VersionService(Diagnostic);
-                    element = this.VersionService.LoadElement<T>(node);
+                    element = this.VersionService.LoadElement<T>(node, openApiDocument);
                     break;
             }
 

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiDocumentDeserializer.cs
@@ -28,16 +28,16 @@ namespace Microsoft.OpenApi.Reader.V2
             {"host", (_, n, _) => n.Context.SetTempStorage("host", n.GetScalarValue())},
             {"basePath", (_, n, _) => n.Context.SetTempStorage("basePath", n.GetScalarValue())},
             {
-                "schemes", (_, n, _) => n.Context.SetTempStorage(
+                "schemes", (_, n, doc) => n.Context.SetTempStorage(
                     "schemes",
                     n.CreateSimpleList(
-                        (s, p) => s.GetScalarValue()))
+                        (s, p) => s.GetScalarValue(), doc))
             },
             {
                 "consumes",
-                (_, n, _) =>
+                (_, n, doc) =>
                 {
-                    var consumes = n.CreateSimpleList((s, p) => s.GetScalarValue());
+                    var consumes = n.CreateSimpleList((s, p) => s.GetScalarValue(), doc);
                     if (consumes.Count > 0)
                     {
                         n.Context.SetTempStorage(TempStorageKeys.GlobalConsumes, consumes);
@@ -45,8 +45,8 @@ namespace Microsoft.OpenApi.Reader.V2
                 }
             },
             {
-                "produces", (_, n, _) => {
-                    var produces = n.CreateSimpleList((s, p) => s.GetScalarValue());
+                "produces", (_, n, doc) => {
+                    var produces = n.CreateSimpleList((s, p) => s.GetScalarValue(), doc);
                     if (produces.Count > 0)
                     {
                         n.Context.SetTempStorage(TempStorageKeys.GlobalProduces, produces);

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
@@ -24,8 +24,7 @@ namespace Microsoft.OpenApi.Reader.V2
                     "tags", (o, n, doc) => o.Tags = n.CreateSimpleList(
                         (valueNode, doc) =>
                             LoadTagByReference(
-                                valueNode.Context,
-                                valueNode.GetScalarValue(), doc))
+                                valueNode.GetScalarValue(), doc), doc)
                 },
                 {
                     "summary",
@@ -48,16 +47,16 @@ namespace Microsoft.OpenApi.Reader.V2
                     (o, n, t) => o.Parameters = n.CreateList(LoadParameter, t)
                 },
                 {
-                    "consumes", (_, n, _) => {
-                        var consumes = n.CreateSimpleList((s, p) => s.GetScalarValue());
+                    "consumes", (_, n, doc) => {
+                        var consumes = n.CreateSimpleList((s, p) => s.GetScalarValue(), doc);
                         if (consumes.Count > 0) {
                             n.Context.SetTempStorage(TempStorageKeys.OperationConsumes,consumes);
                         }
                     }
                 },
                 {
-                    "produces", (_, n, _) => {
-                        var produces = n.CreateSimpleList((s, p) => s.GetScalarValue());
+                    "produces", (_, n, doc) => {
+                        var produces = n.CreateSimpleList((s, p) => s.GetScalarValue(), doc);
                         if (produces.Count > 0) {
                             n.Context.SetTempStorage(TempStorageKeys.OperationProduces, produces);
                         }
@@ -205,8 +204,7 @@ namespace Microsoft.OpenApi.Reader.V2
             return requestBody;
         }
 
-        private static OpenApiTag LoadTagByReference(
-            ParsingContext context,
+        private static OpenApiTagReference LoadTagByReference(
             string tagName, OpenApiDocument hostDocument = null)
         {
             return new OpenApiTagReference(tagName, hostDocument);

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
@@ -76,7 +76,7 @@ namespace Microsoft.OpenApi.Reader.V2
             },
             {
                 "required",
-                (o, n, _) => o.Required = new HashSet<string>(n.CreateSimpleList((n2, p) => n2.GetScalarValue()))
+                (o, n, doc) => o.Required = new HashSet<string>(n.CreateSimpleList((n2, p) => n2.GetScalarValue(), doc))
             },
             {
                 "enum",

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiSecurityRequirementDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiSecurityRequirementDeserializer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.OpenApi.Reader.V2
     /// </summary>
     internal static partial class OpenApiV2Deserializer
     {
-        public static OpenApiSecurityRequirement LoadSecurityRequirement(ParseNode node, OpenApiDocument hostDocument = null)
+        public static OpenApiSecurityRequirement LoadSecurityRequirement(ParseNode node, OpenApiDocument hostDocument)
         {
             var mapNode = node.CheckMapNode("security");
 
@@ -24,7 +24,7 @@ namespace Microsoft.OpenApi.Reader.V2
                     mapNode.Context,
                     property.Name);
 
-                var scopes = property.Value.CreateSimpleList((n2, p)  => n2.GetScalarValue());
+                var scopes = property.Value.CreateSimpleList((n2, p)  => n2.GetScalarValue(), hostDocument);
 
                 if (scheme != null)
                 {

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiDocumentDeserializer.cs
@@ -26,16 +26,7 @@ namespace Microsoft.OpenApi.Reader.V3
             {"servers", (o, n, _) => o.Servers = n.CreateList(LoadServer, o)},
             {"paths", (o, n, _) => o.Paths = LoadPaths(n, o)},
             {"components", (o, n, _) => o.Components = LoadComponents(n, o)},
-            {"tags", (o, n, _) => {o.Tags = n.CreateList(LoadTag, o);
-                foreach (var tag in o.Tags)
-                {
-                    tag.Reference = new()
-                    {
-                        Id = tag.Name,
-                        Type = ReferenceType.Tag
-                    };
-                }
-            } },
+            {"tags", (o, n, _) => o.Tags = n.CreateList(LoadTag, o) },
             {"externalDocs", (o, n, _) => o.ExternalDocs = LoadExternalDocs(n, o)},
             {"security", (o, n, _) => o.SecurityRequirements = n.CreateList(LoadSecurityRequirement, o)}
         };

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiOperationDeserializer.cs
@@ -21,8 +21,7 @@ namespace Microsoft.OpenApi.Reader.V3
                     "tags", (o, n, doc) => o.Tags = n.CreateSimpleList(
                         (valueNode, doc) =>
                             LoadTagByReference(
-                                valueNode.Context,
-                                valueNode.GetScalarValue(), doc))
+                                valueNode.GetScalarValue(), doc), doc)
                 },
                 {
                     "summary",
@@ -87,8 +86,7 @@ namespace Microsoft.OpenApi.Reader.V3
             return operation;
         }
 
-        private static OpenApiTag LoadTagByReference(
-            ParsingContext context,
+        private static OpenApiTagReference LoadTagByReference(
             string tagName, OpenApiDocument hostDocument)
         {
             return new OpenApiTagReference(tagName, hostDocument);

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
@@ -76,7 +76,7 @@ namespace Microsoft.OpenApi.Reader.V3
             },
             {
                 "required",
-                (o, n, _) => o.Required = new HashSet<string>(n.CreateSimpleList((n2, p) => n2.GetScalarValue()))
+                (o, n, doc) => o.Required = new HashSet<string>(n.CreateSimpleList((n2, p) => n2.GetScalarValue(), doc))
             },
             {
                 "enum",

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSecurityRequirementDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSecurityRequirementDeserializer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OpenApi.Reader.V3
     /// </summary>
     internal static partial class OpenApiV3Deserializer
     {
-        public static OpenApiSecurityRequirement LoadSecurityRequirement(ParseNode node, OpenApiDocument hostDocument = null)
+        public static OpenApiSecurityRequirement LoadSecurityRequirement(ParseNode node, OpenApiDocument hostDocument)
         {
             var mapNode = node.CheckMapNode("security");
 
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.Reader.V3
             {
                 var scheme = LoadSecuritySchemeByReference(mapNode.Context, property.Name);
 
-                var scopes = property.Value.CreateSimpleList((value, p) => value.GetScalarValue());
+                var scopes = property.Value.CreateSimpleList((value, p) => value.GetScalarValue(), hostDocument);
 
                 if (scheme != null)
                 {

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiServerVariableDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiServerVariableDeserializer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.OpenApi.Reader.V3
             {
                 {
                     "enum",
-                    (o, n, _) => o.Enum = n.CreateSimpleList((s, p) => s.GetScalarValue())
+                    (o, n, doc) => o.Enum = n.CreateSimpleList((s, p) => s.GetScalarValue(), doc)
                 },
                 {
                     "default",

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiDocumentDeserializer.cs
@@ -25,16 +25,7 @@ namespace Microsoft.OpenApi.Reader.V31
             {"paths", (o, n, _) => o.Paths = LoadPaths(n, o)},
             {"webhooks", (o, n, _) => o.Webhooks = n.CreateMap(LoadPathItem, o)},
             {"components", (o, n, _) => o.Components = LoadComponents(n, o)},
-            {"tags", (o, n, _) => {o.Tags = n.CreateList(LoadTag, o);
-                foreach (var tag in o.Tags)
-    {
-                    tag.Reference = new OpenApiReference()
-                    {
-                        Id = tag.Name,
-                        Type = ReferenceType.Tag
-                    };
-    }
-            } },
+            {"tags", (o, n, _) => o.Tags = n.CreateList(LoadTag, o) },
             {"externalDocs", (o, n, _) => o.ExternalDocs = LoadExternalDocs(n, o)},
             {"security", (o, n, _) => o.SecurityRequirements = n.CreateList(LoadSecurityRequirement, o)}
         };

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiOperationDeserializer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OpenApi.Reader.V31
                 {
                     "tags", (o, n, doc) => o.Tags = n.CreateSimpleList(
                         (valueNode, doc) =>
-                            LoadTagByReference(valueNode.GetScalarValue(), doc))
+                            LoadTagByReference(valueNode.GetScalarValue(), doc), doc)
                 },
                 {
                     "summary", (o, n, _) =>
@@ -104,7 +104,7 @@ namespace Microsoft.OpenApi.Reader.V31
             return operation;
         }
 
-        private static OpenApiTag LoadTagByReference(string tagName, OpenApiDocument hostDocument = null)
+        private static OpenApiTagReference LoadTagByReference(string tagName, OpenApiDocument hostDocument = null)
         {
             var tagObject = new OpenApiTagReference(tagName, hostDocument);
             return tagObject;

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.OpenApi.Reader.V31
             },
             {
                 "required",
-                (o, n, _) => o.Required = new HashSet<string>(n.CreateSimpleList((n2, p) => n2.GetScalarValue()))
+                (o, n, doc) => o.Required = new HashSet<string>(n.CreateSimpleList((n2, p) => n2.GetScalarValue(), doc))
             },
             {
                 "enum",
@@ -114,7 +114,7 @@ namespace Microsoft.OpenApi.Reader.V31
             },
             {
                 "type",
-                (o, n, _) => 
+                (o, n, doc) => 
                 {
                     if (n is ValueNode)
                     {
@@ -122,7 +122,7 @@ namespace Microsoft.OpenApi.Reader.V31
                     }
                     else
                     {
-                        var list = n.CreateSimpleList((n2, p) => n2.GetScalarValue());
+                        var list = n.CreateSimpleList((n2, p) => n2.GetScalarValue(), doc);
                         JsonSchemaType combinedType = 0;
                         foreach(var type in list)
                         {

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiSecurityRequirementDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiSecurityRequirementDeserializer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OpenApi.Reader.V31
     /// </summary>
     internal static partial class OpenApiV31Deserializer
     {
-        public static OpenApiSecurityRequirement LoadSecurityRequirement(ParseNode node, OpenApiDocument hostDocument = null)
+        public static OpenApiSecurityRequirement LoadSecurityRequirement(ParseNode node, OpenApiDocument hostDocument)
         {
             var mapNode = node.CheckMapNode("security");
 
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.Reader.V31
             {
                 var scheme = LoadSecuritySchemeByReference(property.Name, hostDocument);
 
-                var scopes = property.Value.CreateSimpleList((value, p) => value.GetScalarValue());
+                var scopes = property.Value.CreateSimpleList((value, p) => value.GetScalarValue(), hostDocument);
 
                 if (scheme != null)
                 {

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiServerVariableDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiServerVariableDeserializer.cs
@@ -17,9 +17,9 @@ namespace Microsoft.OpenApi.Reader.V31
             new()
             {
                 {
-                    "enum", (o, n, _) =>
+                    "enum", (o, n, doc) =>
                     {
-                        o.Enum = n.CreateSimpleList((s, p) => s.GetScalarValue());
+                        o.Enum = n.CreateSimpleList((s, p) => s.GetScalarValue(), doc);
                     }
                 },
                 {

--- a/src/Microsoft.OpenApi/Services/OpenApiVisitorBase.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiVisitorBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text.Json.Nodes;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.References;
 
 namespace Microsoft.OpenApi.Services
 {
@@ -263,6 +264,13 @@ namespace Microsoft.OpenApi.Services
         }
 
         /// <summary>
+        /// Visits <see cref="OpenApiTagReference"/>
+        /// </summary>
+        public virtual void Visit(OpenApiTagReference tag)
+        {
+        }
+
+        /// <summary>
         /// Visits <see cref="OpenApiHeader"/>
         /// </summary>
         public virtual void Visit(OpenApiHeader header)
@@ -301,6 +309,13 @@ namespace Microsoft.OpenApi.Services
         /// Visits list of <see cref="OpenApiTag"/>
         /// </summary>
         public virtual void Visit(IList<OpenApiTag> openApiTags)
+        {
+        }
+
+        /// <summary>
+        /// Visits list of <see cref="OpenApiTagReference"/>
+        /// </summary>
+        public virtual void Visit(IList<OpenApiTagReference> openApiTags)
         {
         }
 

--- a/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
@@ -81,6 +81,28 @@ namespace Microsoft.OpenApi.Services
         }
 
         /// <summary>
+        /// Visits list of <see cref="OpenApiTagReference"/> and child objects
+        /// </summary>
+        internal void Walk(IList<OpenApiTagReference> tags)
+        {
+            if (tags == null)
+            {
+                return;
+            }
+
+            _visitor.Visit(tags);
+
+            // Visit tags
+            if (tags != null)
+            {
+                for (var i = 0; i < tags.Count; i++)
+                {
+                    Walk(i.ToString(), () => Walk(tags[i]));
+                }
+            }
+        }
+
+        /// <summary>
         /// Visits <see cref="OpenApiExternalDocs"/> and child objects
         /// </summary>
         internal void Walk(string externalDocs)
@@ -424,15 +446,22 @@ namespace Microsoft.OpenApi.Services
                 return;
             }
 
-            if (tag is OpenApiTagReference)
-            {
-                Walk(tag as IOpenApiReferenceable);
-                return;
-            }
-
             _visitor.Visit(tag);
             _visitor.Visit(tag.ExternalDocs);
             _visitor.Visit(tag as IOpenApiExtensible);
+        }
+
+        /// <summary>
+        /// Visits <see cref="OpenApiTagReference"/> and child objects
+        /// </summary>
+        internal void Walk(OpenApiTagReference tag)
+        {
+            if (tag == null)
+            {
+                return;
+            }
+
+            Walk(tag as IOpenApiReferenceable);
         }
 
         /// <summary>

--- a/test/Microsoft.OpenApi.Hidi.Tests/UtilityFiles/OpenApiDocumentMock.cs
+++ b/test/Microsoft.OpenApi.Hidi.Tests/UtilityFiles/OpenApiDocumentMock.cs
@@ -4,6 +4,7 @@
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.References;
 
 namespace Microsoft.OpenApi.Tests.UtilityFiles
 {
@@ -19,6 +20,17 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
         public static OpenApiDocument CreateOpenApiDocument()
         {
             var applicationJsonMediaType = "application/json";
+            const string getTeamsActivityByPeriodPath = "/reports/microsoft.graph.getTeamsUserActivityCounts(period={period})";
+            const string getTeamsActivityByDatePath = "/reports/microsoft.graph.getTeamsUserActivityUserDetail(date={date})";
+            const string usersPath = "/users";
+            const string usersByIdPath = "/users/{user-id}";
+            const string messagesByIdPath = "/users/{user-id}/messages/{message-id}";
+            const string administrativeUnitRestorePath = "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore";
+            const string logoPath = "/applications/{application-id}/logo";
+            const string securityProfilesPath = "/security/hostSecurityProfiles";
+            const string communicationsCallsKeepAlivePath = "/communications/calls/{call-id}/microsoft.graph.keepAlive";
+            const string eventsDeltaPath = "/groups/{group-id}/events/{event-id}/calendar/events/microsoft.graph.delta";
+            const string refPath = "/applications/{application-id}/createdOnBehalfOf/$ref";
 
             var document = new OpenApiDocument
             {
@@ -57,22 +69,13 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                             }
                         }
                     },
-                    ["/reports/microsoft.graph.getTeamsUserActivityCounts(period={period})"] = new()
+                    [getTeamsActivityByPeriodPath] = new()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>
                         {
                             {
                                 OperationType.Get, new OpenApiOperation
                                 {
-                                    Tags = new List<OpenApiTag>
-                                    {
-                                        {
-                                            new()
-                                            {
-                                                Name = "reports.Functions"
-                                            }
-                                        }
-                                    },
                                     OperationId = "reports.getTeamsUserActivityCounts",
                                     Summary = "Invoke function getTeamsUserActivityUserCounts",
                                     Parameters = new List<OpenApiParameter>
@@ -131,22 +134,13 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                             }
                         }
                     },
-                    ["/reports/microsoft.graph.getTeamsUserActivityUserDetail(date={date})"] = new()
+                    [getTeamsActivityByDatePath] = new()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>
                         {
                             {
                                 OperationType.Get, new OpenApiOperation
                                 {
-                                    Tags = new List<OpenApiTag>
-                                    {
-                                        {
-                                            new()
-                                            {
-                                                Name = "reports.Functions"
-                                            }
-                                        }
-                                    },
                                     OperationId = "reports.getTeamsUserActivityUserDetail-a3f1",
                                     Summary = "Invoke function getTeamsUserActivityUserDetail",
                                     Parameters = new List<OpenApiParameter>
@@ -203,22 +197,13 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                             }
                         }
                     },
-                    ["/users"] = new()
+                    [usersPath] = new()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>
                         {
                             {
                                 OperationType.Get, new OpenApiOperation
                                 {
-                                    Tags = new List<OpenApiTag>
-                                    {
-                                        {
-                                            new()
-                                            {
-                                                Name = "users.user"
-                                            }
-                                        }
-                                    },
                                     OperationId = "users.user.ListUser",
                                     Summary = "Get entities from users",
                                     Responses = new()
@@ -266,22 +251,13 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                             }
                         }
                     },
-                    ["/users/{user-id}"] = new()
+                    [usersByIdPath] = new()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>
                         {
                             {
                                 OperationType.Get, new OpenApiOperation
                                 {
-                                    Tags = new List<OpenApiTag>
-                                    {
-                                        {
-                                            new()
-                                            {
-                                                Name = "users.user"
-                                            }
-                                        }
-                                    },
                                     OperationId = "users.user.GetUser",
                                     Summary = "Get entity from users by key",
                                     Responses = new()
@@ -315,15 +291,6 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                             {
                                 OperationType.Patch, new OpenApiOperation
                                 {
-                                    Tags = new List<OpenApiTag>
-                                    {
-                                        {
-                                            new()
-                                            {
-                                                Name = "users.user"
-                                            }
-                                        }
-                                    },
                                     OperationId = "users.user.UpdateUser",
                                     Summary = "Update entity in users",
                                     Responses = new()
@@ -339,22 +306,13 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                             }
                         }
                     },
-                    ["/users/{user-id}/messages/{message-id}"] = new()
+                    [messagesByIdPath] = new()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>
                         {
                             {
                                 OperationType.Get, new OpenApiOperation
                                 {
-                                    Tags = new List<OpenApiTag>
-                                    {
-                                        {
-                                            new()
-                                            {
-                                                Name = "users.message"
-                                            }
-                                        }
-                                    },
                                     OperationId = "users.GetMessages",
                                     Summary = "Get messages from users",
                                     Description = "The messages in a mailbox or folder. Read-only. Nullable.",
@@ -403,22 +361,13 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                             }
                         }
                     },
-                    ["/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore"] = new()
+                    [administrativeUnitRestorePath] = new()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>
                         {
                             {
                                 OperationType.Post, new OpenApiOperation
                                 {
-                                    Tags = new List<OpenApiTag>
-                                    {
-                                        {
-                                            new()
-                                            {
-                                                Name = "administrativeUnits.Actions"
-                                            }
-                                        }
-                                    },
                                     OperationId = "administrativeUnits.restore",
                                     Summary = "Invoke action restore",
                                     Parameters = new List<OpenApiParameter>
@@ -470,22 +419,13 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                             }
                         }
                     },
-                    ["/applications/{application-id}/logo"] = new()
+                    [logoPath] = new()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>
                         {
                             {
                                 OperationType.Put, new OpenApiOperation
                                 {
-                                    Tags = new List<OpenApiTag>
-                                    {
-                                        {
-                                            new()
-                                            {
-                                                Name = "applications.application"
-                                            }
-                                        }
-                                    },
                                     OperationId = "applications.application.UpdateLogo",
                                     Summary = "Update media content for application in applications",
                                     Responses = new()
@@ -501,22 +441,13 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                             }
                         }
                     },
-                    ["/security/hostSecurityProfiles"] = new()
+                    [securityProfilesPath] = new()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>
                         {
                             {
                                 OperationType.Get, new OpenApiOperation
                                 {
-                                    Tags = new List<OpenApiTag>
-                                    {
-                                        {
-                                            new()
-                                            {
-                                                Name = "security.hostSecurityProfile"
-                                            }
-                                        }
-                                    },
                                     OperationId = "security.ListHostSecurityProfiles",
                                     Summary = "Get hostSecurityProfiles from security",
                                     Responses = new()
@@ -564,22 +495,13 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                             }
                         }
                     },
-                    ["/communications/calls/{call-id}/microsoft.graph.keepAlive"] = new()
+                    [communicationsCallsKeepAlivePath] = new()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>
                         {
                             {
                                 OperationType.Post, new OpenApiOperation
                                 {
-                                    Tags = new List<OpenApiTag>
-                                    {
-                                        {
-                                            new()
-                                            {
-                                                Name = "communications.Actions"
-                                            }
-                                        }
-                                    },
                                     OperationId = "communications.calls.call.keepAlive",
                                     Summary = "Invoke action keepAlive",
                                     Parameters = new List<OpenApiParameter>
@@ -621,20 +543,13 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                             }
                         }
                     },
-                    ["/groups/{group-id}/events/{event-id}/calendar/events/microsoft.graph.delta"] = new()
+                    [eventsDeltaPath] = new()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>
                         {
                             {
                                 OperationType.Get, new OpenApiOperation
                                 {
-                                    Tags = new List<OpenApiTag>
-                                    {
-                                        new()
-                                        {
-                                            Name = "groups.Functions"
-                                        }
-                                    },
                                     OperationId = "groups.group.events.event.calendar.events.delta",
                                     Summary = "Invoke function delta",
                                     Parameters = new List<OpenApiParameter>
@@ -711,20 +626,13 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                             }
                         }
                     },
-                    ["/applications/{application-id}/createdOnBehalfOf/$ref"] = new()
+                    [refPath] = new()
                     {
                         Operations = new Dictionary<OperationType, OpenApiOperation>
                         {
                             {
                                 OperationType.Get, new OpenApiOperation
                                 {
-                                    Tags = new List<OpenApiTag>
-                                    {
-                                        new()
-                                        {
-                                            Name = "applications.directoryObject"
-                                        }
-                                    },
                                     OperationId = "applications.GetRefCreatedOnBehalfOf",
                                     Summary = "Get ref of createdOnBehalfOf from applications"
                                 }
@@ -755,8 +663,68 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                             }
                         }
                     }
+                },
+                Tags = new List<OpenApiTag>
+                {
+                    new()
+                    {
+                        Name = "reports.Functions",
+                        Description = "The reports.Functions operations"
+                    },
+                    new()
+                    {
+                        Name = "users.user",
+                        Description = "The users.user operations"
+                    },
+                    new()
+                    {
+                        Name = "users.message",
+                        Description = "The users.message operations"
+                    },
+                    new()
+                    {
+                        Name = "administrativeUnits.Actions",
+                        Description = "The administrativeUnits.Actions operations"
+                    },
+                    new()
+                    {
+                        Name = "applications.application",
+                        Description = "The applications.application operations"
+                    },
+                    new()
+                    {
+                        Name = "security.hostSecurityProfile",
+                        Description = "The security.hostSecurityProfile operations"
+                    },
+                    new()
+                    {
+                        Name = "communications.Actions",
+                        Description = "The communications.Actions operations"
+                    },
+                    new()
+                    {
+                        Name = "groups.Functions",
+                        Description = "The groups.Functions operations"
+                    },
+                    new()
+                    {
+                        Name = "applications.directoryObject",
+                        Description = "The applications.directoryObject operations"
+                    }
                 }
             };
+            document.Paths[getTeamsActivityByPeriodPath].Operations[OperationType.Get].Tags!.Add(new OpenApiTagReference("reports.Functions", document));
+            document.Paths[getTeamsActivityByDatePath].Operations[OperationType.Get].Tags!.Add(new OpenApiTagReference("reports.Functions", document));
+            document.Paths[usersPath].Operations[OperationType.Get].Tags!.Add(new OpenApiTagReference("users.user", document));
+            document.Paths[usersByIdPath].Operations[OperationType.Get].Tags!.Add(new OpenApiTagReference("users.user", document));
+            document.Paths[usersByIdPath].Operations[OperationType.Patch].Tags!.Add(new OpenApiTagReference("users.user", document));
+            document.Paths[messagesByIdPath].Operations[OperationType.Get].Tags!.Add(new OpenApiTagReference("users.message", document));
+            document.Paths[administrativeUnitRestorePath].Operations[OperationType.Post].Tags!.Add(new OpenApiTagReference("administrativeUnits.Actions", document));
+            document.Paths[logoPath].Operations[OperationType.Put].Tags!.Add(new OpenApiTagReference("applications.application", document));
+            document.Paths[securityProfilesPath].Operations[OperationType.Get].Tags!.Add(new OpenApiTagReference("security.hostSecurityProfile", document));
+            document.Paths[communicationsCallsKeepAlivePath].Operations[OperationType.Post].Tags!.Add(new OpenApiTagReference("communications.Actions", document));
+            document.Paths[eventsDeltaPath].Operations[OperationType.Get].Tags!.Add(new OpenApiTagReference("groups.Functions", document));
+            document.Paths[refPath].Operations[OperationType.Get].Tags!.Add(new OpenApiTagReference("applications.directoryObject", document));
             return document;
         }
     }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiContactTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiContactTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 """;
 
             // Act
-            var contact = OpenApiModelFactory.Parse<OpenApiContact>(input, OpenApiSpecVersion.OpenApi2_0, out var diagnostic);
+            var contact = OpenApiModelFactory.Parse<OpenApiContact>(input, OpenApiSpecVersion.OpenApi2_0, new(), out var diagnostic);
 
             // Assert
             diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiSchemaTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
 
             // Act
             var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(
-                System.IO.Path.Combine(SampleFolderPath, "jsonSchema.json"), OpenApiSpecVersion.OpenApi3_1);
+                Path.Combine(SampleFolderPath, "jsonSchema.json"), OpenApiSpecVersion.OpenApi3_1, new());
 
             // Assert
             schema.Should().BeEquivalentTo(expectedObject);
@@ -112,7 +112,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             };
 
             // Act
-            var actual = OpenApiModelFactory.Parse<OpenApiSchema>(schema, OpenApiSpecVersion.OpenApi3_1, out _);
+            var actual = OpenApiModelFactory.Parse<OpenApiSchema>(schema, OpenApiSpecVersion.OpenApi3_1, new(), out _);
 
             // Assert
             actual.Should().BeEquivalentTo(expected);
@@ -161,7 +161,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             var path = Path.Combine(SampleFolderPath, "schema.yaml");
 
             // Act
-            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1);
+            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1, new());
             var expectedSchema = new OpenApiSchema
             {
                 Type = JsonSchemaType.Object,
@@ -184,7 +184,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
         {
             // Arrange and Act
             var path = Path.Combine(SampleFolderPath, "advancedSchema.yaml");
-            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1);
+            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1, new());
 
             var expectedSchema = new OpenApiSchema
             {
@@ -275,7 +275,7 @@ examples:
  - ubuntu
 ";
             // Act
-            var schema = OpenApiModelFactory.Parse<OpenApiSchema>(input, OpenApiSpecVersion.OpenApi3_1, out _, "yaml");
+            var schema = OpenApiModelFactory.Parse<OpenApiSchema>(input, OpenApiSpecVersion.OpenApi3_1, new(), out _, "yaml");
 
             // Assert
             schema.Examples.Should().HaveCount(2);
@@ -314,7 +314,7 @@ nullable: true";
             var path = Path.Combine(SampleFolderPath, "schemaWithTypeArray.yaml");
 
             // Act
-            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1);
+            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1, new());
 
             var writer = new StringWriter();
             schema.SerializeAsV3(new OpenApiYamlWriter(writer));
@@ -333,7 +333,7 @@ x-nullable: true";
             var path = Path.Combine(SampleFolderPath, "schemaWithTypeArray.yaml");
 
             // Act
-            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1);
+            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1, new());
 
             var writer = new StringWriter();
             schema.SerializeAsV2(new OpenApiYamlWriter(writer));
@@ -353,7 +353,7 @@ x-nullable: true";
             var path = Path.Combine(SampleFolderPath, "schemaWithNullable.yaml");
 
             // Act
-            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_0);
+            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_0, new());
 
             var writer = new StringWriter();
             schema.SerializeAsV31(new OpenApiYamlWriter(writer));
@@ -374,7 +374,7 @@ x-nullable: true";
             var path = Path.Combine(SampleFolderPath, "schemaWithNullableExtension.yaml");
 
             // Act
-            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi2_0);
+            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi2_0, new());
 
             var writer = new StringWriter();
             schema.SerializeAsV31(new OpenApiYamlWriter(writer));
@@ -393,7 +393,7 @@ nullable: true";
 
             var expected = @"{ }";
 
-            var schema = OpenApiModelFactory.Parse<OpenApiSchema>(input, OpenApiSpecVersion.OpenApi3_1, out _, "yaml");
+            var schema = OpenApiModelFactory.Parse<OpenApiSchema>(input, OpenApiSpecVersion.OpenApi3_1, new(), out _, "yaml");
 
             var writer = new StringWriter();
             schema.SerializeAsV2(new OpenApiYamlWriter(writer));
@@ -411,7 +411,7 @@ nullable: true";
             var path = Path.Combine(SampleFolderPath, filePath);
 
             // Act
-            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1);
+            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1, new());
 
             // Assert
             schema.Type.Should().Be(JsonSchemaType.String | JsonSchemaType.Null);
@@ -451,7 +451,7 @@ description: Schema for a person object
             var path = Path.Combine(SampleFolderPath, "schemaWithJsonSchemaKeywords.yaml");
 
             // Act
-            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1);
+            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1, new());
 
             // serialization
             var writer = new StringWriter();
@@ -495,7 +495,7 @@ description: Schema for a person object
             var path = Path.Combine(SampleFolderPath, "schemaWithConst.json");
 
             // Act
-            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1);
+            var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1, new());
             schema.Properties["status"].Const.Should().Be("active");
             schema.Properties["user"].Properties["role"].Const.Should().Be("admin");
 
@@ -517,7 +517,7 @@ description: Schema for a person object
     ""x-test"": ""test""
 }
 ";
-            var schema = OpenApiModelFactory.Parse<OpenApiSchema>(input, OpenApiSpecVersion.OpenApi3_1, out _, "json");
+            var schema = OpenApiModelFactory.Parse<OpenApiSchema>(input, OpenApiSpecVersion.OpenApi3_1, new(), out _, "json");
             schema.UnrecognizedKeywords.Should().HaveCount(2);
         }
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiCallbackTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiCallbackTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseBasicCallbackShouldSucceed()
         {
             // Act
-            var callback = await OpenApiModelFactory.LoadAsync<OpenApiCallback>(Path.Combine(SampleFolderPath, "basicCallback.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var callback = await OpenApiModelFactory.LoadAsync<OpenApiCallback>(Path.Combine(SampleFolderPath, "basicCallback.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             callback.Should().BeEquivalentTo(

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiContactTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiContactTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 """;
 
             // Act
-            var contact = OpenApiModelFactory.Parse<OpenApiContact>(input, OpenApiSpecVersion.OpenApi3_0, out var diagnostic, OpenApiConstants.Json);
+            var contact = OpenApiModelFactory.Parse<OpenApiContact>(input, OpenApiSpecVersion.OpenApi3_0, new(), out var diagnostic, OpenApiConstants.Json);
 
             // Assert
             diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDiscriminatorTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDiscriminatorTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             memoryStream.Position = 0;
 
             // Act
-            var discriminator = OpenApiModelFactory.Load<OpenApiDiscriminator>(memoryStream, OpenApiSpecVersion.OpenApi3_0, OpenApiConstants.Yaml, out var diagnostic);
+            var discriminator = OpenApiModelFactory.Load<OpenApiDiscriminator>(memoryStream, OpenApiSpecVersion.OpenApi3_0, OpenApiConstants.Yaml, new(), out var diagnostic);
 
             // Assert
             discriminator.Should().BeEquivalentTo(

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
 
             using var streamReader = new StreamReader(stream);
             var result = streamReader.ReadToEnd();
-            return OpenApiModelFactory.Parse<T>(result, OpenApiSpecVersion.OpenApi3_0, out var _);
+            return OpenApiModelFactory.Parse<T>(result, OpenApiSpecVersion.OpenApi3_0, new(), out var _);
         }
 
         private static OpenApiSecurityScheme CloneSecurityScheme(OpenApiSecurityScheme element)
@@ -63,7 +63,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
 
             using var streamReader = new StreamReader(stream);
             var result = streamReader.ReadToEnd();
-            return OpenApiModelFactory.Parse<OpenApiSecurityScheme>(result, OpenApiSpecVersion.OpenApi3_0, out var _);
+            return OpenApiModelFactory.Parse<OpenApiSecurityScheme>(result, OpenApiSpecVersion.OpenApi3_0, new(), out var _);
         }
 
         [Fact]
@@ -707,27 +707,9 @@ paths: {}
                 HostDocument = actual.Document
             };
 
-            var tag1 = new OpenApiTag
-            {
-                Name = "tagName1",
-                Description = "tagDescription1",
-                Reference = new OpenApiReference
-                {
-                    Id = "tagName1",
-                    Type = ReferenceType.Tag
-                }
-            };
+            var tagReference1 = new OpenApiTagReference("tagName1", null);
 
-
-            var tag2 = new OpenApiTag
-            {
-                Name = "tagName2",
-                Reference = new OpenApiReference
-                {
-                    Id = "tagName2",
-                    Type = ReferenceType.Tag
-                }
-            };
+            var tagReference2 = new OpenApiTagReference("tagName2", null);
 
             var securityScheme1 = CloneSecurityScheme(components.SecuritySchemes["securitySchemeName1"]);
 
@@ -781,10 +763,10 @@ paths: {}
                         {
                             [OperationType.Get] = new OpenApiOperation
                             {
-                                Tags = new List<OpenApiTag>
+                                Tags = new List<OpenApiTagReference>
                                     {
-                                        tag1,
-                                        tag2
+                                        tagReference1,
+                                        tagReference2
                                     },
                                 Description = "Returns all pets from the system that the user has access to",
                                 OperationId = "findPets",
@@ -869,10 +851,10 @@ paths: {}
                             },
                             [OperationType.Post] = new OpenApiOperation
                             {
-                                Tags = new List<OpenApiTag>
+                                Tags = new List<OpenApiTagReference>
                                     {
-                                        tag1,
-                                        tag2
+                                        tagReference1,
+                                        tagReference2
                                     },
                                 Description = "Creates a new pet in the store.  Duplicates are allowed",
                                 OperationId = "addPet",
@@ -1063,6 +1045,11 @@ paths: {}
                         {
                             Name = "tagName1",
                             Description = "tagDescription1"                            
+                        },
+                        new OpenApiTag
+                        {
+                            Name = "tagName2",
+                            Description = "tagDescription2"
                         }
                     },
                 SecurityRequirements = new List<OpenApiSecurityRequirement>
@@ -1080,14 +1067,20 @@ paths: {}
                     }
             };
 
+            tagReference1.Reference.HostDocument = expected;
+            tagReference2.Reference.HostDocument = expected;
+
             actual.Document.Should().BeEquivalentTo(expected, options => options
             .Excluding(x => x.HashCode)
-            .Excluding(m => m.Tags[0].Reference)
             .Excluding(x => x.Paths["/pets"].Operations[OperationType.Get].Tags[0].Reference)
             .Excluding(x => x.Paths["/pets"].Operations[OperationType.Get].Tags[0].Reference.HostDocument)
+            .Excluding(x => x.Paths["/pets"].Operations[OperationType.Get].Tags[0].Target)
             .Excluding(x => x.Paths["/pets"].Operations[OperationType.Post].Tags[0].Reference.HostDocument)
+            .Excluding(x => x.Paths["/pets"].Operations[OperationType.Post].Tags[0].Target)
             .Excluding(x => x.Paths["/pets"].Operations[OperationType.Get].Tags[1].Reference.HostDocument)
+            .Excluding(x => x.Paths["/pets"].Operations[OperationType.Get].Tags[1].Target)
             .Excluding(x => x.Paths["/pets"].Operations[OperationType.Post].Tags[1].Reference.HostDocument)
+            .Excluding(x => x.Paths["/pets"].Operations[OperationType.Post].Tags[1].Target)
             .Excluding(x => x.Workspace)
             .Excluding(y => y.BaseUri));
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiEncodingTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiEncodingTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseBasicEncodingShouldSucceed()
         {
             // Act
-            var encoding = await OpenApiModelFactory.LoadAsync<OpenApiEncoding>(Path.Combine(SampleFolderPath, "basicEncoding.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var encoding = await OpenApiModelFactory.LoadAsync<OpenApiEncoding>(Path.Combine(SampleFolderPath, "basicEncoding.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             encoding.Should().BeEquivalentTo(
@@ -40,7 +40,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "advancedEncoding.yaml"));
 
             // Act
-            var encoding = await OpenApiModelFactory.LoadAsync<OpenApiEncoding>(stream, OpenApiSpecVersion.OpenApi3_0);
+            var encoding = await OpenApiModelFactory.LoadAsync<OpenApiEncoding>(stream, OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             encoding.Should().BeEquivalentTo(

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiExampleTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiExampleTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         [Fact]
         public async Task ParseAdvancedExampleShouldSucceed()
         {
-            var example = await OpenApiModelFactory.LoadAsync<OpenApiExample>(Path.Combine(SampleFolderPath, "advancedExample.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var example = await OpenApiModelFactory.LoadAsync<OpenApiExample>(Path.Combine(SampleFolderPath, "advancedExample.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
             var expected = new OpenApiExample
             {
                 Value = new JsonObject

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiInfoTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiInfoTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseAdvancedInfoShouldSucceed()
         {
             // Act
-            var openApiInfo = await OpenApiModelFactory.LoadAsync<OpenApiInfo>(Path.Combine(SampleFolderPath, "advancedInfo.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var openApiInfo = await OpenApiModelFactory.LoadAsync<OpenApiInfo>(Path.Combine(SampleFolderPath, "advancedInfo.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             openApiInfo.Should().BeEquivalentTo(
@@ -84,7 +84,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseBasicInfoShouldSucceed()
         {
             // Act
-            var openApiInfo = await OpenApiModelFactory.LoadAsync<OpenApiInfo>(Path.Combine(SampleFolderPath, "basicInfo.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var openApiInfo = await OpenApiModelFactory.LoadAsync<OpenApiInfo>(Path.Combine(SampleFolderPath, "basicInfo.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             openApiInfo.Should().BeEquivalentTo(
@@ -114,7 +114,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "minimalInfo.yaml"));
 
             // Act
-            var openApiInfo = await OpenApiModelFactory.LoadAsync<OpenApiInfo>(stream, OpenApiSpecVersion.OpenApi3_0);
+            var openApiInfo = await OpenApiModelFactory.LoadAsync<OpenApiInfo>(stream, OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             openApiInfo.Should().BeEquivalentTo(

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiMediaTypeTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiMediaTypeTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseMediaTypeWithExampleShouldSucceed()
         {
             // Act
-            var mediaType = await OpenApiModelFactory.LoadAsync<OpenApiMediaType>(Path.Combine(SampleFolderPath, "mediaTypeWithExample.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var mediaType = await OpenApiModelFactory.LoadAsync<OpenApiMediaType>(Path.Combine(SampleFolderPath, "mediaTypeWithExample.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             mediaType.Should().BeEquivalentTo(
@@ -49,7 +49,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseMediaTypeWithExamplesShouldSucceed()
         {
             // Act
-            var mediaType = await OpenApiModelFactory.LoadAsync<OpenApiMediaType>(Path.Combine(SampleFolderPath, "mediaTypeWithExamples.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var mediaType = await OpenApiModelFactory.LoadAsync<OpenApiMediaType>(Path.Combine(SampleFolderPath, "mediaTypeWithExamples.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             mediaType.Should().BeEquivalentTo(

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiOperationTests.cs
@@ -34,13 +34,17 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         [Fact]
         public async Task ParseOperationWithParameterWithNoLocationShouldSucceed()
         {
+            var openApiDocument = new OpenApiDocument
+            {
+                Tags = { new OpenApiTag() { Name = "user" } }
+            };
             // Act
-            var operation = await OpenApiModelFactory.LoadAsync<OpenApiOperation>(Path.Combine(SampleFolderPath, "operationWithParameterWithNoLocation.json"), OpenApiSpecVersion.OpenApi3_0);
+            var operation = await OpenApiModelFactory.LoadAsync<OpenApiOperation>(Path.Combine(SampleFolderPath, "operationWithParameterWithNoLocation.json"), OpenApiSpecVersion.OpenApi3_0, openApiDocument);
             var expectedOp = new OpenApiOperation
             {
                 Tags =
                 {
-                    new OpenApiTagReference("user", null)
+                    new OpenApiTagReference("user", openApiDocument)
                 },
                 Summary = "Logs user into the system",
                 Description = "",
@@ -73,8 +77,11 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
 
             // Assert
             expectedOp.Should().BeEquivalentTo(operation, 
-                options => options.Excluding(x => x.Tags[0].Reference.HostDocument)
-                .Excluding(x => x.Tags[0].Extensions));
+                options => 
+                options.Excluding(x => x.Tags[0].Reference.HostDocument)
+                        .Excluding(x => x.Tags[0].Reference)
+                        .Excluding(x => x.Tags[0].Target)
+                        .Excluding(x => x.Tags[0].Extensions));
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiParameterTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "pathParameter.yaml"));
 
             // Act
-            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             parameter.Should().BeEquivalentTo(
@@ -53,7 +53,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseQueryParameterShouldSucceed()
         {
             // Act
-            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "queryParameter.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "queryParameter.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             parameter.Should().BeEquivalentTo(
@@ -80,7 +80,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseQueryParameterWithObjectTypeShouldSucceed()
         {
             // Act
-            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "queryParameterWithObjectType.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "queryParameterWithObjectType.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             parameter.Should().BeEquivalentTo(
@@ -107,7 +107,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "queryParameterWithObjectTypeAndContent.yaml"));
 
             // Act
-            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             parameter.Should().BeEquivalentTo(
@@ -148,7 +148,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseHeaderParameterShouldSucceed()
         {
             // Act
-            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "headerParameter.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "headerParameter.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             parameter.Should().BeEquivalentTo(
@@ -176,7 +176,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseParameterWithNullLocationShouldSucceed()
         {
             // Act
-            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "parameterWithNullLocation.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "parameterWithNullLocation.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             parameter.Should().BeEquivalentTo(
@@ -200,7 +200,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "parameterWithNoLocation.yaml"));
 
             // Act
-            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             parameter.Should().BeEquivalentTo(
@@ -224,7 +224,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "parameterWithUnknownLocation.yaml"));
 
             // Act
-            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(stream, OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             parameter.Should().BeEquivalentTo(
@@ -245,7 +245,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseParameterWithExampleShouldSucceed()
         {
             // Act
-            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "parameterWithExample.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "parameterWithExample.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             parameter.Should().BeEquivalentTo(
@@ -268,7 +268,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseParameterWithExamplesShouldSucceed()
         {
             // Act
-            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "parameterWithExamples.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var parameter = await OpenApiModelFactory.LoadAsync<OpenApiParameter>(Path.Combine(SampleFolderPath, "parameterWithExamples.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             parameter.Should().BeEquivalentTo(

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
 }";
 
             // Act
-            var openApiAny = OpenApiModelFactory.Parse<OpenApiAny>(input, OpenApiSpecVersion.OpenApi3_0, out var diagnostic);
+            var openApiAny = OpenApiModelFactory.Parse<OpenApiAny>(input, OpenApiSpecVersion.OpenApi3_0, new(), out var diagnostic);
 
             // Assert
             diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());
@@ -91,7 +91,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
 ]";
 
             // Act
-            var openApiAny = OpenApiModelFactory.Parse<OpenApiAny>(input, OpenApiSpecVersion.OpenApi3_0, out var diagnostic);
+            var openApiAny = OpenApiModelFactory.Parse<OpenApiAny>(input, OpenApiSpecVersion.OpenApi3_0, new(), out var diagnostic);
 
             // Assert
             diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());
@@ -116,7 +116,7 @@ get:
 ";
 
             // Act
-            var openApiAny = OpenApiModelFactory.Parse<OpenApiPathItem>(input, OpenApiSpecVersion.OpenApi3_0, out var diagnostic, "yaml");
+            var openApiAny = OpenApiModelFactory.Parse<OpenApiPathItem>(input, OpenApiSpecVersion.OpenApi3_0, new(), out var diagnostic, "yaml");
 
             // Assert
             diagnostic.Should().BeEquivalentTo(new OpenApiDiagnostic());

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSecuritySchemeTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSecuritySchemeTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseHttpSecuritySchemeShouldSucceed()
         {
             // Act
-            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "httpSecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "httpSecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             securityScheme.Should().BeEquivalentTo(
@@ -39,7 +39,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseApiKeySecuritySchemeShouldSucceed()
         {
             // Act
-            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "apiKeySecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "apiKeySecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             securityScheme.Should().BeEquivalentTo(
@@ -55,7 +55,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseBearerSecuritySchemeShouldSucceed()
         {
             // Act
-            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "bearerSecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "bearerSecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             securityScheme.Should().BeEquivalentTo(
@@ -71,7 +71,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseOAuth2SecuritySchemeShouldSucceed()
         {
             // Act
-            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "oauth2SecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "oauth2SecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             securityScheme.Should().BeEquivalentTo(
@@ -97,7 +97,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseOpenIdConnectSecuritySchemeShouldSucceed()
         {
             // Act
-            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "openIdConnectSecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0);
+            var securityScheme = await OpenApiModelFactory.LoadAsync<OpenApiSecurityScheme>(Path.Combine(SampleFolderPath, "openIdConnectSecurityScheme.yaml"), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             securityScheme.Should().BeEquivalentTo(

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiXmlTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiXmlTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
         public async Task ParseBasicXmlShouldSucceed()
         {
             // Act
-            var xml = await OpenApiModelFactory.LoadAsync<OpenApiXml>(Resources.GetStream(Path.Combine(SampleFolderPath, "basicXml.yaml")), OpenApiSpecVersion.OpenApi3_0);
+            var xml = await OpenApiModelFactory.LoadAsync<OpenApiXml>(Resources.GetStream(Path.Combine(SampleFolderPath, "basicXml.yaml")), OpenApiSpecVersion.OpenApi3_0, new());
 
             // Assert
             xml.Should().BeEquivalentTo(

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiDocument/petStoreWithTagAndSecurity.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiDocument/petStoreWithTagAndSecurity.yaml
@@ -210,6 +210,8 @@ components:
 tags:
   - name: tagName1
     description: tagDescription1
+  - name: tagName2
+    description: tagDescription2
 security: 
   - securitySchemeName1: []
     securitySchemeName2:

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiOperationTests.cs
@@ -87,9 +87,9 @@ namespace Microsoft.OpenApi.Tests.Models
 
         private static readonly OpenApiOperation _advancedOperationWithTagsAndSecurity = new()
         {
-            Tags = new List<OpenApiTag>
+            Tags = new List<OpenApiTagReference>
             {
-                new OpenApiTagReference("tagId1", null)
+                new OpenApiTagReference("tagId1", new OpenApiDocument{ Tags = new List<OpenApiTag>() { new OpenApiTag{Name = "tagId1"}} })
             },
             Summary = "summary1",
             Description = "operationDescription",

--- a/test/Microsoft.OpenApi.Tests/Models/References/OpenApiTagReferenceTest.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/References/OpenApiTagReferenceTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
@@ -64,10 +65,7 @@ tags:
         {
             OpenApiReaderRegistry.RegisterReader(OpenApiConstants.Yaml, new OpenApiYamlReader());
             var result = OpenApiDocument.Parse(OpenApi, "yaml");
-            _openApiTagReference = new("user", result.Document)
-            {
-                Description = "Users operations"
-            };
+            _openApiTagReference = new("user", result.Document);
         }
 
         [Fact]
@@ -75,7 +73,8 @@ tags:
         {
             // Assert
             Assert.Equal("user", _openApiTagReference.Name);
-            Assert.Equal("Users operations", _openApiTagReference.Description);
+            Assert.Equal("Operations about users.", _openApiTagReference.Description);
+            Assert.Throws<InvalidOperationException>(() => _openApiTagReference.Description = "New Description");
         }
 
         [Theory]

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -221,7 +221,7 @@ namespace Microsoft.OpenApi.Interfaces
     {
         Microsoft.OpenApi.Reader.ReadResult Read(System.IO.MemoryStream input, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings);
         System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.IO.Stream input, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings, System.Threading.CancellationToken cancellationToken = default);
-        T ReadFragment<T>(System.IO.MemoryStream input, Microsoft.OpenApi.OpenApiSpecVersion version, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        T ReadFragment<T>(System.IO.MemoryStream input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Models.OpenApiDocument openApiDocument, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement;
     }
     public interface IOpenApiReferenceable : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
@@ -765,7 +765,7 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiSecurityRequirement>? Security { get; set; }
         public System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiServer>? Servers { get; set; }
         public string? Summary { get; set; }
-        public System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiTag>? Tags { get; set; }
+        public System.Collections.Generic.IList<Microsoft.OpenApi.Models.References.OpenApiTagReference>? Tags { get; set; }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -983,11 +983,10 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiTag : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
+    public class OpenApiTag : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
         public OpenApiTag() { }
         public OpenApiTag(Microsoft.OpenApi.Models.OpenApiTag tag) { }
-        public Microsoft.OpenApi.Models.OpenApiReference Reference { get; set; }
         public bool UnresolvedReference { get; set; }
         public virtual string Description { get; set; }
         public virtual System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; set; }
@@ -1284,9 +1283,12 @@ namespace Microsoft.OpenApi.Models.References
         public override void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public override void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiTagReference : Microsoft.OpenApi.Models.OpenApiTag
+    public class OpenApiTagReference : Microsoft.OpenApi.Models.OpenApiTag, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
+        public OpenApiTagReference(Microsoft.OpenApi.Models.References.OpenApiTagReference source) { }
         public OpenApiTagReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument) { }
+        public Microsoft.OpenApi.Models.OpenApiReference Reference { get; set; }
+        public Microsoft.OpenApi.Models.OpenApiTag Target { get; }
         public override string Description { get; set; }
         public override System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; set; }
         public override Microsoft.OpenApi.Models.OpenApiExternalDocs ExternalDocs { get; set; }
@@ -1312,24 +1314,24 @@ namespace Microsoft.OpenApi.Reader
         public Microsoft.OpenApi.Reader.ReadResult Read(System.IO.MemoryStream input, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings) { }
         public Microsoft.OpenApi.Reader.ReadResult Read(System.Text.Json.Nodes.JsonNode jsonNode, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings, string format = null) { }
         public System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.IO.Stream input, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings, System.Threading.CancellationToken cancellationToken = default) { }
-        public T ReadFragment<T>(System.IO.MemoryStream input, Microsoft.OpenApi.OpenApiSpecVersion version, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        public T ReadFragment<T>(System.IO.MemoryStream input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Models.OpenApiDocument openApiDocument, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
-        public T ReadFragment<T>(System.Text.Json.Nodes.JsonNode input, Microsoft.OpenApi.OpenApiSpecVersion version, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        public T ReadFragment<T>(System.Text.Json.Nodes.JsonNode input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Models.OpenApiDocument openApiDocument, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
     }
     public static class OpenApiModelFactory
     {
         public static Microsoft.OpenApi.Reader.ReadResult Load(System.IO.MemoryStream stream, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null) { }
-        public static T Load<T>(System.IO.MemoryStream input, Microsoft.OpenApi.OpenApiSpecVersion version, string format, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        public static T Load<T>(System.IO.MemoryStream input, Microsoft.OpenApi.OpenApiSpecVersion version, string format, Microsoft.OpenApi.Models.OpenApiDocument openApiDocument, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
         public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(string url, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken token = default) { }
         public static System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> LoadAsync(System.IO.Stream input, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken cancellationToken = default) { }
-        public static System.Threading.Tasks.Task<T> LoadAsync<T>(string url, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken token = default)
+        public static System.Threading.Tasks.Task<T> LoadAsync<T>(string url, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Models.OpenApiDocument openApiDocument, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken token = default)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
-        public static System.Threading.Tasks.Task<T> LoadAsync<T>(System.IO.Stream input, Microsoft.OpenApi.OpenApiSpecVersion version, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken token = default)
+        public static System.Threading.Tasks.Task<T> LoadAsync<T>(System.IO.Stream input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Models.OpenApiDocument openApiDocument, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null, System.Threading.CancellationToken token = default)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
         public static Microsoft.OpenApi.Reader.ReadResult Parse(string input, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null) { }
-        public static T Parse<T>(string input, Microsoft.OpenApi.OpenApiSpecVersion version, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
+        public static T Parse<T>(string input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Models.OpenApiDocument openApiDocument, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, string format = null, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
     }
     public static class OpenApiReaderRegistry
@@ -1368,7 +1370,7 @@ namespace Microsoft.OpenApi.Reader
         public T GetFromTempStorage<T>(string key, object scope = null) { }
         public string GetLocation() { }
         public Microsoft.OpenApi.Models.OpenApiDocument Parse(System.Text.Json.Nodes.JsonNode jsonNode) { }
-        public T ParseFragment<T>(System.Text.Json.Nodes.JsonNode jsonNode, Microsoft.OpenApi.OpenApiSpecVersion version)
+        public T ParseFragment<T>(System.Text.Json.Nodes.JsonNode jsonNode, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Models.OpenApiDocument openApiDocument)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
         public void PopLoop(string loopid) { }
         public bool PushLoop(string loopId, string key) { }
@@ -1501,6 +1503,7 @@ namespace Microsoft.OpenApi.Services
         public virtual void Visit(Microsoft.OpenApi.Models.OpenApiServer server) { }
         public virtual void Visit(Microsoft.OpenApi.Models.OpenApiServerVariable serverVariable) { }
         public virtual void Visit(Microsoft.OpenApi.Models.OpenApiTag tag) { }
+        public virtual void Visit(Microsoft.OpenApi.Models.References.OpenApiTagReference tag) { }
         public virtual void Visit(System.Collections.Generic.IDictionary<Microsoft.OpenApi.Models.OperationType, Microsoft.OpenApi.Models.OpenApiOperation> operations) { }
         public virtual void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiCallback> callbacks) { }
         public virtual void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiEncoding> encodings) { }
@@ -1515,6 +1518,7 @@ namespace Microsoft.OpenApi.Services
         public virtual void Visit(System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiSecurityRequirement> openApiSecurityRequirements) { }
         public virtual void Visit(System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiServer> servers) { }
         public virtual void Visit(System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiTag> openApiTags) { }
+        public virtual void Visit(System.Collections.Generic.IList<Microsoft.OpenApi.Models.References.OpenApiTagReference> openApiTags) { }
         public virtual void Visit(System.Text.Json.Nodes.JsonNode node) { }
     }
     public class OpenApiWalker

--- a/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
@@ -328,5 +328,9 @@ namespace Microsoft.OpenApi.Tests.Walkers
         {
             Locations.Add(this.PathString);
         }
+        public override void Visit(IList<OpenApiTagReference> openApiTags)
+        {
+            Locations.Add(this.PathString);
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiReferencableTests.cs
@@ -47,8 +47,6 @@ namespace Microsoft.OpenApi.Tests.Workspaces
         };
         private static readonly OpenApiSchema _schemaFragment = new OpenApiSchema();
         private static readonly OpenApiSecurityScheme _securitySchemeFragment = new OpenApiSecurityScheme();
-        private static readonly OpenApiTag _tagFragment = new OpenApiTag();
-
         public static IEnumerable<object[]> ResolveReferenceCanResolveValidJsonPointersTestData =>
         new List<object[]>
         {
@@ -64,7 +62,6 @@ namespace Microsoft.OpenApi.Tests.Workspaces
             new object[] { _responseFragment, "/headers/header1", _responseFragment.Headers["header1"] },
             new object[] { _responseFragment, "/links/link1", _responseFragment.Links["link1"] },
             new object[] { _securitySchemeFragment, "/", _securitySchemeFragment},
-            new object[] { _tagFragment, "/", _tagFragment}
         };
 
         [Theory]


### PR DESCRIPTION
This fixes multiple issues:
- tag references are not like other component references. The tag in the operation is just a string. We had a lot of special casing, etc...
- lot of side effects where we were impacting the source tag by assigning things to the reference. As discussed in #1998
- fixes references not being resolvable in a lot of contexts due to a missing document reference.

We should still break the inheritance, and use a base abstract class as well.