### PR TITLE
make IDiagnosticExtensions internal and fix namespace

### DIFF
--- a/src/Microsoft.OpenApi/Reader/OpenApiDiagnostic.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiDiagnostic.cs
@@ -48,26 +48,26 @@ namespace Microsoft.OpenApi.Reader
             }
         }
     }
-}
 
-/// <summary>
-/// Extension class for IList to add the Method "AddRange" used above
-/// </summary>
-public static class IDiagnosticExtensions
-{
     /// <summary>
-    /// Extension method for IList so that another list can be added to the current list.
+    /// Extension class for IList to add the Method "AddRange" used above
     /// </summary>
-    /// <param name="collection"></param>
-    /// <param name="enumerable"></param>
-    /// <typeparam name="T"></typeparam>
-    public static void AddRange<T>(this ICollection<T> collection, IEnumerable<T> enumerable)
+    internal static class IDiagnosticExtensions
     {
-        if (collection is null || enumerable is null) return;
-
-        foreach (var cur in enumerable)
+        /// <summary>
+        /// Extension method for IList so that another list can be added to the current list.
+        /// </summary>
+        /// <param name="collection"></param>
+        /// <param name="enumerable"></param>
+        /// <typeparam name="T"></typeparam>
+        public static void AddRange<T>(this ICollection<T> collection, IEnumerable<T> enumerable)
         {
-            collection.Add(cur);
+            if (collection is null || enumerable is null) return;
+
+            foreach (var cur in enumerable)
+            {
+                collection.Add(cur);
+            }
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -2,10 +2,6 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Microsoft.OpenApi.Readers.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100957cb48387b2a5f54f5ce39255f18f26d32a39990db27cf48737afc6bc62759ba996b8a2bfb675d4e39f3d06ecb55a178b1b4031dcb2a767e29977d88cce864a0d16bfc1b3bebb0edf9fe285f10fffc0a85f93d664fa05af07faa3aad2e545182dbf787e3fd32b56aca95df1a3c4e75dec164a3f1a4c653d971b01ffc39eb3c4")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"Microsoft.OpenApi.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100957cb48387b2a5f54f5ce39255f18f26d32a39990db27cf48737afc6bc62759ba996b8a2bfb675d4e39f3d06ecb55a178b1b4031dcb2a767e29977d88cce864a0d16bfc1b3bebb0edf9fe285f10fffc0a85f93d664fa05af07faa3aad2e545182dbf787e3fd32b56aca95df1a3c4e75dec164a3f1a4c653d971b01ffc39eb3c4")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
-public static class IDiagnosticExtensions
-{
-    public static void AddRange<T>(this System.Collections.Generic.ICollection<T> collection, System.Collections.Generic.IEnumerable<T> enumerable) { }
-}
 namespace Microsoft.OpenApi.Any
 {
     public class OpenApiAny : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtension


### PR DESCRIPTION
I assume this was neither meant to be public nor meant to be in the global namespace. I noticed this when trying the latest preview because it conflicted with our own AddRange extension method.

This was introduced in #1245 and made public in https://github.com/microsoft/OpenAPI.NET/commit/90dc7fc5587cee40f5964919387baa3bafd8b9d8#diff-65294c3e990da88445c0036dfe9f8e7bcfb00675881d47c22fb3c6000c3b9d76R56 .