### PR TITLE
fixes OpenAPI v2 request body parameter references serialization

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -283,7 +283,7 @@ namespace Microsoft.OpenApi.Models
                 {
                     foreach (var requestBody in Components.RequestBodies.Where(b => !parameters.ContainsKey(b.Key)))
                     {
-                        parameters.Add(requestBody.Key, requestBody.Value.ConvertToBodyParameter());
+                        parameters.Add(requestBody.Key, requestBody.Value.ConvertToBodyParameter(writer));
                     }
                 }
                 writer.WriteOptionalMap(

--- a/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
@@ -212,7 +212,7 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         public void SerializeAsV2(IOpenApiWriter writer)
         {
-            Utils.CheckArgumentNull(writer);;
+            Utils.CheckArgumentNull(writer);
 
             writer.WriteStartObject();
 
@@ -258,7 +258,7 @@ namespace Microsoft.OpenApi.Models
                     }
                     else
                     {
-                        parameters.Add(RequestBody.ConvertToBodyParameter());
+                        parameters.Add(RequestBody.ConvertToBodyParameter(writer));
                     }
                 }
                 else if (RequestBody.Reference != null && RequestBody.Reference.HostDocument is {} hostDocument)

--- a/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
@@ -112,7 +112,7 @@ namespace Microsoft.OpenApi.Models
             // RequestBody object does not exist in V2.
         }
 
-        internal OpenApiBodyParameter ConvertToBodyParameter()
+        internal virtual OpenApiParameter ConvertToBodyParameter(IOpenApiWriter writer)
         {
             var bodyParameter = new OpenApiBodyParameter
             {

--- a/src/Microsoft.OpenApi/Models/References/OpenApiRequestBodyReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiRequestBodyReference.cs
@@ -92,7 +92,6 @@ namespace Microsoft.OpenApi.Models.References
             if (!writer.GetSettings().ShouldInlineReference(_reference))
             {
                 _reference.SerializeAsV3(writer);
-                return;
             }
             else
             {
@@ -106,7 +105,6 @@ namespace Microsoft.OpenApi.Models.References
             if (!writer.GetSettings().ShouldInlineReference(_reference))
             {
                 _reference.SerializeAsV31(writer);
-                return;
             }
             else
             {

--- a/src/Microsoft.OpenApi/Models/References/OpenApiRequestBodyReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiRequestBodyReference.cs
@@ -119,5 +119,18 @@ namespace Microsoft.OpenApi.Models.References
             Utils.CheckArgumentNull(writer);
             action(writer, Target);
         }
+
+        /// <inheritdoc/>
+        internal override OpenApiParameter ConvertToBodyParameter(IOpenApiWriter writer)
+        {
+            if (writer.GetSettings().ShouldInlineReference(_reference))
+            {
+                return Target.ConvertToBodyParameter(writer);
+            }
+            else
+            {
+                return new OpenApiParameterReference(_reference.Id, _reference.HostDocument);
+            }
+        }
     }
 }


### PR DESCRIPTION
fixes a bug where OpenAPI v2 body parameter references would not serialize properly and always inline the definition