### PR TITLE
fix/references cleanup

### DIFF
--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiReferenceHolder.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiReferenceHolder.cs
@@ -8,22 +8,14 @@ namespace Microsoft.OpenApi.Interfaces
     /// <summary>
     /// A generic interface for OpenApiReferenceable objects that have a target.
     /// </summary>
-    /// <typeparam name="T">Type of the target being referenced</typeparam>
-    public interface IOpenApiReferenceHolder<out T> : IOpenApiReferenceHolder where T : IOpenApiReferenceable
+    /// <typeparam name="T">The type of the target being referenced</typeparam>
+    /// <typeparam name="V">The type of the interface implemented by both the target and the reference type</typeparam>
+    public interface IOpenApiReferenceHolder<out T, V> : IOpenApiReferenceHolder where T : IOpenApiReferenceable, V
     {
         /// <summary>
         /// Gets the resolved target object.
         /// </summary>
         T Target { get; }
-    }
-    /// <summary>
-    /// A generic interface for OpenApiReferenceable objects that have a target.
-    /// </summary>
-    /// <typeparam name="T">The type of the target being referenced</typeparam>
-    /// <typeparam name="V">The type of the interface implemented by both the target and the reference type</typeparam>
-    public interface IOpenApiReferenceHolder<out T, V> : IOpenApiReferenceHolder<T> where T : IOpenApiReferenceable, V
-    {
-        //TODO merge this interface with the previous once all implementations are updated
         /// <summary>
         /// Copy the reference as a target element with overrides.
         /// </summary>
@@ -37,8 +29,7 @@ namespace Microsoft.OpenApi.Interfaces
         /// <summary>
         /// Indicates if object is populated with data or is just a reference to the data
         /// </summary>
-        bool UnresolvedReference { get; set; }
-        //TODO the UnresolvedReference property setter should be removed and a default implementation that checks whether the target is null for the getter should be provided instead
+        bool UnresolvedReference { get; }
 
         /// <summary>
         /// Reference object.

--- a/src/Microsoft.OpenApi/Interfaces/IShallowCopyable.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IShallowCopyable.cs
@@ -1,0 +1,12 @@
+namespace Microsoft.OpenApi.Interfaces;
+/// <summary>
+/// Interface for shallow copyable objects.
+/// </summary>
+/// <typeparam name="T">The type of the resulting object</typeparam>
+public interface IShallowCopyable<out T>
+{
+    /// <summary>
+    /// Create a shallow copy of the current instance.
+    /// </summary>
+    T CreateShallowCopy();
+}

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiCallback.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiCallback.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OpenApi.Models.Interfaces;
 /// Defines the base properties for the callback object.
 /// This interface is provided for type assertions but should not be implemented by package consumers beyond automatic mocking.
 /// </summary>
-public interface IOpenApiCallback : IOpenApiSerializable, IOpenApiReadOnlyExtensible
+public interface IOpenApiCallback : IOpenApiSerializable, IOpenApiReadOnlyExtensible, IShallowCopyable<IOpenApiCallback>
 {
     /// <summary>
     /// A Path Item Object used to define a callback request and expected responses.

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiExample.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiExample.cs
@@ -7,7 +7,7 @@ namespace Microsoft.OpenApi.Models.Interfaces;
 /// Defines the base properties for the example object.
 /// This interface is provided for type assertions but should not be implemented by package consumers beyond automatic mocking.
 /// </summary>
-public interface IOpenApiExample : IOpenApiDescribedElement, IOpenApiSummarizedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible
+public interface IOpenApiExample : IOpenApiDescribedElement, IOpenApiSummarizedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible, IShallowCopyable<IOpenApiExample>
 {
     /// <summary>
     /// Embedded literal example. The value field and externalValue field are mutually

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiHeader.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiHeader.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OpenApi.Models.Interfaces;
 /// Defines the base properties for the headers object.
 /// This interface is provided for type assertions but should not be implemented by package consumers beyond automatic mocking.
 /// </summary>
-public interface IOpenApiHeader : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible
+public interface IOpenApiHeader : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible, IShallowCopyable<IOpenApiHeader>
 {
     /// <summary>
     /// Determines whether this header is mandatory.

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiLink.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiLink.cs
@@ -7,7 +7,7 @@ namespace Microsoft.OpenApi.Models.Interfaces;
 /// Defines the base properties for the link object.
 /// This interface is provided for type assertions but should not be implemented by package consumers beyond automatic mocking.
 /// </summary>
-public interface IOpenApiLink : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible
+public interface IOpenApiLink : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible, IShallowCopyable<IOpenApiLink>
 {
     /// <summary>
     /// A relative or absolute reference to an OAS operation.

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiParameter.cs
@@ -8,7 +8,7 @@ namespace Microsoft.OpenApi.Models.Interfaces;
 /// Defines the base properties for the parameter object.
 /// This interface is provided for type assertions but should not be implemented by package consumers beyond automatic mocking.
 /// </summary>
-public interface IOpenApiParameter : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible
+public interface IOpenApiParameter : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible, IShallowCopyable<IOpenApiParameter>
 {
     /// <summary>
     /// REQUIRED. The name of the parameter. Parameter names are case sensitive.

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiPathItem.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiPathItem.cs
@@ -8,7 +8,7 @@ namespace Microsoft.OpenApi.Models.Interfaces;
 /// Defines the base properties for the path item object.
 /// This interface is provided for type assertions but should not be implemented by package consumers beyond automatic mocking.
 /// </summary>
-public interface IOpenApiPathItem : IOpenApiDescribedElement, IOpenApiSummarizedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible
+public interface IOpenApiPathItem : IOpenApiDescribedElement, IOpenApiSummarizedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible, IShallowCopyable<IOpenApiPathItem>
 {
     /// <summary>
     /// Gets the definition of operations on this path.

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiRequestBody.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiRequestBody.cs
@@ -8,7 +8,7 @@ namespace Microsoft.OpenApi.Models.Interfaces;
 /// Defines the base properties for the request body object.
 /// This interface is provided for type assertions but should not be implemented by package consumers beyond automatic mocking.
 /// </summary>
-public interface IOpenApiRequestBody : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible
+public interface IOpenApiRequestBody : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible, IShallowCopyable<IOpenApiRequestBody>
 {
     /// <summary>
     /// Determines if the request body is required in the request. Defaults to false.

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiResponse.cs
@@ -7,7 +7,7 @@ namespace Microsoft.OpenApi.Models.Interfaces;
 /// Defines the base properties for the response object.
 /// This interface is provided for type assertions but should not be implemented by package consumers beyond automatic mocking.
 /// </summary>
-public interface IOpenApiResponse : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible
+public interface IOpenApiResponse : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible, IShallowCopyable<IOpenApiResponse>
 {
     /// <summary>
     /// Maps a header name to its definition.

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiSchema.cs
@@ -8,7 +8,7 @@ namespace Microsoft.OpenApi.Models.Interfaces;
 /// Defines the base properties for the schema object.
 /// This interface is provided for type assertions but should not be implemented by package consumers beyond automatic mocking.
 /// </summary>
-public interface IOpenApiSchema : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible
+public interface IOpenApiSchema : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible, IShallowCopyable<IOpenApiSchema>
 {
     
     /// <summary>

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiSecurityScheme.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiSecurityScheme.cs
@@ -8,7 +8,7 @@ namespace Microsoft.OpenApi.Models.Interfaces;
 /// Defines the base properties for the security scheme object.
 /// This interface is provided for type assertions but should not be implemented by package consumers beyond automatic mocking.
 /// </summary>
-public interface IOpenApiSecurityScheme : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible
+public interface IOpenApiSecurityScheme : IOpenApiDescribedElement, IOpenApiSerializable, IOpenApiReadOnlyExtensible, IShallowCopyable<IOpenApiSecurityScheme>
 {
     /// <summary>
     /// REQUIRED. The type of the security scheme. Valid values are "apiKey", "http", "oauth2", "openIdConnect".

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiTag.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiTag.cs
@@ -6,7 +6,7 @@ namespace Microsoft.OpenApi.Models.Interfaces;
 /// Defines the base properties for the path item object.
 /// This interface is provided for type assertions but should not be implemented by package consumers beyond automatic mocking.
 /// </summary>
-public interface IOpenApiTag : IOpenApiSerializable, IOpenApiReadOnlyExtensible, IOpenApiReadOnlyDescribedElement
+public interface IOpenApiTag : IOpenApiSerializable, IOpenApiReadOnlyExtensible, IOpenApiReadOnlyDescribedElement, IShallowCopyable<IOpenApiTag>
 {
     /// <summary>
     /// The name of the tag.

--- a/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
@@ -33,7 +33,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Initializes a copy of an <see cref="OpenApiCallback"/> object
         /// </summary>
-        public OpenApiCallback(IOpenApiCallback callback)
+        internal OpenApiCallback(IOpenApiCallback callback)
         {
             PathItems = callback?.PathItems != null ? new(callback?.PathItems) : null;
             Extensions = callback?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(callback.Extensions) : null;
@@ -97,6 +97,12 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             // Callback object does not exist in V2.
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiCallback CreateShallowCopy()
+        {
+            return new OpenApiCallback(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
@@ -35,6 +35,7 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         internal OpenApiCallback(IOpenApiCallback callback)
         {
+            Utils.CheckArgumentNull(callback);
             PathItems = callback?.PathItems != null ? new(callback?.PathItems) : null;
             Extensions = callback?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(callback.Extensions) : null;
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -587,43 +587,43 @@ namespace Microsoft.OpenApi.Models
             Components ??= new();
             switch (componentToRegister)
             {
-                case OpenApiSchema openApiSchema:
+                case IOpenApiSchema openApiSchema:
                     Components.Schemas ??= new Dictionary<string, IOpenApiSchema>();
                     Components.Schemas.Add(id, openApiSchema);
                     break;
-                case OpenApiParameter openApiParameter:
+                case IOpenApiParameter openApiParameter:
                     Components.Parameters ??= new Dictionary<string, IOpenApiParameter>();
                     Components.Parameters.Add(id, openApiParameter);
                     break;
-                case OpenApiResponse openApiResponse:
+                case IOpenApiResponse openApiResponse:
                     Components.Responses ??= new Dictionary<string, IOpenApiResponse>();
                     Components.Responses.Add(id, openApiResponse);
                     break;
-                case OpenApiRequestBody openApiRequestBody:
+                case IOpenApiRequestBody openApiRequestBody:
                     Components.RequestBodies ??= new Dictionary<string, IOpenApiRequestBody>();
                     Components.RequestBodies.Add(id, openApiRequestBody);
                     break;
-                case OpenApiLink openApiLink:
+                case IOpenApiLink openApiLink:
                     Components.Links ??= new Dictionary<string, IOpenApiLink>();
                     Components.Links.Add(id, openApiLink);
                     break;
-                case OpenApiCallback openApiCallback:
+                case IOpenApiCallback openApiCallback:
                     Components.Callbacks ??= new Dictionary<string, IOpenApiCallback>();
                     Components.Callbacks.Add(id, openApiCallback);
                     break;
-                case OpenApiPathItem openApiPathItem:
+                case IOpenApiPathItem openApiPathItem:
                     Components.PathItems ??= new Dictionary<string, IOpenApiPathItem>();
                     Components.PathItems.Add(id, openApiPathItem);
                     break;
-                case OpenApiExample openApiExample:
+                case IOpenApiExample openApiExample:
                     Components.Examples ??= new Dictionary<string, IOpenApiExample>();
                     Components.Examples.Add(id, openApiExample);
                     break;
-                case OpenApiHeader openApiHeader:
+                case IOpenApiHeader openApiHeader:
                     Components.Headers ??= new Dictionary<string, IOpenApiHeader>();
                     Components.Headers.Add(id, openApiHeader);
                     break;
-                case OpenApiSecurityScheme openApiSecurityScheme:
+                case IOpenApiSecurityScheme openApiSecurityScheme:
                     Components.SecuritySchemes ??= new Dictionary<string, IOpenApiSecurityScheme>();
                     Components.SecuritySchemes.Add(id, openApiSecurityScheme);
                     break;

--- a/src/Microsoft.OpenApi/Models/OpenApiExample.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExample.cs
@@ -39,7 +39,7 @@ namespace Microsoft.OpenApi.Models
         /// Initializes a copy of <see cref="OpenApiExample"/> object
         /// </summary>
         /// <param name="example">The <see cref="IOpenApiExample"/> object</param>
-        public OpenApiExample(IOpenApiExample example)
+        internal OpenApiExample(IOpenApiExample example)
         {
             Utils.CheckArgumentNull(example);
             Summary = example.Summary ?? Summary;
@@ -89,6 +89,12 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi2_0);
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiExample CreateShallowCopy()
+        {
+            return new OpenApiExample(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
@@ -72,7 +72,7 @@ namespace Microsoft.OpenApi.Models
             Style = header?.Style ?? Style;
             Explode = header?.Explode ?? Explode;
             AllowReserved = header?.AllowReserved ?? AllowReserved;
-            Schema = header?.Schema != null ? new OpenApiSchema(header.Schema) : null;
+            Schema = header?.Schema?.CreateShallowCopy();
             Example = header?.Example != null ? JsonNodeCloneHelper.Clone(header.Example) : null;
             Examples = header?.Examples != null ? new Dictionary<string, IOpenApiExample>(header.Examples) : null;
             Content = header?.Content != null ? new Dictionary<string, OpenApiMediaType>(header.Content) : null;

--- a/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
@@ -65,18 +65,19 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         internal OpenApiHeader(IOpenApiHeader header)
         {
-            Description = header?.Description ?? Description;
-            Required = header?.Required ?? Required;
-            Deprecated = header?.Deprecated ?? Deprecated;
-            AllowEmptyValue = header?.AllowEmptyValue ?? AllowEmptyValue;
-            Style = header?.Style ?? Style;
-            Explode = header?.Explode ?? Explode;
-            AllowReserved = header?.AllowReserved ?? AllowReserved;
-            Schema = header?.Schema?.CreateShallowCopy();
-            Example = header?.Example != null ? JsonNodeCloneHelper.Clone(header.Example) : null;
-            Examples = header?.Examples != null ? new Dictionary<string, IOpenApiExample>(header.Examples) : null;
-            Content = header?.Content != null ? new Dictionary<string, OpenApiMediaType>(header.Content) : null;
-            Extensions = header?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(header.Extensions) : null;
+            Utils.CheckArgumentNull(header);
+            Description = header.Description ?? Description;
+            Required = header.Required;
+            Deprecated = header.Deprecated;
+            AllowEmptyValue = header.AllowEmptyValue;
+            Style = header.Style ?? Style;
+            Explode = header.Explode;
+            AllowReserved = header.AllowReserved;
+            Schema = header.Schema.CreateShallowCopy();
+            Example = header.Example != null ? JsonNodeCloneHelper.Clone(header.Example) : null;
+            Examples = header.Examples != null ? new Dictionary<string, IOpenApiExample>(header.Examples) : null;
+            Content = header.Content != null ? new Dictionary<string, OpenApiMediaType>(header.Content) : null;
+            Extensions = header.Extensions != null ? new Dictionary<string, IOpenApiExtension>(header.Extensions) : null;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
@@ -63,7 +63,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Initializes a copy of an <see cref="OpenApiHeader"/> object
         /// </summary>
-        public OpenApiHeader(IOpenApiHeader header)
+        internal OpenApiHeader(IOpenApiHeader header)
         {
             Description = header?.Description ?? Description;
             Required = header?.Required ?? Required;
@@ -186,6 +186,12 @@ namespace Microsoft.OpenApi.Models
             writer.WriteExtensions(Extensions, OpenApiSpecVersion.OpenApi2_0);
 
             writer.WriteEndObject();
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiHeader CreateShallowCopy()
+        {
+            return new OpenApiHeader(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiLink.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiLink.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Initializes a copy of an <see cref="OpenApiLink"/> object
         /// </summary>
-        public OpenApiLink(IOpenApiLink link)
+        internal OpenApiLink(IOpenApiLink link)
         {
             Utils.CheckArgumentNull(link);
             OperationRef = link.OperationRef ?? OperationRef;
@@ -101,6 +101,12 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV2(IOpenApiWriter writer)
         {
             // Link object does not exist in V2.
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiLink CreateShallowCopy()
+        {
+            return new OpenApiLink(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
@@ -59,7 +59,7 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         public OpenApiMediaType(OpenApiMediaType? mediaType)
         {
-            Schema = mediaType?.Schema != null ? new OpenApiSchema(mediaType.Schema) : null;
+            Schema = mediaType?.Schema?.CreateShallowCopy();
             Example = mediaType?.Example != null ? JsonNodeCloneHelper.Clone(mediaType.Example) : null;
             Examples = mediaType?.Examples != null ? new Dictionary<string, IOpenApiExample>(mediaType.Examples) : null;
             Encoding = mediaType?.Encoding != null ? new Dictionary<string, OpenApiEncoding>(mediaType.Encoding) : null;

--- a/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
@@ -120,22 +120,23 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Initializes a copy of an <see cref="OpenApiOperation"/> object
         /// </summary>
-        public OpenApiOperation(OpenApiOperation? operation)
+        public OpenApiOperation(OpenApiOperation operation)
         {
-            Tags = operation?.Tags != null ? new List<OpenApiTagReference>(operation.Tags) : null;
-            Summary = operation?.Summary ?? Summary;
-            Description = operation?.Description ?? Description;
-            ExternalDocs = operation?.ExternalDocs != null ? new(operation?.ExternalDocs) : null;
-            OperationId = operation?.OperationId ?? OperationId;
-            Parameters = operation?.Parameters != null ? new List<IOpenApiParameter>(operation.Parameters) : null;
-            RequestBody = operation?.RequestBody != null ? new OpenApiRequestBody(operation?.RequestBody) : null;
-            Responses = operation?.Responses != null ? new(operation?.Responses) : null;
-            Callbacks = operation?.Callbacks != null ? new Dictionary<string, IOpenApiCallback>(operation.Callbacks) : null;
-            Deprecated = operation?.Deprecated ?? Deprecated;
-            Security = operation?.Security != null ? new List<OpenApiSecurityRequirement>(operation.Security) : null;
-            Servers = operation?.Servers != null ? new List<OpenApiServer>(operation.Servers) : null;
-            Extensions = operation?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(operation.Extensions) : null;
-            Annotations = operation?.Annotations != null ? new Dictionary<string, object>(operation.Annotations) : null;
+            Utils.CheckArgumentNull(operation);
+            Tags = operation.Tags != null ? new List<OpenApiTagReference>(operation.Tags) : null;
+            Summary = operation.Summary ?? Summary;
+            Description = operation.Description ?? Description;
+            ExternalDocs = operation.ExternalDocs != null ? new(operation.ExternalDocs) : null;
+            OperationId = operation.OperationId ?? OperationId;
+            Parameters = operation.Parameters != null ? new List<IOpenApiParameter>(operation.Parameters) : null;
+            RequestBody = operation.RequestBody?.CreateShallowCopy();
+            Responses = operation.Responses != null ? new(operation.Responses) : null;
+            Callbacks = operation.Callbacks != null ? new Dictionary<string, IOpenApiCallback>(operation.Callbacks) : null;
+            Deprecated = operation.Deprecated;
+            Security = operation.Security != null ? new List<OpenApiSecurityRequirement>(operation.Security) : null;
+            Servers = operation.Servers != null ? new List<OpenApiServer>(operation.Servers) : null;
+            Extensions = operation.Extensions != null ? new Dictionary<string, IOpenApiExtension>(operation.Extensions) : null;
+            Annotations = operation.Annotations != null ? new Dictionary<string, object>(operation.Annotations) : null;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
@@ -278,12 +278,7 @@ namespace Microsoft.OpenApi.Models
                 var produces = Responses
                     .Where(static r => r.Value.Content != null)
                     .SelectMany(static r => r.Value.Content?.Keys ?? [])
-                    .Concat(
-                        Responses
-                        .Select(static r => r.Value)
-                        .OfType<OpenApiResponseReference>()
-                        .Where(static r => r.Reference is {HostDocument: not null})
-                        .SelectMany(static r => r.Content?.Keys ?? []))
+                    .Where(static m => !string.IsNullOrEmpty(m))
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToArray();
 

--- a/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
@@ -90,7 +90,7 @@ namespace Microsoft.OpenApi.Models
             Style = parameter.Style ?? Style;
             Explode = parameter.Explode;
             AllowReserved = parameter.AllowReserved;
-            Schema = parameter.Schema != null ? new OpenApiSchema(parameter.Schema) : null;
+            Schema = parameter.Schema.CreateShallowCopy();
             Examples = parameter.Examples != null ? new Dictionary<string, IOpenApiExample>(parameter.Examples) : null;
             Example = parameter.Example != null ? JsonNodeCloneHelper.Clone(parameter.Example) : null;
             Content = parameter.Content != null ? new Dictionary<string, OpenApiMediaType>(parameter.Content) : null;

--- a/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
@@ -80,7 +80,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Initializes a clone instance of <see cref="OpenApiParameter"/> object
         /// </summary>
-        public OpenApiParameter(IOpenApiParameter parameter)
+        internal OpenApiParameter(IOpenApiParameter parameter)
         {
             Utils.CheckArgumentNull(parameter);
             Name = parameter.Name ?? Name;
@@ -301,6 +301,12 @@ namespace Microsoft.OpenApi.Models
                 ParameterLocation.Cookie => ParameterStyle.Form,
                 _ => (ParameterStyle?)ParameterStyle.Simple,
             };
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiParameter CreateShallowCopy()
+        {
+            return new OpenApiParameter(this);
         }
     }
 

--- a/src/Microsoft.OpenApi/Models/OpenApiPathItem.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiPathItem.cs
@@ -55,12 +55,12 @@ namespace Microsoft.OpenApi.Models
         internal OpenApiPathItem(IOpenApiPathItem pathItem)
         {
             Utils.CheckArgumentNull(pathItem);
-            Summary = pathItem?.Summary ?? Summary;
-            Description = pathItem?.Description ?? Description;
-            Operations = pathItem?.Operations != null ? new Dictionary<OperationType, OpenApiOperation>(pathItem.Operations) : null;
-            Servers = pathItem?.Servers != null ? new List<OpenApiServer>(pathItem.Servers) : null;
-            Parameters = pathItem?.Parameters != null ? new List<IOpenApiParameter>(pathItem.Parameters) : null;
-            Extensions = pathItem?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(pathItem.Extensions) : null;
+            Summary = pathItem.Summary ?? Summary;
+            Description = pathItem.Description ?? Description;
+            Operations = pathItem.Operations != null ? new Dictionary<OperationType, OpenApiOperation>(pathItem.Operations) : null;
+            Servers = pathItem.Servers != null ? new List<OpenApiServer>(pathItem.Servers) : null;
+            Parameters = pathItem.Parameters != null ? new List<IOpenApiParameter>(pathItem.Parameters) : null;
+            Extensions = pathItem.Extensions != null ? new Dictionary<string, IOpenApiExtension>(pathItem.Extensions) : null;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiPathItem.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiPathItem.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Initializes a clone of an <see cref="OpenApiPathItem"/> object
         /// </summary>
-        public OpenApiPathItem(IOpenApiPathItem pathItem)
+        internal OpenApiPathItem(IOpenApiPathItem pathItem)
         {
             Utils.CheckArgumentNull(pathItem);
             Summary = pathItem?.Summary ?? Summary;
@@ -150,6 +150,12 @@ namespace Microsoft.OpenApi.Models
             writer.WriteExtensions(Extensions, version);
 
             writer.WriteEndObject();
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiPathItem CreateShallowCopy()
+        {
+            return new OpenApiPathItem(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
@@ -38,7 +38,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Initializes a copy instance of an <see cref="IOpenApiRequestBody"/> object
         /// </summary>
-        public OpenApiRequestBody(IOpenApiRequestBody requestBody)
+        internal OpenApiRequestBody(IOpenApiRequestBody requestBody)
         {
             Utils.CheckArgumentNull(requestBody);
             Description = requestBody?.Description ?? Description;
@@ -149,6 +149,12 @@ namespace Microsoft.OpenApi.Models
                     Required = Content.First().Value.Schema.Required?.Contains(property.Key) ?? false
                 };
             }
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiRequestBody CreateShallowCopy()
+        {
+            return new OpenApiRequestBody(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
@@ -41,10 +41,10 @@ namespace Microsoft.OpenApi.Models
         internal OpenApiRequestBody(IOpenApiRequestBody requestBody)
         {
             Utils.CheckArgumentNull(requestBody);
-            Description = requestBody?.Description ?? Description;
-            Required = requestBody?.Required ?? Required;
-            Content = requestBody?.Content != null ? new Dictionary<string, OpenApiMediaType>(requestBody.Content) : null;
-            Extensions = requestBody?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(requestBody.Extensions) : null;
+            Description = requestBody.Description ?? Description;
+            Required = requestBody.Required;
+            Content = requestBody.Content != null ? new Dictionary<string, OpenApiMediaType>(requestBody.Content) : null;
+            Extensions = requestBody.Extensions != null ? new Dictionary<string, IOpenApiExtension>(requestBody.Extensions) : null;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
@@ -38,14 +38,14 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Initializes a copy of <see cref="IOpenApiResponse"/> object
         /// </summary>
-        public OpenApiResponse(IOpenApiResponse response)
+        internal OpenApiResponse(IOpenApiResponse response)
         {
             Utils.CheckArgumentNull(response);
-            Description = response?.Description ?? Description;
-            Headers = response?.Headers != null ? new Dictionary<string, IOpenApiHeader>(response.Headers) : null;
-            Content = response?.Content != null ? new Dictionary<string, OpenApiMediaType>(response.Content) : null;
-            Links = response?.Links != null ? new Dictionary<string, IOpenApiLink>(response.Links) : null;
-            Extensions = response?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(response.Extensions) : null;
+            Description = response.Description ?? Description;
+            Headers = response.Headers != null ? new Dictionary<string, IOpenApiHeader>(response.Headers) : null;
+            Content = response.Content != null ? new Dictionary<string, OpenApiMediaType>(response.Content) : null;
+            Links = response.Links != null ? new Dictionary<string, IOpenApiLink>(response.Links) : null;
+            Extensions = response.Extensions != null ? new Dictionary<string, IOpenApiExtension>(response.Extensions) : null;
         }
 
         /// <summary>
@@ -163,6 +163,12 @@ namespace Microsoft.OpenApi.Models
             writer.WriteExtensions(extensionsClone, OpenApiSpecVersion.OpenApi2_0);
 
             writer.WriteEndObject();
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiResponse CreateShallowCopy()
+        {
+            return new OpenApiResponse(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -186,60 +186,61 @@ namespace Microsoft.OpenApi.Models
         /// Initializes a copy of <see cref="IOpenApiSchema"/> object
         /// </summary>
         /// <param name="schema">The schema object to copy from.</param>
-        public OpenApiSchema(IOpenApiSchema schema)
+        internal OpenApiSchema(IOpenApiSchema schema)
         {
-            Title = schema?.Title ?? Title;
-            Id = schema?.Id ?? Id;
-            Const = schema?.Const ?? Const;
-            Schema = schema?.Schema ?? Schema;
-            Comment = schema?.Comment ?? Comment;
-            Vocabulary = schema?.Vocabulary != null ? new Dictionary<string, bool>(schema.Vocabulary) : null;
-            DynamicAnchor = schema?.DynamicAnchor ?? DynamicAnchor;
-            DynamicRef = schema?.DynamicRef ?? DynamicRef;
-            Definitions = schema?.Definitions != null ? new Dictionary<string, IOpenApiSchema>(schema.Definitions) : null;
-            UnevaluatedProperties = schema?.UnevaluatedProperties ?? UnevaluatedProperties;
-            V31ExclusiveMaximum = schema?.V31ExclusiveMaximum ?? V31ExclusiveMaximum;
-            V31ExclusiveMinimum = schema?.V31ExclusiveMinimum ?? V31ExclusiveMinimum;
-            Type = schema?.Type ?? Type;
-            Format = schema?.Format ?? Format;
-            Description = schema?.Description ?? Description;
-            Maximum = schema?.Maximum ?? Maximum;
-            ExclusiveMaximum = schema?.ExclusiveMaximum ?? ExclusiveMaximum;
-            Minimum = schema?.Minimum ?? Minimum;
-            ExclusiveMinimum = schema?.ExclusiveMinimum ?? ExclusiveMinimum;
-            MaxLength = schema?.MaxLength ?? MaxLength;
-            MinLength = schema?.MinLength ?? MinLength;
-            Pattern = schema?.Pattern ?? Pattern;
-            MultipleOf = schema?.MultipleOf ?? MultipleOf;
-            Default = schema?.Default != null ? JsonNodeCloneHelper.Clone(schema?.Default) : null;
-            ReadOnly = schema?.ReadOnly ?? ReadOnly;
-            WriteOnly = schema?.WriteOnly ?? WriteOnly;
-            AllOf = schema?.AllOf != null ? new List<IOpenApiSchema>(schema.AllOf) : null;
-            OneOf = schema?.OneOf != null ? new List<IOpenApiSchema>(schema.OneOf) : null;
-            AnyOf = schema?.AnyOf != null ? new List<IOpenApiSchema>(schema.AnyOf) : null;
-            Not = schema?.Not != null ? new OpenApiSchema(schema?.Not) : null;
-            Required = schema?.Required != null ? new HashSet<string>(schema.Required) : null;
-            Items = schema?.Items != null ? new OpenApiSchema(schema?.Items) : null;
-            MaxItems = schema?.MaxItems ?? MaxItems;
-            MinItems = schema?.MinItems ?? MinItems;
-            UniqueItems = schema?.UniqueItems ?? UniqueItems;
-            Properties = schema?.Properties != null ? new Dictionary<string, IOpenApiSchema>(schema.Properties) : null;
-            PatternProperties = schema?.PatternProperties != null ? new Dictionary<string, IOpenApiSchema>(schema.PatternProperties) : null;
-            MaxProperties = schema?.MaxProperties ?? MaxProperties;
-            MinProperties = schema?.MinProperties ?? MinProperties;
-            AdditionalPropertiesAllowed = schema?.AdditionalPropertiesAllowed ?? AdditionalPropertiesAllowed;
-            AdditionalProperties = schema?.AdditionalProperties != null ? new OpenApiSchema(schema?.AdditionalProperties) : null;
-            Discriminator = schema?.Discriminator != null ? new(schema?.Discriminator) : null; 
-            Example = schema?.Example != null ? JsonNodeCloneHelper.Clone(schema?.Example) : null;
-            Examples = schema?.Examples != null ? new List<JsonNode>(schema.Examples) : null;
-            Enum = schema?.Enum != null ? new List<JsonNode>(schema.Enum) : null;
-            Nullable = schema?.Nullable ?? Nullable;
-            ExternalDocs = schema?.ExternalDocs != null ? new(schema?.ExternalDocs) : null;
-            Deprecated = schema?.Deprecated ?? Deprecated;
-            Xml = schema?.Xml != null ? new(schema?.Xml) : null;
-            Extensions = schema?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(schema.Extensions) : null;
-            Annotations = schema?.Annotations != null ? new Dictionary<string, object>(schema?.Annotations) : null;
-            UnrecognizedKeywords = schema?.UnrecognizedKeywords != null ? new Dictionary<string, JsonNode>(schema?.UnrecognizedKeywords) : null;
+            Utils.CheckArgumentNull(schema);
+            Title = schema.Title ?? Title;
+            Id = schema.Id ?? Id;
+            Const = schema.Const ?? Const;
+            Schema = schema.Schema ?? Schema;
+            Comment = schema.Comment ?? Comment;
+            Vocabulary = schema.Vocabulary != null ? new Dictionary<string, bool>(schema.Vocabulary) : null;
+            DynamicAnchor = schema.DynamicAnchor ?? DynamicAnchor;
+            DynamicRef = schema.DynamicRef ?? DynamicRef;
+            Definitions = schema.Definitions != null ? new Dictionary<string, IOpenApiSchema>(schema.Definitions) : null;
+            UnevaluatedProperties = schema.UnevaluatedProperties;
+            V31ExclusiveMaximum = schema.V31ExclusiveMaximum ?? V31ExclusiveMaximum;
+            V31ExclusiveMinimum = schema.V31ExclusiveMinimum ?? V31ExclusiveMinimum;
+            Type = schema.Type ?? Type;
+            Format = schema.Format ?? Format;
+            Description = schema.Description ?? Description;
+            Maximum = schema.Maximum ?? Maximum;
+            ExclusiveMaximum = schema.ExclusiveMaximum ?? ExclusiveMaximum;
+            Minimum = schema.Minimum ?? Minimum;
+            ExclusiveMinimum = schema.ExclusiveMinimum ?? ExclusiveMinimum;
+            MaxLength = schema.MaxLength ?? MaxLength;
+            MinLength = schema.MinLength ?? MinLength;
+            Pattern = schema.Pattern ?? Pattern;
+            MultipleOf = schema.MultipleOf ?? MultipleOf;
+            Default = schema.Default != null ? JsonNodeCloneHelper.Clone(schema.Default) : null;
+            ReadOnly = schema.ReadOnly;
+            WriteOnly = schema.WriteOnly;
+            AllOf = schema.AllOf != null ? new List<IOpenApiSchema>(schema.AllOf) : null;
+            OneOf = schema.OneOf != null ? new List<IOpenApiSchema>(schema.OneOf) : null;
+            AnyOf = schema.AnyOf != null ? new List<IOpenApiSchema>(schema.AnyOf) : null;
+            Not = schema.Not?.CreateShallowCopy();
+            Required = schema.Required != null ? new HashSet<string>(schema.Required) : null;
+            Items = schema.Items?.CreateShallowCopy();
+            MaxItems = schema.MaxItems ?? MaxItems;
+            MinItems = schema.MinItems ?? MinItems;
+            UniqueItems = schema.UniqueItems ?? UniqueItems;
+            Properties = schema.Properties != null ? new Dictionary<string, IOpenApiSchema>(schema.Properties) : null;
+            PatternProperties = schema.PatternProperties != null ? new Dictionary<string, IOpenApiSchema>(schema.PatternProperties) : null;
+            MaxProperties = schema.MaxProperties ?? MaxProperties;
+            MinProperties = schema.MinProperties ?? MinProperties;
+            AdditionalPropertiesAllowed = schema.AdditionalPropertiesAllowed;
+            AdditionalProperties = schema.AdditionalProperties?.CreateShallowCopy();
+            Discriminator = schema.Discriminator != null ? new(schema.Discriminator) : null; 
+            Example = schema.Example != null ? JsonNodeCloneHelper.Clone(schema.Example) : null;
+            Examples = schema.Examples != null ? new List<JsonNode>(schema.Examples) : null;
+            Enum = schema.Enum != null ? new List<JsonNode>(schema.Enum) : null;
+            Nullable = schema.Nullable;
+            ExternalDocs = schema.ExternalDocs != null ? new(schema.ExternalDocs) : null;
+            Deprecated = schema.Deprecated;
+            Xml = schema.Xml != null ? new(schema.Xml) : null;
+            Extensions = schema.Extensions != null ? new Dictionary<string, IOpenApiExtension>(schema.Extensions) : null;
+            Annotations = schema.Annotations != null ? new Dictionary<string, object>(schema.Annotations) : null;
+            UnrecognizedKeywords = schema.UnrecognizedKeywords != null ? new Dictionary<string, JsonNode>(schema.UnrecognizedKeywords) : null;
         }
 
         /// <inheritdoc />
@@ -735,6 +736,12 @@ namespace Microsoft.OpenApi.Models
                     writer.WriteProperty(OpenApiConstants.Type, schemaType.ToIdentifier());
                 }
             }
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiSchema CreateShallowCopy()
+        {
+            return new OpenApiSchema(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiSecurityScheme.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSecurityScheme.cs
@@ -53,15 +53,15 @@ namespace Microsoft.OpenApi.Models
         internal OpenApiSecurityScheme(IOpenApiSecurityScheme securityScheme)
         {
             Utils.CheckArgumentNull(securityScheme);
-            Type = securityScheme?.Type;
-            Description = securityScheme?.Description ?? Description;
-            Name = securityScheme?.Name ?? Name;
-            In = securityScheme?.In;
-            Scheme = securityScheme?.Scheme ?? Scheme;
-            BearerFormat = securityScheme?.BearerFormat ?? BearerFormat;
-            Flows = securityScheme?.Flows != null ? new(securityScheme?.Flows) : null;
-            OpenIdConnectUrl = securityScheme?.OpenIdConnectUrl != null ? new Uri(securityScheme.OpenIdConnectUrl.OriginalString, UriKind.RelativeOrAbsolute) : null;
-            Extensions = securityScheme?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(securityScheme.Extensions) : null;
+            Type = securityScheme.Type;
+            Description = securityScheme.Description ?? Description;
+            Name = securityScheme.Name ?? Name;
+            In = securityScheme.In;
+            Scheme = securityScheme.Scheme ?? Scheme;
+            BearerFormat = securityScheme.BearerFormat ?? BearerFormat;
+            Flows = securityScheme.Flows != null ? new(securityScheme.Flows) : null;
+            OpenIdConnectUrl = securityScheme.OpenIdConnectUrl != null ? new Uri(securityScheme.OpenIdConnectUrl.OriginalString, UriKind.RelativeOrAbsolute) : null;
+            Extensions = securityScheme.Extensions != null ? new Dictionary<string, IOpenApiExtension>(securityScheme.Extensions) : null;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiSecurityScheme.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSecurityScheme.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Initializes a copy of <see cref="IOpenApiSecurityScheme"/> object
         /// </summary>
-        public OpenApiSecurityScheme(IOpenApiSecurityScheme securityScheme)
+        internal OpenApiSecurityScheme(IOpenApiSecurityScheme securityScheme)
         {
             Utils.CheckArgumentNull(securityScheme);
             Type = securityScheme?.Type;
@@ -228,6 +228,12 @@ namespace Microsoft.OpenApi.Models
 
             // scopes
             writer.WriteOptionalMap(OpenApiConstants.Scopes, flow.Scopes, (w, s) => w.WriteValue(s));
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiSecurityScheme CreateShallowCopy()
+        {
+            return new OpenApiSecurityScheme(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiTag.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiTag.cs
@@ -34,12 +34,13 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Initializes a copy of an <see cref="IOpenApiTag"/> object
         /// </summary>
-        public OpenApiTag(IOpenApiTag tag)
+        internal OpenApiTag(IOpenApiTag tag)
         {
-            Name = tag?.Name ?? Name;
-            Description = tag?.Description ?? Description;
-            ExternalDocs = tag?.ExternalDocs != null ? new(tag.ExternalDocs) : null;
-            Extensions = tag?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(tag.Extensions) : null;
+            Utils.CheckArgumentNull(tag);
+            Name = tag.Name ?? Name;
+            Description = tag.Description ?? Description;
+            ExternalDocs = tag.ExternalDocs != null ? new(tag.ExternalDocs) : null;
+            Extensions = tag.Extensions != null ? new Dictionary<string, IOpenApiExtension>(tag.Extensions) : null;
         }
 
         /// <summary>
@@ -100,6 +101,12 @@ namespace Microsoft.OpenApi.Models
             writer.WriteExtensions(Extensions, OpenApiSpecVersion.OpenApi2_0);
 
             writer.WriteEndObject();
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiTag CreateShallowCopy()
+        {
+            return new OpenApiTag(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
+++ b/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
@@ -31,7 +31,6 @@ public abstract class BaseOpenApiReferenceHolder<T, V> : IOpenApiReferenceHolder
     {
         Utils.CheckArgumentNull(source);
         Reference = source.Reference != null ? new(source.Reference) : null;
-        UnresolvedReference = source.UnresolvedReference;
         //no need to copy summary and description as if they are not overridden, they will be fetched from the target
         //if they are, the reference copy will handle it
     }
@@ -69,7 +68,7 @@ public abstract class BaseOpenApiReferenceHolder<T, V> : IOpenApiReferenceHolder
         };
     }
     /// <inheritdoc/>
-    public bool UnresolvedReference { get; set; }
+    public bool UnresolvedReference { get => Reference is null || Target is null; }
     /// <inheritdoc/>
     public OpenApiReference Reference { get; set; }
     /// <inheritdoc/>

--- a/src/Microsoft.OpenApi/Models/References/OpenApiCallbackReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiCallbackReference.cs
@@ -28,6 +28,14 @@ namespace Microsoft.OpenApi.Models.References
         public OpenApiCallbackReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Callback, externalResource)
         {
         }
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        /// <param name="callback">The reference to copy</param>
+        private OpenApiCallbackReference(OpenApiCallbackReference callback):base(callback)
+        {
+            
+        }
 
         internal OpenApiCallbackReference(OpenApiCallback target, string referenceId):base(target, referenceId, ReferenceType.Callback)
         {
@@ -55,9 +63,7 @@ namespace Microsoft.OpenApi.Models.References
         /// <inheritdoc/>
         public IOpenApiCallback CreateShallowCopy()
         {
-            return _target is null ?
-                new OpenApiCallbackReference(Reference.Id, Reference.HostDocument, Reference.ExternalResource) :
-                new OpenApiCallbackReference(_target, Reference.Id);
+            return new OpenApiCallbackReference(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiCallbackReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiCallbackReference.cs
@@ -29,14 +29,6 @@ namespace Microsoft.OpenApi.Models.References
         {
         }
 
-        /// <summary>
-        /// Copy constructor
-        /// </summary>
-        /// <param name="callback">The callback reference to copy</param>
-        public OpenApiCallbackReference(OpenApiCallbackReference callback):base(callback)
-        {
-        }
-
         internal OpenApiCallbackReference(OpenApiCallback target, string referenceId):base(target, referenceId, ReferenceType.Callback)
         {
         }
@@ -58,6 +50,14 @@ namespace Microsoft.OpenApi.Models.References
         {
             // examples components are not supported in OAS 2.0
             Reference.SerializeAsV2(writer);
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiCallback CreateShallowCopy()
+        {
+            return _target is null ?
+                new OpenApiCallbackReference(Reference.Id, Reference.HostDocument, Reference.ExternalResource) :
+                new OpenApiCallbackReference(_target, Reference.Id);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiExampleReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiExampleReference.cs
@@ -29,14 +29,6 @@ namespace Microsoft.OpenApi.Models.References
         {
         }
 
-        /// <summary>
-        /// Copy constructor
-        /// </summary>
-        /// <param name="example">The reference to copy.</param>
-        public OpenApiExampleReference(OpenApiExampleReference example):base(example)
-        {
-        }
-
         internal OpenApiExampleReference(OpenApiExample target, string referenceId):base(target, referenceId, ReferenceType.Example)
         {
         }
@@ -87,6 +79,14 @@ namespace Microsoft.OpenApi.Models.References
         {
             // examples components are not supported in OAS 2.0
             Reference.SerializeAsV2(writer);
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiExample CreateShallowCopy()
+        {
+            return _target is null ?
+                new OpenApiExampleReference(Reference.Id, Reference.HostDocument, Reference.ExternalResource) :
+                new OpenApiExampleReference(_target, Reference.Id);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiExampleReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiExampleReference.cs
@@ -28,6 +28,13 @@ namespace Microsoft.OpenApi.Models.References
         public OpenApiExampleReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Example, externalResource)
         {
         }
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        /// <param name="example">The example reference to copy</param>
+        private OpenApiExampleReference(OpenApiExampleReference example):base(example)
+        {
+        }
 
         internal OpenApiExampleReference(OpenApiExample target, string referenceId):base(target, referenceId, ReferenceType.Example)
         {
@@ -84,9 +91,7 @@ namespace Microsoft.OpenApi.Models.References
         /// <inheritdoc/>
         public IOpenApiExample CreateShallowCopy()
         {
-            return _target is null ?
-                new OpenApiExampleReference(Reference.Id, Reference.HostDocument, Reference.ExternalResource) :
-                new OpenApiExampleReference(_target, Reference.Id);
+            return new OpenApiExampleReference(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiHeaderReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiHeaderReference.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models.Interfaces;
-using Microsoft.OpenApi.Writers;
 
 namespace Microsoft.OpenApi.Models.References
 {
@@ -33,7 +32,7 @@ namespace Microsoft.OpenApi.Models.References
         /// Copy constructor
         /// </summary>
         /// <param name="header">The <see cref="OpenApiHeaderReference"/> object to copy</param>
-        public OpenApiHeaderReference(OpenApiHeaderReference header):base(header)
+        private OpenApiHeaderReference(OpenApiHeaderReference header):base(header)
         {
         }
 
@@ -91,6 +90,12 @@ namespace Microsoft.OpenApi.Models.References
         public override IOpenApiHeader CopyReferenceAsTargetElementWithOverrides(IOpenApiHeader source)
         {
             return source is OpenApiHeader ? new OpenApiHeader(this) : source;
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiHeader CreateShallowCopy()
+        {
+            return new OpenApiHeaderReference(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiLinkReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiLinkReference.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OpenApi.Models.References
         /// Copy constructor.
         /// </summary>
         /// <param name="reference">The reference to copy</param>
-        public OpenApiLinkReference(OpenApiLinkReference reference):base(reference)
+        private OpenApiLinkReference(OpenApiLinkReference reference):base(reference)
         {
         }
         internal OpenApiLinkReference(OpenApiLink target, string referenceId):base(target, referenceId, ReferenceType.Link)

--- a/src/Microsoft.OpenApi/Models/References/OpenApiLinkReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiLinkReference.cs
@@ -80,5 +80,11 @@ namespace Microsoft.OpenApi.Models.References
         {
             return source is OpenApiLink ? new OpenApiLink(this) : source;
         }
+
+        /// <inheritdoc/>
+        public IOpenApiLink CreateShallowCopy()
+        {
+            return new OpenApiLinkReference(this);
+        }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiParameterReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiParameterReference.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OpenApi.Models.References
         /// Copy constructor
         /// </summary>
         /// <param name="parameter">The parameter reference to copy</param>
-        public OpenApiParameterReference(OpenApiParameterReference parameter):base(parameter)
+        private OpenApiParameterReference(OpenApiParameterReference parameter):base(parameter)
         {
         }
 

--- a/src/Microsoft.OpenApi/Models/References/OpenApiParameterReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiParameterReference.cs
@@ -40,7 +40,7 @@ namespace Microsoft.OpenApi.Models.References
         }
 
         /// <inheritdoc/>
-        public string Name { get => Target.Name; }
+        public string Name { get => Target?.Name; }
 
         /// <inheritdoc/>
         public string Description
@@ -86,10 +86,10 @@ namespace Microsoft.OpenApi.Models.References
         public bool Explode { get => Target?.Explode ?? default; }
 
         /// <inheritdoc/>
-        public IDictionary<string, OpenApiMediaType> Content { get => Target.Content; }
+        public IDictionary<string, OpenApiMediaType> Content { get => Target?.Content; }
 
         /// <inheritdoc/>
-        public IDictionary<string, IOpenApiExtension> Extensions { get => Target.Extensions; }
+        public IDictionary<string, IOpenApiExtension> Extensions { get => Target?.Extensions; }
         
         /// <inheritdoc/>
         public override IOpenApiParameter CopyReferenceAsTargetElementWithOverrides(IOpenApiParameter source)

--- a/src/Microsoft.OpenApi/Models/References/OpenApiParameterReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiParameterReference.cs
@@ -96,5 +96,11 @@ namespace Microsoft.OpenApi.Models.References
         {
             return source is OpenApiParameter ? new OpenApiParameter(this) : source;
         }
+
+        /// <inheritdoc/>
+        public IOpenApiParameter CreateShallowCopy()
+        {
+            return new OpenApiParameterReference(this);
+        }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiPathItemReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiPathItemReference.cs
@@ -28,6 +28,15 @@ namespace Microsoft.OpenApi.Models.References
         {
         }
 
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        /// <param name="pathItem">The reference to copy</param>
+        private OpenApiPathItemReference(OpenApiPathItemReference pathItem):base(pathItem)
+        {
+            
+        }
+
         internal OpenApiPathItemReference(OpenApiPathItem target, string referenceId):base(target, referenceId, ReferenceType.PathItem)
         {
         }
@@ -74,6 +83,12 @@ namespace Microsoft.OpenApi.Models.References
         public override IOpenApiPathItem CopyReferenceAsTargetElementWithOverrides(IOpenApiPathItem source)
         {
             return source is OpenApiPathItem ? new OpenApiPathItem(this) : source;
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiPathItem CreateShallowCopy()
+        {
+            return new OpenApiPathItemReference(this);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi/Models/References/OpenApiRequestBodyReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiRequestBodyReference.cs
@@ -28,6 +28,14 @@ namespace Microsoft.OpenApi.Models.References
         public OpenApiRequestBodyReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.RequestBody, externalResource)
         {
         }
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        /// <param name="openApiRequestBodyReference">The reference to copy</param>
+        private OpenApiRequestBodyReference(OpenApiRequestBodyReference openApiRequestBodyReference):base(openApiRequestBodyReference)
+        {
+            
+        }
         internal OpenApiRequestBodyReference(OpenApiRequestBody target, string referenceId):base(target, referenceId, ReferenceType.RequestBody)
         {
         }
@@ -88,6 +96,12 @@ namespace Microsoft.OpenApi.Models.References
                 return [];
 
             return Content.First().Value.Schema.Properties.Select(x => new OpenApiParameterReference(x.Key, Reference.HostDocument));
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiRequestBody CreateShallowCopy()
+        {
+            return new OpenApiRequestBodyReference(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiResponseReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiResponseReference.cs
@@ -26,6 +26,14 @@ namespace Microsoft.OpenApi.Models.References
         public OpenApiResponseReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Response, externalResource)
         {
         }
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        /// <param name="openApiResponseReference">The reference to copy</param>
+        private OpenApiResponseReference(OpenApiResponseReference openApiResponseReference):base(openApiResponseReference)
+        {
+            
+        }
 
         internal OpenApiResponseReference(OpenApiResponse target, string referenceId):base(target, referenceId, ReferenceType.Response)
         {
@@ -60,6 +68,12 @@ namespace Microsoft.OpenApi.Models.References
         public override IOpenApiResponse CopyReferenceAsTargetElementWithOverrides(IOpenApiResponse source)
         {
             return source is OpenApiResponse ? new OpenApiResponse(this) : source;
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiResponse CreateShallowCopy()
+        {
+            return new OpenApiResponseReference(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
@@ -28,6 +28,13 @@ namespace Microsoft.OpenApi.Models.References
         public OpenApiSchemaReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Schema, externalResource)
         {
         }
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        /// <param name="schema">The schema reference to copy</param>
+        private OpenApiSchemaReference(OpenApiSchemaReference schema):base(schema)
+        {
+        }
 
         internal OpenApiSchemaReference(OpenApiSchema target, string referenceId):base(target, referenceId, ReferenceType.Schema)
         {
@@ -196,9 +203,7 @@ namespace Microsoft.OpenApi.Models.References
         /// <inheritdoc/>
         public IOpenApiSchema CreateShallowCopy()
         {
-            return _target is null ?
-                new OpenApiSchemaReference(Reference.Id, Reference.HostDocument, Reference.ExternalResource) :
-                new OpenApiSchemaReference(_target, Reference.Id);
+            return new OpenApiSchemaReference(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
@@ -193,5 +193,12 @@ namespace Microsoft.OpenApi.Models.References
         {
             return source is OpenApiSchema ? new OpenApiSchema(this) : source;
         }
+        /// <inheritdoc/>
+        public IOpenApiSchema CreateShallowCopy()
+        {
+            return _target is null ?
+                new OpenApiSchemaReference(Reference.Id, Reference?.HostDocument, Reference?.ExternalResource) :
+                new OpenApiSchemaReference(_target, Reference.Id);
+        }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
@@ -197,7 +197,7 @@ namespace Microsoft.OpenApi.Models.References
         public IOpenApiSchema CreateShallowCopy()
         {
             return _target is null ?
-                new OpenApiSchemaReference(Reference.Id, Reference?.HostDocument, Reference?.ExternalResource) :
+                new OpenApiSchemaReference(Reference.Id, Reference.HostDocument, Reference.ExternalResource) :
                 new OpenApiSchemaReference(_target, Reference.Id);
         }
     }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiSecuritySchemeReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiSecuritySchemeReference.cs
@@ -22,6 +22,14 @@ namespace Microsoft.OpenApi.Models.References
         public OpenApiSecuritySchemeReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.SecurityScheme, externalResource)
         {
         }
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        /// <param name="openApiSecuritySchemeReference">The reference to copy</param>
+        private OpenApiSecuritySchemeReference(OpenApiSecuritySchemeReference openApiSecuritySchemeReference):base(openApiSecuritySchemeReference)
+        {
+            
+        }
         internal OpenApiSecuritySchemeReference(OpenApiSecurityScheme target, string referenceId):base(target, referenceId, ReferenceType.SecurityScheme)
         {
         }
@@ -67,6 +75,12 @@ namespace Microsoft.OpenApi.Models.References
         public override IOpenApiSecurityScheme CopyReferenceAsTargetElementWithOverrides(IOpenApiSecurityScheme source)
         {
             return source is OpenApiSecurityScheme ? new OpenApiSecurityScheme(this) : source;
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiSecurityScheme CreateShallowCopy()
+        {
+            return new OpenApiSecuritySchemeReference(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiTagReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiTagReference.cs
@@ -34,6 +34,14 @@ namespace Microsoft.OpenApi.Models.References
         public OpenApiTagReference(string referenceId, OpenApiDocument hostDocument):base(referenceId, hostDocument, ReferenceType.Tag)
         {
         }
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        /// <param name="openApiTagReference">The reference to copy</param>
+        private OpenApiTagReference(OpenApiTagReference openApiTagReference):base(openApiTagReference)
+        {
+            
+        }
 
         internal OpenApiTagReference(OpenApiTag target, string referenceId):base(target, referenceId, ReferenceType.Tag)
         {
@@ -57,6 +65,12 @@ namespace Microsoft.OpenApi.Models.References
         public override IOpenApiTag CopyReferenceAsTargetElementWithOverrides(IOpenApiTag source)
         {
             return source is OpenApiTag ? new OpenApiTag(this) : source;
+        }
+
+        /// <inheritdoc/>
+        public IOpenApiTag CreateShallowCopy()
+        {
+            return new OpenApiTagReference(this);
         }
     }
 }

--- a/src/Microsoft.OpenApi/Reader/ParseNodes/MapNode.cs
+++ b/src/Microsoft.OpenApi/Reader/ParseNodes/MapNode.cs
@@ -124,7 +124,6 @@ namespace Microsoft.OpenApi.Reader.ParseNodes
         {
             return new()
             {
-                UnresolvedReference = true,
                 Reference = Context.VersionService.ConvertToOpenApiReference(referenceId, referenceType, summary, description)
             };
         }

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
@@ -154,12 +154,13 @@ namespace Microsoft.OpenApi.Reader.V2
                         k => k.Name,
                         v => 
                         {
-                            var schema = new OpenApiSchema(v.Schema)
+                            var schema = v.Schema.CreateShallowCopy();
+                            schema.Description = v.Description;
+                            if (schema is OpenApiSchema openApiSchema)
                             {
-                                Description = v.Description,
-                                Extensions = v.Extensions
-                            };
-                            return (IOpenApiSchema)schema;
+                                openApiSchema.Extensions = v.Extensions;
+                            }
+                            return schema;
                         }),
                     Required = new HashSet<string>(formParameters.Where(static p => p.Required).Select(static p => p.Name), StringComparer.Ordinal)
                 }

--- a/src/Microsoft.OpenApi/Services/OpenApiWorkspace.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWorkspace.cs
@@ -7,6 +7,7 @@ using System.IO;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
 
 namespace Microsoft.OpenApi.Services
 {
@@ -165,16 +166,16 @@ namespace Microsoft.OpenApi.Services
 
             var location = componentToRegister switch
             {
-                OpenApiSchema => baseUri + ReferenceType.Schema.GetDisplayName() + ComponentSegmentSeparator + id,
-                OpenApiParameter => baseUri + ReferenceType.Parameter.GetDisplayName() + ComponentSegmentSeparator + id,
-                OpenApiResponse => baseUri + ReferenceType.Response.GetDisplayName() + ComponentSegmentSeparator + id,
-                OpenApiRequestBody => baseUri + ReferenceType.RequestBody.GetDisplayName() + ComponentSegmentSeparator + id,
-                OpenApiLink => baseUri + ReferenceType.Link.GetDisplayName() + ComponentSegmentSeparator + id,
-                OpenApiCallback => baseUri + ReferenceType.Callback.GetDisplayName() + ComponentSegmentSeparator + id,
-                OpenApiPathItem => baseUri + ReferenceType.PathItem.GetDisplayName() + ComponentSegmentSeparator + id,
-                OpenApiExample => baseUri + ReferenceType.Example.GetDisplayName() + ComponentSegmentSeparator + id,
-                OpenApiHeader => baseUri + ReferenceType.Header.GetDisplayName() + ComponentSegmentSeparator + id,
-                OpenApiSecurityScheme => baseUri + ReferenceType.SecurityScheme.GetDisplayName() + ComponentSegmentSeparator + id,
+                IOpenApiSchema => baseUri + ReferenceType.Schema.GetDisplayName() + ComponentSegmentSeparator + id,
+                IOpenApiParameter => baseUri + ReferenceType.Parameter.GetDisplayName() + ComponentSegmentSeparator + id,
+                IOpenApiResponse => baseUri + ReferenceType.Response.GetDisplayName() + ComponentSegmentSeparator + id,
+                IOpenApiRequestBody => baseUri + ReferenceType.RequestBody.GetDisplayName() + ComponentSegmentSeparator + id,
+                IOpenApiLink => baseUri + ReferenceType.Link.GetDisplayName() + ComponentSegmentSeparator + id,
+                IOpenApiCallback => baseUri + ReferenceType.Callback.GetDisplayName() + ComponentSegmentSeparator + id,
+                IOpenApiPathItem => baseUri + ReferenceType.PathItem.GetDisplayName() + ComponentSegmentSeparator + id,
+                IOpenApiExample => baseUri + ReferenceType.Example.GetDisplayName() + ComponentSegmentSeparator + id,
+                IOpenApiHeader => baseUri + ReferenceType.Header.GetDisplayName() + ComponentSegmentSeparator + id,
+                IOpenApiSecurityScheme => baseUri + ReferenceType.SecurityScheme.GetDisplayName() + ComponentSegmentSeparator + id,
                 _ => throw new ArgumentException($"Invalid component type {componentToRegister.GetType().Name}"),
             };
 

--- a/src/Microsoft.OpenApi/Utils.cs
+++ b/src/Microsoft.OpenApi/Utils.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Microsoft.OpenApi
@@ -19,7 +20,11 @@ namespace Microsoft.OpenApi
         /// <param name="parameterName">The input parameter name.</param>
         /// <returns>The input value.</returns>
         internal static T CheckArgumentNull<T>(
+#if NET5_0_OR_GREATER
+            [NotNull] T value,
+#else
             T value,
+#endif
             [CallerArgumentExpression(nameof(value))] string parameterName = "")
         {
             return value ?? throw new ArgumentNullException(parameterName, $"Value cannot be null: {parameterName}");
@@ -32,7 +37,11 @@ namespace Microsoft.OpenApi
         /// <param name="parameterName">The input parameter name.</param>
         /// <returns>The input value.</returns>
         internal static string CheckArgumentNullOrEmpty(
+#if NET5_0_OR_GREATER
+            [NotNull] string value,
+#else
             string value,
+#endif
             [CallerArgumentExpression(nameof(value))] string parameterName = "")
         {
             return string.IsNullOrWhiteSpace(value) ? throw new ArgumentNullException(parameterName, $"Value cannot be null or empty: {parameterName}") : value;

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiWorkspaceTests/OpenApiWorkspaceStreamTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiWorkspaceTests/OpenApiWorkspaceStreamTests.cs
@@ -30,7 +30,6 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiWorkspaceTests
                 BaseUrl = new("file://c:\\")
             };
 
-            // Todo: this should be ReadAsync
             var stream = new MemoryStream();
             var doc = """
                       openapi: 3.0.0

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiSchemaTests.cs
@@ -140,13 +140,11 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             };
 
             // Act
-            var schemaWithArrayCopy = new OpenApiSchema(schemaWithTypeArray);
+            var schemaWithArrayCopy = schemaWithTypeArray.CreateShallowCopy() as OpenApiSchema;
             schemaWithArrayCopy.Type = JsonSchemaType.String;
 
-            var simpleSchemaCopy = new OpenApiSchema(simpleSchema)
-            {
-                Type = JsonSchemaType.String | JsonSchemaType.Null
-            };
+            var simpleSchemaCopy = simpleSchema.CreateShallowCopy() as OpenApiSchema;
+            simpleSchemaCopy.Type = JsonSchemaType.String | JsonSchemaType.Null;
 
             // Assert
             Assert.NotEqual(schemaWithTypeArray.Type, schemaWithArrayCopy.Type);
@@ -294,7 +292,7 @@ examples:
                 Enum = [1, 2, 3]
             };
 
-            var clone = new OpenApiSchema(schema);
+            var clone = schema.CreateShallowCopy() as OpenApiSchema;
             clone.Examples.Add(4);
             clone.Enum.Add(4);
             clone.Default = 6;

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -471,10 +471,8 @@ namespace Microsoft.OpenApi.Tests.Models
                 Format = "date"
             };
 
-            var actualSchema = new OpenApiSchema(baseSchema)
-            {
-                Nullable = true
-            };
+            var actualSchema = baseSchema.CreateShallowCopy() as OpenApiSchema;
+            actualSchema.Nullable = true;
 
             Assert.Equal(JsonSchemaType.String, actualSchema.Type);
             Assert.Equal("date", actualSchema.Format);
@@ -493,7 +491,7 @@ namespace Microsoft.OpenApi.Tests.Models
                 }
             };
 
-            var actualSchema = new OpenApiSchema(baseSchema);
+            var actualSchema = baseSchema.CreateShallowCopy();
 
             Assert.Equal(baseSchema.Annotations["key1"], actualSchema.Annotations["key1"]);
 
@@ -531,7 +529,7 @@ namespace Microsoft.OpenApi.Tests.Models
             };
 
             // Act && Assert
-            var schemaCopy = new OpenApiSchema(schema);
+            var schemaCopy = schema.CreateShallowCopy();
 
             // Act && Assert
             schema.Example.Should().BeEquivalentTo(schemaCopy.Example, options => options
@@ -552,7 +550,7 @@ namespace Microsoft.OpenApi.Tests.Models
             };
 
             // Act && Assert
-            var schemaCopy = new OpenApiSchema(schema);
+            var schemaCopy = schema.CreateShallowCopy() as OpenApiSchema;
             Assert.Single(schemaCopy.Extensions);
 
             // Act && Assert

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -363,7 +363,7 @@ namespace Microsoft.OpenApi.Models.Interfaces
         Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema Schema { get; }
         Microsoft.OpenApi.Models.ParameterStyle? Style { get; }
     }
-    public interface IOpenApiLink : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
+    public interface IOpenApiLink : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
     {
         string OperationId { get; }
         string OperationRef { get; }
@@ -371,7 +371,7 @@ namespace Microsoft.OpenApi.Models.Interfaces
         Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper RequestBody { get; }
         Microsoft.OpenApi.Models.OpenApiServer Server { get; }
     }
-    public interface IOpenApiParameter : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
+    public interface IOpenApiParameter : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
     {
         bool AllowEmptyValue { get; }
         bool AllowReserved { get; }
@@ -386,7 +386,7 @@ namespace Microsoft.OpenApi.Models.Interfaces
         Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema Schema { get; }
         Microsoft.OpenApi.Models.ParameterStyle? Style { get; }
     }
-    public interface IOpenApiPathItem : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
+    public interface IOpenApiPathItem : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
     {
         System.Collections.Generic.IDictionary<Microsoft.OpenApi.Models.OperationType, Microsoft.OpenApi.Models.OpenApiOperation> Operations { get; }
         System.Collections.Generic.IList<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter> Parameters { get; }
@@ -396,7 +396,7 @@ namespace Microsoft.OpenApi.Models.Interfaces
     {
         string Description { get; }
     }
-    public interface IOpenApiRequestBody : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
+    public interface IOpenApiRequestBody : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
     {
         System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> Content { get; }
         bool Required { get; }
@@ -839,10 +839,9 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiLink : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink
+    public class OpenApiLink : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink
     {
         public OpenApiLink() { }
-        public OpenApiLink(Microsoft.OpenApi.Models.Interfaces.IOpenApiLink link) { }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; set; }
         public string OperationId { get; set; }
@@ -850,6 +849,7 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper> Parameters { get; set; }
         public Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper RequestBody { get; set; }
         public Microsoft.OpenApi.Models.OpenApiServer Server { get; set; }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiLink CreateShallowCopy() { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -897,7 +897,7 @@ namespace Microsoft.OpenApi.Models
     {
         public const bool DeprecatedDefault = false;
         public OpenApiOperation() { }
-        public OpenApiOperation(Microsoft.OpenApi.Models.OpenApiOperation? operation) { }
+        public OpenApiOperation(Microsoft.OpenApi.Models.OpenApiOperation operation) { }
         public System.Collections.Generic.IDictionary<string, object>? Annotations { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>? Callbacks { get; set; }
         public bool Deprecated { get; set; }
@@ -916,10 +916,9 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiParameter : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter
+    public class OpenApiParameter : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter
     {
         public OpenApiParameter() { }
-        public OpenApiParameter(Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter parameter) { }
         public bool AllowEmptyValue { get; set; }
         public bool AllowReserved { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> Content { get; set; }
@@ -934,14 +933,14 @@ namespace Microsoft.OpenApi.Models
         public bool Required { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema Schema { get; set; }
         public Microsoft.OpenApi.Models.ParameterStyle? Style { get; set; }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter CreateShallowCopy() { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiPathItem : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
+    public class OpenApiPathItem : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
     {
         public OpenApiPathItem() { }
-        public OpenApiPathItem(Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem pathItem) { }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; set; }
         public System.Collections.Generic.IDictionary<Microsoft.OpenApi.Models.OperationType, Microsoft.OpenApi.Models.OpenApiOperation> Operations { get; set; }
@@ -949,6 +948,7 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiServer> Servers { get; set; }
         public string Summary { get; set; }
         public void AddOperation(Microsoft.OpenApi.Models.OperationType operationType, Microsoft.OpenApi.Models.OpenApiOperation operation) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem CreateShallowCopy() { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -977,16 +977,16 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiRequestBody : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody
+    public class OpenApiRequestBody : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody
     {
         public OpenApiRequestBody() { }
-        public OpenApiRequestBody(Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody requestBody) { }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> Content { get; set; }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; set; }
         public bool Required { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter ConvertToBodyParameter(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter> ConvertToFormDataParameters(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody CreateShallowCopy() { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1292,7 +1292,7 @@ namespace Microsoft.OpenApi.Models.References
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader source) { }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader CreateShallowCopy() { }
     }
-    public class OpenApiLinkReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiLink, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink
+    public class OpenApiLinkReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiLink, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink
     {
         public OpenApiLinkReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
         public string Description { get; set; }
@@ -1303,9 +1303,10 @@ namespace Microsoft.OpenApi.Models.References
         public Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper RequestBody { get; }
         public Microsoft.OpenApi.Models.OpenApiServer Server { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiLink CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiLink source) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiLink CreateShallowCopy() { }
         public override void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiParameterReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiParameter, Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter
+    public class OpenApiParameterReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiParameter, Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter
     {
         public OpenApiParameterReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
         public bool AllowEmptyValue { get; }
@@ -1323,8 +1324,9 @@ namespace Microsoft.OpenApi.Models.References
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema Schema { get; }
         public Microsoft.OpenApi.Models.ParameterStyle? Style { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter source) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter CreateShallowCopy() { }
     }
-    public class OpenApiPathItemReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiPathItem, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
+    public class OpenApiPathItemReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiPathItem, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
     {
         public OpenApiPathItemReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
         public string Description { get; set; }
@@ -1334,9 +1336,10 @@ namespace Microsoft.OpenApi.Models.References
         public System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiServer> Servers { get; }
         public string Summary { get; set; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem source) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem CreateShallowCopy() { }
         public override void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiRequestBodyReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiRequestBody, Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody
+    public class OpenApiRequestBodyReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiRequestBody, Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody
     {
         public OpenApiRequestBodyReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> Content { get; }
@@ -1346,6 +1349,7 @@ namespace Microsoft.OpenApi.Models.References
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter ConvertToBodyParameter(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter> ConvertToFormDataParameters(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody source) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody CreateShallowCopy() { }
         public override void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiResponseReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiResponse, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -345,12 +345,12 @@ namespace Microsoft.OpenApi.Models.Interfaces
     {
         string Description { get; set; }
     }
-    public interface IOpenApiExample : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
+    public interface IOpenApiExample : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
     {
         string ExternalValue { get; }
         System.Text.Json.Nodes.JsonNode Value { get; }
     }
-    public interface IOpenApiHeader : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
+    public interface IOpenApiHeader : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
     {
         bool AllowEmptyValue { get; }
         bool AllowReserved { get; }
@@ -757,15 +757,15 @@ namespace Microsoft.OpenApi.Models
         public string Pointer { get; set; }
         public override string ToString() { }
     }
-    public class OpenApiExample : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
+    public class OpenApiExample : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
     {
         public OpenApiExample() { }
-        public OpenApiExample(Microsoft.OpenApi.Models.Interfaces.IOpenApiExample example) { }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; set; }
         public string ExternalValue { get; set; }
         public string Summary { get; set; }
         public System.Text.Json.Nodes.JsonNode Value { get; set; }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiExample CreateShallowCopy() { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -791,10 +791,9 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiHeader : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader
+    public class OpenApiHeader : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader
     {
         public OpenApiHeader() { }
-        public OpenApiHeader(Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader header) { }
         public bool AllowEmptyValue { get; set; }
         public bool AllowReserved { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> Content { get; set; }
@@ -807,6 +806,7 @@ namespace Microsoft.OpenApi.Models
         public bool Required { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema Schema { get; set; }
         public Microsoft.OpenApi.Models.ParameterStyle? Style { get; set; }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader CreateShallowCopy() { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1262,9 +1262,8 @@ namespace Microsoft.OpenApi.Models.References
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback CreateShallowCopy() { }
         public override void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiExampleReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiExample, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
+    public class OpenApiExampleReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiExample, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
     {
-        public OpenApiExampleReference(Microsoft.OpenApi.Models.References.OpenApiExampleReference example) { }
         public OpenApiExampleReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; }
@@ -1272,11 +1271,11 @@ namespace Microsoft.OpenApi.Models.References
         public string Summary { get; set; }
         public System.Text.Json.Nodes.JsonNode Value { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiExample CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiExample source) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiExample CreateShallowCopy() { }
         public override void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiHeaderReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiHeader, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader
+    public class OpenApiHeaderReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiHeader, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader
     {
-        public OpenApiHeaderReference(Microsoft.OpenApi.Models.References.OpenApiHeaderReference header) { }
         public OpenApiHeaderReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
         public bool AllowEmptyValue { get; }
         public bool AllowReserved { get; }
@@ -1291,10 +1290,10 @@ namespace Microsoft.OpenApi.Models.References
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema Schema { get; }
         public Microsoft.OpenApi.Models.ParameterStyle? Style { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader source) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader CreateShallowCopy() { }
     }
     public class OpenApiLinkReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiLink, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink
     {
-        public OpenApiLinkReference(Microsoft.OpenApi.Models.References.OpenApiLinkReference reference) { }
         public OpenApiLinkReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; }
@@ -1308,7 +1307,6 @@ namespace Microsoft.OpenApi.Models.References
     }
     public class OpenApiParameterReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiParameter, Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter
     {
-        public OpenApiParameterReference(Microsoft.OpenApi.Models.References.OpenApiParameterReference parameter) { }
         public OpenApiParameterReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
         public bool AllowEmptyValue { get; }
         public bool AllowReserved { get; }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -337,7 +337,7 @@ namespace Microsoft.OpenApi.MicrosoftExtensions
 }
 namespace Microsoft.OpenApi.Models.Interfaces
 {
-    public interface IOpenApiCallback : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
+    public interface IOpenApiCallback : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>
     {
         System.Collections.Generic.Dictionary<Microsoft.OpenApi.Expressions.RuntimeExpression, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem> PathItems { get; }
     }
@@ -496,13 +496,13 @@ namespace Microsoft.OpenApi.Models
         Object = 32,
         Array = 64,
     }
-    public class OpenApiCallback : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback
+    public class OpenApiCallback : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback
     {
         public OpenApiCallback() { }
-        public OpenApiCallback(Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback callback) { }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; set; }
         public System.Collections.Generic.Dictionary<Microsoft.OpenApi.Expressions.RuntimeExpression, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem> PathItems { get; set; }
         public void AddPathItem(Microsoft.OpenApi.Expressions.RuntimeExpression expression, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem pathItem) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback CreateShallowCopy() { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1253,13 +1253,13 @@ namespace Microsoft.OpenApi.Models.References
         public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiCallbackReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiCallback, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback
+    public class OpenApiCallbackReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiCallback, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback
     {
-        public OpenApiCallbackReference(Microsoft.OpenApi.Models.References.OpenApiCallbackReference callback) { }
         public OpenApiCallbackReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; }
         public System.Collections.Generic.Dictionary<Microsoft.OpenApi.Expressions.RuntimeExpression, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem> PathItems { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback source) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback CreateShallowCopy() { }
         public override void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiExampleReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiExample, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -225,16 +225,12 @@ namespace Microsoft.OpenApi.Interfaces
     public interface IOpenApiReferenceHolder : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
         Microsoft.OpenApi.Models.OpenApiReference Reference { get; set; }
-        bool UnresolvedReference { get; set; }
+        bool UnresolvedReference { get; }
     }
-    public interface IOpenApiReferenceHolder<out T> : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReferenceHolder, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
-        where out T : Microsoft.OpenApi.Interfaces.IOpenApiReferenceable
-    {
-        T Target { get; }
-    }
-    public interface IOpenApiReferenceHolder<out T, V> : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReferenceHolder, Microsoft.OpenApi.Interfaces.IOpenApiReferenceHolder<T>, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
+    public interface IOpenApiReferenceHolder<out T, V> : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReferenceHolder, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
         where out T : Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, V
     {
+        T Target { get; }
         V CopyReferenceAsTargetElementWithOverrides(V source);
     }
     public interface IOpenApiReferenceable : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiSerializable { }
@@ -1238,7 +1234,7 @@ namespace Microsoft.OpenApi.Models
 }
 namespace Microsoft.OpenApi.Models.References
 {
-    public abstract class BaseOpenApiReferenceHolder<T, V> : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReferenceHolder, Microsoft.OpenApi.Interfaces.IOpenApiReferenceHolder<T>, Microsoft.OpenApi.Interfaces.IOpenApiReferenceHolder<T, V>, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
+    public abstract class BaseOpenApiReferenceHolder<T, V> : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReferenceHolder, Microsoft.OpenApi.Interfaces.IOpenApiReferenceHolder<T, V>, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
         where T :  class, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, V
         where V : Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
@@ -1247,7 +1243,7 @@ namespace Microsoft.OpenApi.Models.References
         protected BaseOpenApiReferenceHolder(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, Microsoft.OpenApi.Models.ReferenceType referenceType, string externalResource = null) { }
         public Microsoft.OpenApi.Models.OpenApiReference Reference { get; set; }
         public virtual T Target { get; }
-        public bool UnresolvedReference { get; set; }
+        public bool UnresolvedReference { get; }
         public abstract V CopyReferenceAsTargetElementWithOverrides(V source);
         public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -240,6 +240,10 @@ namespace Microsoft.OpenApi.Interfaces
         void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer);
         void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer);
     }
+    public interface IShallowCopyable<out T>
+    {
+        T CreateShallowCopy();
+    }
     public interface IStreamLoader
     {
         System.Threading.Tasks.Task<System.IO.Stream> LoadAsync(System.Uri uri);
@@ -405,7 +409,7 @@ namespace Microsoft.OpenApi.Models.Interfaces
         System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader> Headers { get; }
         System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink> Links { get; }
     }
-    public interface IOpenApiSchema : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
+    public interface IOpenApiSchema : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
     {
         Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema AdditionalProperties { get; }
         bool AdditionalPropertiesAllowed { get; }
@@ -1005,10 +1009,9 @@ namespace Microsoft.OpenApi.Models
         public OpenApiResponses() { }
         public OpenApiResponses(Microsoft.OpenApi.Models.OpenApiResponses openApiResponses) { }
     }
-    public class OpenApiSchema : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema
+    public class OpenApiSchema : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema
     {
         public OpenApiSchema() { }
-        public OpenApiSchema(Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema schema) { }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema AdditionalProperties { get; set; }
         public bool AdditionalPropertiesAllowed { get; set; }
         public System.Collections.Generic.IList<Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema> AllOf { get; set; }
@@ -1062,6 +1065,7 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.IDictionary<string, bool> Vocabulary { get; set; }
         public bool WriteOnly { get; set; }
         public Microsoft.OpenApi.Models.OpenApiXml Xml { get; set; }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema CreateShallowCopy() { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1356,7 +1360,7 @@ namespace Microsoft.OpenApi.Models.References
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink> Links { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse source) { }
     }
-    public class OpenApiSchemaReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiSchema, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema
+    public class OpenApiSchemaReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiSchema, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema
     {
         public OpenApiSchemaReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema AdditionalProperties { get; }
@@ -1413,6 +1417,7 @@ namespace Microsoft.OpenApi.Models.References
         public bool WriteOnly { get; }
         public Microsoft.OpenApi.Models.OpenApiXml Xml { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema source) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema CreateShallowCopy() { }
         public override void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public override void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public override void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -403,7 +403,7 @@ namespace Microsoft.OpenApi.Models.Interfaces
         Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter ConvertToBodyParameter(Microsoft.OpenApi.Writers.IOpenApiWriter writer);
         System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter> ConvertToFormDataParameters(Microsoft.OpenApi.Writers.IOpenApiWriter writer);
     }
-    public interface IOpenApiResponse : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
+    public interface IOpenApiResponse : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
     {
         System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> Content { get; }
         System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader> Headers { get; }
@@ -463,7 +463,7 @@ namespace Microsoft.OpenApi.Models.Interfaces
         bool WriteOnly { get; }
         Microsoft.OpenApi.Models.OpenApiXml Xml { get; }
     }
-    public interface IOpenApiSecurityScheme : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
+    public interface IOpenApiSecurityScheme : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
     {
         string BearerFormat { get; }
         Microsoft.OpenApi.Models.OpenApiOAuthFlows Flows { get; }
@@ -477,7 +477,7 @@ namespace Microsoft.OpenApi.Models.Interfaces
     {
         string Summary { get; set; }
     }
-    public interface IOpenApiTag : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiReadOnlyDescribedElement
+    public interface IOpenApiTag : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiTag>, Microsoft.OpenApi.Models.Interfaces.IOpenApiReadOnlyDescribedElement
     {
         Microsoft.OpenApi.Models.OpenApiExternalDocs ExternalDocs { get; }
         string Name { get; }
@@ -991,15 +991,15 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiResponse : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse
+    public class OpenApiResponse : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse
     {
         public OpenApiResponse() { }
-        public OpenApiResponse(Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse response) { }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> Content { get; set; }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader> Headers { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink> Links { get; set; }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse CreateShallowCopy() { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1077,10 +1077,9 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiSecurityScheme : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme
+    public class OpenApiSecurityScheme : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme
     {
         public OpenApiSecurityScheme() { }
-        public OpenApiSecurityScheme(Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme securityScheme) { }
         public string BearerFormat { get; set; }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; set; }
@@ -1090,6 +1089,7 @@ namespace Microsoft.OpenApi.Models
         public System.Uri OpenIdConnectUrl { get; set; }
         public string Scheme { get; set; }
         public Microsoft.OpenApi.Models.SecuritySchemeType? Type { get; set; }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme CreateShallowCopy() { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1118,14 +1118,14 @@ namespace Microsoft.OpenApi.Models
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiTag : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiReadOnlyDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiTag
+    public class OpenApiTag : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiTag>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiReadOnlyDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiTag
     {
         public OpenApiTag() { }
-        public OpenApiTag(Microsoft.OpenApi.Models.Interfaces.IOpenApiTag tag) { }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; set; }
         public Microsoft.OpenApi.Models.OpenApiExternalDocs ExternalDocs { get; set; }
         public string Name { get; set; }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiTag CreateShallowCopy() { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1352,7 +1352,7 @@ namespace Microsoft.OpenApi.Models.References
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody CreateShallowCopy() { }
         public override void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiResponseReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiResponse, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse
+    public class OpenApiResponseReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiResponse, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse
     {
         public OpenApiResponseReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> Content { get; }
@@ -1361,6 +1361,7 @@ namespace Microsoft.OpenApi.Models.References
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader> Headers { get; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink> Links { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse source) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse CreateShallowCopy() { }
     }
     public class OpenApiSchemaReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiSchema, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema
     {
@@ -1424,7 +1425,7 @@ namespace Microsoft.OpenApi.Models.References
         public override void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public override void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
-    public class OpenApiSecuritySchemeReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiSecurityScheme, Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme
+    public class OpenApiSecuritySchemeReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiSecurityScheme, Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme
     {
         public OpenApiSecuritySchemeReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
         public string BearerFormat { get; }
@@ -1437,8 +1438,9 @@ namespace Microsoft.OpenApi.Models.References
         public string Scheme { get; }
         public Microsoft.OpenApi.Models.SecuritySchemeType? Type { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme source) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme CreateShallowCopy() { }
     }
-    public class OpenApiTagReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiTag, Microsoft.OpenApi.Models.Interfaces.IOpenApiTag>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiReadOnlyDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiTag
+    public class OpenApiTagReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiTag, Microsoft.OpenApi.Models.Interfaces.IOpenApiTag>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiTag>, Microsoft.OpenApi.Models.Interfaces.IOpenApiReadOnlyDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiTag
     {
         public OpenApiTagReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument) { }
         public string Description { get; }
@@ -1447,6 +1449,7 @@ namespace Microsoft.OpenApi.Models.References
         public string Name { get; }
         public override Microsoft.OpenApi.Models.OpenApiTag Target { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiTag CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiTag source) { }
+        public Microsoft.OpenApi.Models.Interfaces.IOpenApiTag CreateShallowCopy() { }
     }
 }
 namespace Microsoft.OpenApi.Reader


### PR DESCRIPTION
fixes #1998
closes #2088
review #2109 first
This PR switches from copy constructors to dedicated methods to enable polymorphism and avoid accidental duplicatations of the object model