### PR TITLE
fix: a bug where 3.0 downcast of type null would not work

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -633,6 +633,7 @@ namespace Microsoft.OpenApi.Models
         {
             // check whether nullable is true for upcasting purposes
             var isNullable = Nullable || 
+                                Extensions is not null &&
                                 Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullExtRawValue) && 
                                 nullExtRawValue is OpenApiAny openApiAny &&
                                 openApiAny.Node is JsonNode jsonNode &&

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -635,8 +635,7 @@ namespace Microsoft.OpenApi.Models
             var isNullable = Nullable || 
                                 Extensions is not null &&
                                 Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullExtRawValue) && 
-                                nullExtRawValue is OpenApiAny openApiAny &&
-                                openApiAny.Node is JsonNode jsonNode &&
+                                nullExtRawValue is OpenApiAny { Node: JsonNode jsonNode} &&
                                 jsonNode.GetValueKind() is JsonValueKind.True;
             if (type is null)
             {

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -699,11 +699,11 @@ namespace Microsoft.OpenApi.Models
                     schemaTypeNumeric != (int)JsonSchemaType.Null;
         }
 
-        private void UpCastSchemaTypeToV31(JsonSchemaType type, IOpenApiWriter writer)
+        private static void UpCastSchemaTypeToV31(JsonSchemaType type, IOpenApiWriter writer)
         {
             // create a new array and insert the type and "null" as values
             var temporaryType = type | JsonSchemaType.Null;
-            var list = (from JsonSchemaType? flag in jsonSchemaTypeValues// Check if the flag is set in 'type' using a bitwise AND operation
+            var list = (from JsonSchemaType flag in jsonSchemaTypeValues// Check if the flag is set in 'type' using a bitwise AND operation
                         where temporaryType.HasFlag(flag)
                         select flag.ToIdentifier()).ToList();
             if (list.Count > 1)
@@ -736,7 +736,7 @@ namespace Microsoft.OpenApi.Models
 
             if (!HasMultipleTypes(schemaType ^ JsonSchemaType.Null) && (schemaType & JsonSchemaType.Null) == JsonSchemaType.Null) // checks for two values and one is null
             {
-                foreach (JsonSchemaType? flag in jsonSchemaTypeValues)
+                foreach (JsonSchemaType flag in jsonSchemaTypeValues)
                 {
                     // Skip if the flag is not set or if it's the Null flag
                     if (schemaType.HasFlag(flag) && flag != JsonSchemaType.Null)

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -633,7 +633,7 @@ namespace Microsoft.OpenApi.Models
         {
             // check whether nullable is true for upcasting purposes
             var isNullable = Nullable ||
-                            Type is JsonSchemaType.Null ||
+                            (Type.HasValue && Type.Value.HasFlag(JsonSchemaType.Null))  ||
                                 Extensions is not null &&
                                 Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullExtRawValue) && 
                                 nullExtRawValue is OpenApiAny { Node: JsonNode jsonNode} &&

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -706,7 +706,14 @@ namespace Microsoft.OpenApi.Models
             var list = (from JsonSchemaType? flag in jsonSchemaTypeValues// Check if the flag is set in 'type' using a bitwise AND operation
                         where temporaryType.HasFlag(flag)
                         select flag.ToIdentifier()).ToList();
-            writer.WriteOptionalCollection(OpenApiConstants.Type, list, (w, s) => w.WriteValue(s));
+            if (list.Count > 1)
+            {
+                writer.WriteOptionalCollection(OpenApiConstants.Type, list, (w, s) => w.WriteValue(s));
+            }
+            else
+            {
+                writer.WriteProperty(OpenApiConstants.Type, list[0]);
+            }
         }
 
 #if NET5_0_OR_GREATER

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.SerializeReferencedSchemaAsV3JsonWorksAsync_produceTerseOutput=False.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.SerializeReferencedSchemaAsV3JsonWorksAsync_produceTerseOutput=False.verified.txt
@@ -4,9 +4,9 @@
   "maximum": 42,
   "minimum": 10,
   "exclusiveMinimum": true,
+  "nullable": true,
   "type": "integer",
   "default": 15,
-  "nullable": true,
   "externalDocs": {
     "url": "http://example.com/externalDocs"
   }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.SerializeReferencedSchemaAsV3JsonWorksAsync_produceTerseOutput=True.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.SerializeReferencedSchemaAsV3JsonWorksAsync_produceTerseOutput=True.verified.txt
@@ -1,1 +1,1 @@
-﻿{"title":"title1","multipleOf":3,"maximum":42,"minimum":10,"exclusiveMinimum":true,"type":"integer","default":15,"nullable":true,"externalDocs":{"url":"http://example.com/externalDocs"}}
+﻿{"title":"title1","multipleOf":3,"maximum":42,"minimum":10,"exclusiveMinimum":true,"nullable":true,"type":"integer","default":15,"externalDocs":{"url":"http://example.com/externalDocs"}}

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.SerializeReferencedSchemaAsV3WithoutReferenceJsonWorksAsync_produceTerseOutput=False.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.SerializeReferencedSchemaAsV3WithoutReferenceJsonWorksAsync_produceTerseOutput=False.verified.txt
@@ -4,9 +4,9 @@
   "maximum": 42,
   "minimum": 10,
   "exclusiveMinimum": true,
+  "nullable": true,
   "type": "integer",
   "default": 15,
-  "nullable": true,
   "externalDocs": {
     "url": "http://example.com/externalDocs"
   }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.SerializeReferencedSchemaAsV3WithoutReferenceJsonWorksAsync_produceTerseOutput=True.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.SerializeReferencedSchemaAsV3WithoutReferenceJsonWorksAsync_produceTerseOutput=True.verified.txt
@@ -1,1 +1,1 @@
-﻿{"title":"title1","multipleOf":3,"maximum":42,"minimum":10,"exclusiveMinimum":true,"type":"integer","default":15,"nullable":true,"externalDocs":{"url":"http://example.com/externalDocs"}}
+﻿{"title":"title1","multipleOf":3,"maximum":42,"minimum":10,"exclusiveMinimum":true,"nullable":true,"type":"integer","default":15,"externalDocs":{"url":"http://example.com/externalDocs"}}

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -242,9 +242,9 @@ namespace Microsoft.OpenApi.Tests.Models
                   "maximum": 42,
                   "minimum": 10,
                   "exclusiveMinimum": true,
+                  "nullable": true,
                   "type": "integer",
                   "default": 15,
-                  "nullable": true,
                   "externalDocs": {
                     "url": "http://example.com/externalDocs"
                   }
@@ -268,6 +268,7 @@ namespace Microsoft.OpenApi.Tests.Models
                 """
                 {
                   "title": "title1",
+                  "nullable": true,
                   "properties": {
                     "property1": {
                       "properties": {
@@ -296,7 +297,6 @@ namespace Microsoft.OpenApi.Tests.Models
                       }
                     }
                   },
-                  "nullable": true,
                   "externalDocs": {
                     "url": "http://example.com/externalDocs"
                   }
@@ -320,6 +320,7 @@ namespace Microsoft.OpenApi.Tests.Models
                 """
                 {
                   "title": "title1",
+                  "nullable": true,
                   "allOf": [
                     {
                       "title": "title2",
@@ -335,6 +336,7 @@ namespace Microsoft.OpenApi.Tests.Models
                     },
                     {
                       "title": "title3",
+                      "nullable": true,
                       "properties": {
                         "property3": {
                           "properties": {
@@ -347,11 +349,9 @@ namespace Microsoft.OpenApi.Tests.Models
                           "minLength": 2,
                           "type": "string"
                         }
-                      },
-                      "nullable": true
+                      }
                     }
                   ],
-                  "nullable": true,
                   "externalDocs": {
                     "url": "http://example.com/externalDocs"
                   }


### PR DESCRIPTION
null type in the object model now results in nullable true for 3.0 serialization