### PR TITLE
Fix reading relative path file reference

### DIFF
--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiV3Deserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiV3Deserializer.cs
@@ -193,7 +193,11 @@ namespace Microsoft.OpenApi.Reader.V3
             var refId = refSegments.Last();
             var isExternalResource = !refSegments.First().StartsWith("#", StringComparison.OrdinalIgnoreCase);
 
-            string externalResource = isExternalResource ? $"{refSegments.First()}/{refSegments[1].TrimEnd('#')}" : null;
+            string externalResource = null;
+            if (isExternalResource)
+            {
+                externalResource = pointer.Split('#').FirstOrDefault()?.TrimEnd('#');
+            }
 
             return (refId, externalResource);
         }

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiV31Deserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiV31Deserializer.cs
@@ -165,7 +165,7 @@ namespace Microsoft.OpenApi.Reader.V31
             string externalResource = null;
             if (isExternalResource && pointer.Contains('#'))
             {
-                externalResource = $"{refSegments.First()}/{refSegments[1].TrimEnd('#')}";
+                externalResource = pointer.Split('#').FirstOrDefault()?.TrimEnd('#');
             }
 
             return (refId, externalResource);


### PR DESCRIPTION
A reference like` ./Directory/File.json#/components/schema/abc` was before read as: 
`refId` = `abc`
`externalResource` = `./Directory`

Which dropped the file name, which will be fixed by this commit