### PR TITLE
fix/immutable reference

### DIFF
--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiReferenceHolder.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiReferenceHolder.cs
@@ -34,6 +34,6 @@ namespace Microsoft.OpenApi.Interfaces
         /// <summary>
         /// Reference object.
         /// </summary>
-        OpenApiReference Reference { get; set; }
+        OpenApiReference Reference { get; init; }
     }
 }

--- a/src/Microsoft.OpenApi/IsExternalInit.cs
+++ b/src/Microsoft.OpenApi/IsExternalInit.cs
@@ -1,0 +1,13 @@
+//TODO remove this if we ever remove the netstandard2.0 target
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices {
+   using System.ComponentModel;
+   /// <summary>
+   /// Reserved to be used by the compiler for tracking metadata.
+   /// This class should not be used by developers in source code.
+   /// </summary>
+   [EditorBrowsable(EditorBrowsableState.Never)]
+   internal static class IsExternalInit {
+   }
+}
+#endif

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -27,6 +27,13 @@ namespace Microsoft.OpenApi.Models
     public class OpenApiDocument : IOpenApiSerializable, IOpenApiExtensible, IOpenApiAnnotatable
     {
         /// <summary>
+        /// Register components in the document to the workspace
+        /// </summary>
+        public void RegisterComponents()
+        {
+            Workspace?.RegisterComponents(this);
+        }
+        /// <summary>
         /// Related workspace containing components that are referenced in a document
         /// </summary>
         public OpenApiWorkspace? Workspace { get; set; }

--- a/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
@@ -88,7 +88,7 @@ namespace Microsoft.OpenApi.Models
         private void SerializeInternal(IOpenApiWriter writer, OpenApiSpecVersion version,
             Action<IOpenApiWriter, IOpenApiSerializable> callback)
         {
-            Utils.CheckArgumentNull(writer);;
+            Utils.CheckArgumentNull(writer);
 
             writer.WriteStartObject();
 

--- a/src/Microsoft.OpenApi/Models/OpenApiReference.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiReference.cs
@@ -4,14 +4,28 @@
 using System;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
+using Microsoft.OpenApi.Models.Interfaces;
 using Microsoft.OpenApi.Writers;
+
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices {
+   using System.ComponentModel;
+   /// <summary>
+   /// Reserved to be used by the compiler for tracking metadata.
+   /// This class should not be used by developers in source code.
+   /// </summary>
+   [EditorBrowsable(EditorBrowsableState.Never)]
+   internal static class IsExternalInit {
+   }
+}
+#endif
 
 namespace Microsoft.OpenApi.Models
 {
     /// <summary>
     /// A simple object to allow referencing other components in the specification, internally and externally.
     /// </summary>
-    public class OpenApiReference : IOpenApiSerializable
+    public class OpenApiReference : IOpenApiSerializable, IOpenApiDescribedElement, IOpenApiSummarizedElement
     {
         /// <summary>
         /// A short summary which by default SHOULD override that of the referenced component.
@@ -32,13 +46,13 @@ namespace Microsoft.OpenApi.Models
         /// 1. a absolute/relative file path, for example:  ../commons/pet.json
         /// 2. a Url, for example: http://localhost/pet.json
         /// </summary>
-        public string ExternalResource { get; set; }
+        public string ExternalResource { get; init; }
 
         /// <summary>
         /// The element type referenced.
         /// </summary>
         /// <remarks>This must be present if <see cref="ExternalResource"/> is not present.</remarks>
-        public ReferenceType? Type { get; set; }
+        public ReferenceType? Type { get; init; }
 
         /// <summary>
         /// The identifier of the reusable component of one particular ReferenceType.
@@ -47,7 +61,7 @@ namespace Microsoft.OpenApi.Models
         /// If ExternalResource is not present, this is the name of the component without the reference type name.
         /// For example, if the reference is '#/components/schemas/componentName', the Id is 'componentName'.
         /// </summary>
-        public string Id { get; set; }
+        public string Id { get; init; }
 
         /// <summary>
         /// Gets a flag indicating whether this reference is an external reference.
@@ -62,12 +76,12 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Gets a flag indicating whether a file is a valid OpenAPI document or a fragment
         /// </summary>
-        public bool IsFragment = false;
+        public bool IsFragment { get; init; }
 
         /// <summary>
         /// The OpenApiDocument that is hosting the OpenApiReference instance. This is used to enable dereferencing the reference.
         /// </summary>
-        public OpenApiDocument HostDocument { get; set; }
+        public OpenApiDocument HostDocument { get; init; }
 
         /// <summary>
         /// Gets the full reference string for v3.0.
@@ -145,12 +159,13 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         public OpenApiReference(OpenApiReference reference)
         {
-            Summary = reference?.Summary;
-            Description = reference?.Description;
-            ExternalResource = reference?.ExternalResource;
-            Type = reference?.Type;
-            Id = reference?.Id;
-            HostDocument = reference?.HostDocument;
+            Utils.CheckArgumentNull(reference);
+            Summary = reference.Summary;
+            Description = reference.Description;
+            ExternalResource = reference.ExternalResource;
+            Type = reference.Type;
+            Id = reference.Id;
+            HostDocument = reference.HostDocument;
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiReference.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiReference.cs
@@ -78,10 +78,11 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         public bool IsFragment { get; init; }
 
+        private OpenApiDocument openApiDocument;        
         /// <summary>
         /// The OpenApiDocument that is hosting the OpenApiReference instance. This is used to enable dereferencing the reference.
         /// </summary>
-        public OpenApiDocument HostDocument { get; init; }
+        public OpenApiDocument HostDocument { get => openApiDocument; init => openApiDocument = value; }
 
         /// <summary>
         /// Gets the full reference string for v3.0.
@@ -290,6 +291,17 @@ namespace Microsoft.OpenApi.Models
                 _ => null,// If the reference type is not supported in V2, simply return null
                           // to indicate that the reference is not pointing to any object.
             };
+        }
+
+        /// <summary>
+        /// Sets the host document after deserialization or before serialization.
+        /// This method is internal on purpose to avoid consumers mutating the host document.
+        /// </summary>
+        /// <param name="currentDocument">Host document to set if none is present</param>
+        internal void EnsureHostDocumentIsSet(OpenApiDocument currentDocument)
+        {
+            Utils.CheckArgumentNull(currentDocument);
+            openApiDocument ??= currentDocument;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiReference.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiReference.cs
@@ -7,19 +7,6 @@ using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models.Interfaces;
 using Microsoft.OpenApi.Writers;
 
-#if !NET5_0_OR_GREATER
-namespace System.Runtime.CompilerServices {
-   using System.ComponentModel;
-   /// <summary>
-   /// Reserved to be used by the compiler for tracking metadata.
-   /// This class should not be used by developers in source code.
-   /// </summary>
-   [EditorBrowsable(EditorBrowsableState.Never)]
-   internal static class IsExternalInit {
-   }
-}
-#endif
-
 namespace Microsoft.OpenApi.Models
 {
     /// <summary>
@@ -78,11 +65,11 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         public bool IsFragment { get; init; }
 
-        private OpenApiDocument openApiDocument;        
+        private OpenApiDocument hostDocument;        
         /// <summary>
         /// The OpenApiDocument that is hosting the OpenApiReference instance. This is used to enable dereferencing the reference.
         /// </summary>
-        public OpenApiDocument HostDocument { get => openApiDocument; init => openApiDocument = value; }
+        public OpenApiDocument HostDocument { get => hostDocument; init => hostDocument = value; }
 
         /// <summary>
         /// Gets the full reference string for v3.0.
@@ -301,7 +288,7 @@ namespace Microsoft.OpenApi.Models
         internal void EnsureHostDocumentIsSet(OpenApiDocument currentDocument)
         {
             Utils.CheckArgumentNull(currentDocument);
-            openApiDocument ??= currentDocument;
+            hostDocument ??= currentDocument;
         }
     }
 }

--- a/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
+++ b/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
@@ -71,7 +71,7 @@ public abstract class BaseOpenApiReferenceHolder<T, V> : IOpenApiReferenceHolder
     /// <inheritdoc/>
     public bool UnresolvedReference { get => Reference is null || Target is null; }
     /// <inheritdoc/>
-    public OpenApiReference Reference { get; set; }
+    public OpenApiReference Reference { get; init; }
     /// <inheritdoc/>
     public abstract V CopyReferenceAsTargetElementWithOverrides(V source);
     /// <inheritdoc/>

--- a/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
+++ b/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
@@ -10,16 +10,11 @@ namespace Microsoft.OpenApi.Models.References;
 /// <typeparam name="V">The interface type for the model.</typeparam>
 public abstract class BaseOpenApiReferenceHolder<T, V> : IOpenApiReferenceHolder<T, V> where T : class, IOpenApiReferenceable, V where V : IOpenApiSerializable
 {
-    /// <summary>
-    /// The resolved target object. This should remain readonly, otherwise mutating the reference will have side effects.
-    /// </summary>
-    protected readonly T _target;
     /// <inheritdoc/>
     public virtual T Target
     {
         get
         {
-            if (_target is not null) return _target;
             return Reference.HostDocument?.ResolveReferenceTo<T>(Reference);
         }
     }
@@ -34,17 +29,6 @@ public abstract class BaseOpenApiReferenceHolder<T, V> : IOpenApiReferenceHolder
         //no need to copy summary and description as if they are not overridden, they will be fetched from the target
         //if they are, the reference copy will handle it
     }
-    private protected BaseOpenApiReferenceHolder(T target, string referenceId, ReferenceType referenceType)
-    {
-        Utils.CheckArgumentNull(target);
-        _target = target;
-
-        Reference = new OpenApiReference()
-        {
-            Id = referenceId,
-            Type = referenceType,
-        };
-    }
     /// <summary>
     /// Constructor initializing the reference object.
     /// </summary>
@@ -56,9 +40,11 @@ public abstract class BaseOpenApiReferenceHolder<T, V> : IOpenApiReferenceHolder
     /// 1. a absolute/relative file path, for example:  ../commons/pet.json
     /// 2. a Url, for example: http://localhost/pet.json
     /// </param>
-    protected BaseOpenApiReferenceHolder(string referenceId, OpenApiDocument hostDocument, ReferenceType referenceType, string externalResource = null)
+    protected BaseOpenApiReferenceHolder(string referenceId, OpenApiDocument hostDocument, ReferenceType referenceType, string externalResource)
     {
         Utils.CheckArgumentNullOrEmpty(referenceId);
+        // we're not checking for null hostDocument as it's optional and can be set via additional methods by a walker
+        // this way object initialization of a whole document is supported
 
         Reference = new OpenApiReference()
         {

--- a/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
+++ b/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
@@ -13,14 +13,14 @@ public abstract class BaseOpenApiReferenceHolder<T, V> : IOpenApiReferenceHolder
     /// <summary>
     /// The resolved target object.
     /// </summary>
-    protected T _target;
+    protected readonly T _target;
     /// <inheritdoc/>
     public virtual T Target
     {
         get
         {
-            _target ??= Reference.HostDocument?.ResolveReferenceTo<T>(Reference);
-            return _target;
+            if (_target is not null) return _target;
+            return Reference.HostDocument?.ResolveReferenceTo<T>(Reference);
         }
     }
     /// <summary>
@@ -36,6 +36,7 @@ public abstract class BaseOpenApiReferenceHolder<T, V> : IOpenApiReferenceHolder
     }
     private protected BaseOpenApiReferenceHolder(T target, string referenceId, ReferenceType referenceType)
     {
+        Utils.CheckArgumentNull(target);
         _target = target;
 
         Reference = new OpenApiReference()

--- a/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
+++ b/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OpenApi.Models.References;
 public abstract class BaseOpenApiReferenceHolder<T, V> : IOpenApiReferenceHolder<T, V> where T : class, IOpenApiReferenceable, V where V : IOpenApiSerializable
 {
     /// <summary>
-    /// The resolved target object.
+    /// The resolved target object. This should remain readonly, otherwise mutating the reference will have side effects.
     /// </summary>
     protected readonly T _target;
     /// <inheritdoc/>

--- a/src/Microsoft.OpenApi/Models/References/OpenApiCallbackReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiCallbackReference.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OpenApi.Models.References
         /// 1. an absolute/relative file path, for example:  ../commons/pet.json
         /// 2. a Url, for example: http://localhost/pet.json
         /// </param>
-        public OpenApiCallbackReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Callback, externalResource)
+        public OpenApiCallbackReference(string referenceId, OpenApiDocument hostDocument = null, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Callback, externalResource)
         {
         }
         /// <summary>
@@ -35,10 +35,6 @@ namespace Microsoft.OpenApi.Models.References
         private OpenApiCallbackReference(OpenApiCallbackReference callback):base(callback)
         {
             
-        }
-
-        internal OpenApiCallbackReference(OpenApiCallback target, string referenceId):base(target, referenceId, ReferenceType.Callback)
-        {
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi/Models/References/OpenApiExampleReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiExampleReference.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OpenApi.Models.References
         /// 1. a absolute/relative file path, for example:  ../commons/pet.json
         /// 2. a Url, for example: http://localhost/pet.json
         /// </param>
-        public OpenApiExampleReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Example, externalResource)
+        public OpenApiExampleReference(string referenceId, OpenApiDocument hostDocument = null, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Example, externalResource)
         {
         }
         /// <summary>
@@ -33,10 +33,6 @@ namespace Microsoft.OpenApi.Models.References
         /// </summary>
         /// <param name="example">The example reference to copy</param>
         private OpenApiExampleReference(OpenApiExampleReference example):base(example)
-        {
-        }
-
-        internal OpenApiExampleReference(OpenApiExample target, string referenceId):base(target, referenceId, ReferenceType.Example)
         {
         }
 

--- a/src/Microsoft.OpenApi/Models/References/OpenApiHeaderReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiHeaderReference.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OpenApi.Models.References
         /// 1. a absolute/relative file path, for example:  ../commons/pet.json
         /// 2. a Url, for example: http://localhost/pet.json
         /// </param>
-        public OpenApiHeaderReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Header, externalResource)
+        public OpenApiHeaderReference(string referenceId, OpenApiDocument hostDocument = null, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Header, externalResource)
         {
         }
 
@@ -33,10 +33,6 @@ namespace Microsoft.OpenApi.Models.References
         /// </summary>
         /// <param name="header">The <see cref="OpenApiHeaderReference"/> object to copy</param>
         private OpenApiHeaderReference(OpenApiHeaderReference header):base(header)
-        {
-        }
-
-        internal OpenApiHeaderReference(OpenApiHeader target, string referenceId):base(target, referenceId, ReferenceType.Header)
         {
         }
 

--- a/src/Microsoft.OpenApi/Models/References/OpenApiLinkReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiLinkReference.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OpenApi.Models.References
         /// 1. a absolute/relative file path, for example:  ../commons/pet.json
         /// 2. a Url, for example: http://localhost/pet.json
         /// </param>
-        public OpenApiLinkReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Link, externalResource)
+        public OpenApiLinkReference(string referenceId, OpenApiDocument hostDocument = null, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Link, externalResource)
         {
         }
         /// <summary>
@@ -32,9 +32,6 @@ namespace Microsoft.OpenApi.Models.References
         /// </summary>
         /// <param name="reference">The reference to copy</param>
         private OpenApiLinkReference(OpenApiLinkReference reference):base(reference)
-        {
-        }
-        internal OpenApiLinkReference(OpenApiLink target, string referenceId):base(target, referenceId, ReferenceType.Link)
         {
         }
 

--- a/src/Microsoft.OpenApi/Models/References/OpenApiParameterReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiParameterReference.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.Models.References
         /// 1. a absolute/relative file path, for example:  ../commons/pet.json
         /// 2. a Url, for example: http://localhost/pet.json
         /// </param>
-        public OpenApiParameterReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Parameter, externalResource)
+        public OpenApiParameterReference(string referenceId, OpenApiDocument hostDocument = null, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Parameter, externalResource)
         {
         }
 
@@ -32,10 +32,6 @@ namespace Microsoft.OpenApi.Models.References
         /// </summary>
         /// <param name="parameter">The parameter reference to copy</param>
         private OpenApiParameterReference(OpenApiParameterReference parameter):base(parameter)
-        {
-        }
-
-        internal OpenApiParameterReference(OpenApiParameter target, string referenceId):base(target, referenceId, ReferenceType.Parameter)
         {
         }
 

--- a/src/Microsoft.OpenApi/Models/References/OpenApiPathItemReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiPathItemReference.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OpenApi.Models.References
         /// 1. a absolute/relative file path, for example:  ../commons/pet.json
         /// 2. a Url, for example: http://localhost/pet.json
         /// </param>
-        public OpenApiPathItemReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null): base(referenceId, hostDocument, ReferenceType.PathItem, externalResource)
+        public OpenApiPathItemReference(string referenceId, OpenApiDocument hostDocument = null, string externalResource = null): base(referenceId, hostDocument, ReferenceType.PathItem, externalResource)
         {
         }
 
@@ -35,10 +35,6 @@ namespace Microsoft.OpenApi.Models.References
         private OpenApiPathItemReference(OpenApiPathItemReference pathItem):base(pathItem)
         {
             
-        }
-
-        internal OpenApiPathItemReference(OpenApiPathItem target, string referenceId):base(target, referenceId, ReferenceType.PathItem)
-        {
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi/Models/References/OpenApiRequestBodyReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiRequestBodyReference.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OpenApi.Models.References
         /// 1. a absolute/relative file path, for example:  ../commons/pet.json
         /// 2. a Url, for example: http://localhost/pet.json
         /// </param>
-        public OpenApiRequestBodyReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.RequestBody, externalResource)
+        public OpenApiRequestBodyReference(string referenceId, OpenApiDocument hostDocument = null, string externalResource = null):base(referenceId, hostDocument, ReferenceType.RequestBody, externalResource)
         {
         }
         /// <summary>
@@ -35,9 +35,6 @@ namespace Microsoft.OpenApi.Models.References
         private OpenApiRequestBodyReference(OpenApiRequestBodyReference openApiRequestBodyReference):base(openApiRequestBodyReference)
         {
             
-        }
-        internal OpenApiRequestBodyReference(OpenApiRequestBody target, string referenceId):base(target, referenceId, ReferenceType.RequestBody)
-        {
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi/Models/References/OpenApiResponseReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiResponseReference.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OpenApi.Models.References
         /// 1. a absolute/relative file path, for example:  ../commons/pet.json
         /// 2. a Url, for example: http://localhost/pet.json
         /// </param>
-        public OpenApiResponseReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Response, externalResource)
+        public OpenApiResponseReference(string referenceId, OpenApiDocument hostDocument = null, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Response, externalResource)
         {
         }
         /// <summary>
@@ -33,10 +33,6 @@ namespace Microsoft.OpenApi.Models.References
         private OpenApiResponseReference(OpenApiResponseReference openApiResponseReference):base(openApiResponseReference)
         {
             
-        }
-
-        internal OpenApiResponseReference(OpenApiResponse target, string referenceId):base(target, referenceId, ReferenceType.Response)
-        {
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OpenApi.Models.References
         /// 1. a absolute/relative file path, for example:  ../commons/pet.json
         /// 2. a Url, for example: http://localhost/pet.json
         /// </param>
-        public OpenApiSchemaReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Schema, externalResource)
+        public OpenApiSchemaReference(string referenceId, OpenApiDocument hostDocument = null, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Schema, externalResource)
         {
         }
         /// <summary>
@@ -33,10 +33,6 @@ namespace Microsoft.OpenApi.Models.References
         /// </summary>
         /// <param name="schema">The schema reference to copy</param>
         private OpenApiSchemaReference(OpenApiSchemaReference schema):base(schema)
-        {
-        }
-
-        internal OpenApiSchemaReference(OpenApiSchema target, string referenceId):base(target, referenceId, ReferenceType.Schema)
         {
         }
 

--- a/src/Microsoft.OpenApi/Models/References/OpenApiSecuritySchemeReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiSecuritySchemeReference.cs
@@ -19,7 +19,7 @@ namespace Microsoft.OpenApi.Models.References
         /// <param name="referenceId">The reference Id.</param>
         /// <param name="hostDocument">The host OpenAPI document.</param>
         /// <param name="externalResource">The externally referenced file.</param>
-        public OpenApiSecuritySchemeReference(string referenceId, OpenApiDocument hostDocument, string externalResource = null):base(referenceId, hostDocument, ReferenceType.SecurityScheme, externalResource)
+        public OpenApiSecuritySchemeReference(string referenceId, OpenApiDocument hostDocument = null, string externalResource = null):base(referenceId, hostDocument, ReferenceType.SecurityScheme, externalResource)
         {
         }
         /// <summary>
@@ -29,9 +29,6 @@ namespace Microsoft.OpenApi.Models.References
         private OpenApiSecuritySchemeReference(OpenApiSecuritySchemeReference openApiSecuritySchemeReference):base(openApiSecuritySchemeReference)
         {
             
-        }
-        internal OpenApiSecuritySchemeReference(OpenApiSecurityScheme target, string referenceId):base(target, referenceId, ReferenceType.SecurityScheme)
-        {
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi/Models/References/OpenApiTagReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiTagReference.cs
@@ -21,8 +21,8 @@ namespace Microsoft.OpenApi.Models.References
         {
             get
             {
-                _target ??= Reference.HostDocument?.Tags.FirstOrDefault(t => StringComparer.Ordinal.Equals(t.Name, Reference.Id));
-                return _target;
+                if (_target is not null) return _target;
+                return Reference.HostDocument?.Tags.FirstOrDefault(t => StringComparer.Ordinal.Equals(t.Name, Reference.Id));
             }
         }
 

--- a/src/Microsoft.OpenApi/Models/References/OpenApiTagReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiTagReference.cs
@@ -21,7 +21,6 @@ namespace Microsoft.OpenApi.Models.References
         {
             get
             {
-                if (_target is not null) return _target;
                 return Reference.HostDocument?.Tags.FirstOrDefault(t => StringComparer.Ordinal.Equals(t.Name, Reference.Id));
             }
         }
@@ -31,7 +30,12 @@ namespace Microsoft.OpenApi.Models.References
         /// </summary>
         /// <param name="referenceId">The reference Id.</param>
         /// <param name="hostDocument">The host OpenAPI document.</param>
-        public OpenApiTagReference(string referenceId, OpenApiDocument hostDocument):base(referenceId, hostDocument, ReferenceType.Tag)
+        /// <param name="externalResource">Optional: External resource in the reference.
+        /// It may be:
+        /// 1. a absolute/relative file path, for example:  ../commons/pet.json
+        /// 2. a Url, for example: http://localhost/pet.json
+        /// </param>
+        public OpenApiTagReference(string referenceId, OpenApiDocument hostDocument = null, string externalResource = null):base(referenceId, hostDocument, ReferenceType.Tag, externalResource)
         {
         }
         /// <summary>
@@ -41,10 +45,6 @@ namespace Microsoft.OpenApi.Models.References
         private OpenApiTagReference(OpenApiTagReference openApiTagReference):base(openApiTagReference)
         {
             
-        }
-
-        internal OpenApiTagReference(OpenApiTag target, string referenceId):base(target, referenceId, ReferenceType.Tag)
-        {
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiV3VersionService.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiV3VersionService.cs
@@ -183,11 +183,12 @@ namespace Microsoft.OpenApi.Reader.V3
         /// <inheritdoc />
         public string GetReferenceScalarValues(MapNode mapNode, string scalarValue)
         {
-            if (mapNode.Any(static x => !"$ref".Equals(x.Name, StringComparison.OrdinalIgnoreCase)))
+            if (mapNode.Any(static x => !"$ref".Equals(x.Name, StringComparison.OrdinalIgnoreCase)) &&
+                mapNode
+                .Where(x => x.Name.Equals(scalarValue))
+                .Select(static x => x.Value)
+                .OfType<ValueNode>().FirstOrDefault() is {} valueNode)
             {
-                var valueNode = mapNode.Where(x => x.Name.Equals(scalarValue))
-                .Select(static x => x.Value).OfType<ValueNode>().FirstOrDefault();
-
                 return valueNode.GetScalarValue();
             }
 

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiV3VersionService.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiV3VersionService.cs
@@ -116,7 +116,7 @@ namespace Microsoft.OpenApi.Reader.V3
                     }
                     // Where fragments point into a non-OpenAPI document, the id will be the complete fragment identifier
                     var id = segments[1];
-                    var openApiReference = new OpenApiReference();
+                    var isFragment = false;
 
                     // $ref: externalSource.yaml#/Pet
                     if (id.StartsWith("/components/", StringComparison.Ordinal))
@@ -152,12 +152,16 @@ namespace Microsoft.OpenApi.Reader.V3
                     }
                     else
                     {
-                        openApiReference.IsFragment = true;
+                        isFragment = true;
                     }
 
-                    openApiReference.ExternalResource = segments[0];
-                    openApiReference.Type = type;
-                    openApiReference.Id = id;
+                    var openApiReference = new OpenApiReference
+                    {
+                        ExternalResource = segments[0],
+                        Type = type,
+                        Id = id,
+                        IsFragment = isFragment,
+                    };
 
                     return openApiReference;
                 }

--- a/src/Microsoft.OpenApi/Services/ReferenceHostDocumentSetter.cs
+++ b/src/Microsoft.OpenApi/Services/ReferenceHostDocumentSetter.cs
@@ -23,7 +23,10 @@ namespace Microsoft.OpenApi.Services
         {
             if (referenceHolder.Reference != null)
             {
-                referenceHolder.Reference.HostDocument = _currentDocument;
+                referenceHolder.Reference = new OpenApiReference(referenceHolder.Reference)
+                {
+                    HostDocument = _currentDocument,
+                };
             }
         }
     }

--- a/src/Microsoft.OpenApi/Services/ReferenceHostDocumentSetter.cs
+++ b/src/Microsoft.OpenApi/Services/ReferenceHostDocumentSetter.cs
@@ -21,13 +21,7 @@ namespace Microsoft.OpenApi.Services
         /// <inheritdoc/>
         public override void Visit(IOpenApiReferenceHolder referenceHolder)
         {
-            if (referenceHolder.Reference != null)
-            {
-                referenceHolder.Reference = new OpenApiReference(referenceHolder.Reference)
-                {
-                    HostDocument = _currentDocument,
-                };
-            }
+            referenceHolder.Reference?.EnsureHostDocumentIsSet(_currentDocument);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/TryLoadReferenceV2Tests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/TryLoadReferenceV2Tests.cs
@@ -99,21 +99,7 @@ namespace Microsoft.OpenApi.Readers.Tests.ReferenceService
                     {
                         ["application/json"] = new()
                         {
-                            Schema = new OpenApiSchemaReference(new OpenApiSchema()
-                            {
-                                Description = "Sample description",
-                                Required = new HashSet<string> {"name" },
-                                Properties = {
-                                    ["name"] = new OpenApiSchema()
-                                    {
-                                        Type = JsonSchemaType.String
-                                    },
-                                    ["tag"] = new OpenApiSchema()
-                                    {
-                                        Type = JsonSchemaType.String
-                                    }
-                                },
-                            }, "SampleObject2")
+                            Schema = new OpenApiSchemaReference("SampleObject2")
                         }
                     }
                 };

--- a/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/TryLoadReferenceV2Tests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/TryLoadReferenceV2Tests.cs
@@ -118,7 +118,11 @@ namespace Microsoft.OpenApi.Readers.Tests.ReferenceService
                     }
                 };
 
-            ((OpenApiSchemaReference)expected.Content["application/json"].Schema).Reference.HostDocument = result.Document;
+            var schemaReference = (OpenApiSchemaReference)expected.Content["application/json"].Schema;
+            schemaReference.Reference = new OpenApiReference(schemaReference.Reference)
+            {
+                HostDocument = result.Document,
+            };
             var actual = reference.Target;
 
             // Assert

--- a/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/TryLoadReferenceV2Tests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/TryLoadReferenceV2Tests.cs
@@ -118,11 +118,7 @@ namespace Microsoft.OpenApi.Readers.Tests.ReferenceService
                     }
                 };
 
-            var schemaReference = (OpenApiSchemaReference)expected.Content["application/json"].Schema;
-            schemaReference.Reference = new OpenApiReference(schemaReference.Reference)
-            {
-                HostDocument = result.Document,
-            };
+            ((OpenApiSchemaReference)expected.Content["application/json"].Schema).Reference.EnsureHostDocumentIsSet(result.Document);
             var actual = reference.Target;
 
             // Assert

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -1046,11 +1046,11 @@ paths: {}
                     }
             };
 
-            tagReference1.Reference.HostDocument = expected;
-            tagReference2.Reference.HostDocument = expected;
-            petSchemaReference.Reference.HostDocument = expected;
-            newPetSchemaReference.Reference.HostDocument = expected;
-            errorModelSchemaReference.Reference.HostDocument = expected;
+            tagReference1.Reference = new OpenApiReference(tagReference1.Reference) {HostDocument = expected };
+            tagReference2.Reference = new OpenApiReference(tagReference2.Reference) {HostDocument = expected };
+            petSchemaReference.Reference = new OpenApiReference(petSchemaReference.Reference) {HostDocument = expected };
+            newPetSchemaReference.Reference = new OpenApiReference(newPetSchemaReference.Reference) {HostDocument = expected };
+            errorModelSchemaReference.Reference = new OpenApiReference(errorModelSchemaReference.Reference) {HostDocument = expected };
 
             actual.Document.Should().BeEquivalentTo(expected, options => options
             .IgnoringCyclicReferences()
@@ -1284,7 +1284,7 @@ components:
             var outputDoc = (await doc.SerializeAsYamlAsync(OpenApiSpecVersion.OpenApi3_0)).MakeLineBreaksEnvironmentNeutral();
             var expectedParam = expected.Paths["/pets"].Operations[OperationType.Get].Parameters[0];
             var expectedParamReference = Assert.IsType<OpenApiParameterReference>(expectedParam);
-            expectedParamReference.Reference.HostDocument = doc;
+            expectedParamReference.Reference = new OpenApiReference(expectedParamReference.Reference) {HostDocument = doc};
 
             var actualParamReference = Assert.IsType<OpenApiParameterReference>(actualParam);
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -1046,11 +1046,11 @@ paths: {}
                     }
             };
 
-            tagReference1.Reference = new OpenApiReference(tagReference1.Reference) {HostDocument = expected };
-            tagReference2.Reference = new OpenApiReference(tagReference2.Reference) {HostDocument = expected };
-            petSchemaReference.Reference = new OpenApiReference(petSchemaReference.Reference) {HostDocument = expected };
-            newPetSchemaReference.Reference = new OpenApiReference(newPetSchemaReference.Reference) {HostDocument = expected };
-            errorModelSchemaReference.Reference = new OpenApiReference(errorModelSchemaReference.Reference) {HostDocument = expected };
+            tagReference1.Reference.EnsureHostDocumentIsSet(expected);
+            tagReference2.Reference.EnsureHostDocumentIsSet(expected);
+            petSchemaReference.Reference.EnsureHostDocumentIsSet(expected);
+            newPetSchemaReference.Reference.EnsureHostDocumentIsSet(expected);
+            errorModelSchemaReference.Reference.EnsureHostDocumentIsSet(expected);
 
             actual.Document.Should().BeEquivalentTo(expected, options => options
             .IgnoringCyclicReferences()
@@ -1284,7 +1284,7 @@ components:
             var outputDoc = (await doc.SerializeAsYamlAsync(OpenApiSpecVersion.OpenApi3_0)).MakeLineBreaksEnvironmentNeutral();
             var expectedParam = expected.Paths["/pets"].Operations[OperationType.Get].Parameters[0];
             var expectedParamReference = Assert.IsType<OpenApiParameterReference>(expectedParam);
-            expectedParamReference.Reference = new OpenApiReference(expectedParamReference.Reference) {HostDocument = doc};
+            expectedParamReference.Reference.EnsureHostDocumentIsSet(doc);
 
             var actualParamReference = Assert.IsType<OpenApiParameterReference>(actualParam);
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -684,21 +684,21 @@ paths: {}
             var petSchemaSource = Assert.IsType<OpenApiSchema>(components.Schemas["pet1"]);
             var petSchema = await CloneAsync(petSchemaSource);
             var castPetSchema = Assert.IsType<OpenApiSchema>(petSchema);
-            var petSchemaReference = new OpenApiSchemaReference(castPetSchema, "pet1");
+            var petSchemaReference = new OpenApiSchemaReference("pet1");
 
             var newPetSchemaSource = Assert.IsType<OpenApiSchema>(components.Schemas["newPet"]);
             var newPetSchema = await CloneAsync(newPetSchemaSource);
             var castNewPetSchema = Assert.IsType<OpenApiSchema>(newPetSchema);
-            var newPetSchemaReference = new OpenApiSchemaReference(castNewPetSchema, "newPet");
+            var newPetSchemaReference = new OpenApiSchemaReference("newPet");
 
             var errorModelSchemaSource = Assert.IsType<OpenApiSchema>(components.Schemas["errorModel"]);
             var errorModelSchema = await CloneAsync(errorModelSchemaSource);
             var castErrorModelSchema = Assert.IsType<OpenApiSchema>(errorModelSchema);
-            var errorModelSchemaReference = new OpenApiSchemaReference(castErrorModelSchema, "errorModel");
+            var errorModelSchemaReference = new OpenApiSchemaReference("errorModel");
 
-            var tagReference1 = new OpenApiTagReference("tagName1", null);
+            var tagReference1 = new OpenApiTagReference("tagName1");
 
-            var tagReference2 = new OpenApiTagReference("tagName2", null);
+            var tagReference2 = new OpenApiTagReference("tagName2");
 
             var securityScheme1Cast = Assert.IsType<OpenApiSecurityScheme>(components.SecuritySchemes["securitySchemeName1"]);
             var securityScheme1 = await CloneSecuritySchemeAsync(securityScheme1Cast);
@@ -889,8 +889,8 @@ paths: {}
                                     {
                                         new OpenApiSecurityRequirement
                                         {
-                                            [new OpenApiSecuritySchemeReference(securityScheme1, "securitySchemeName1")] = new List<string>(),
-                                            [new OpenApiSecuritySchemeReference(securityScheme2, "securitySchemeName2")] = new List<string>
+                                            [new OpenApiSecuritySchemeReference("securitySchemeName1")] = new List<string>(),
+                                            [new OpenApiSecuritySchemeReference("securitySchemeName2")] = new List<string>
                                             {
                                                 "scope1",
                                                 "scope2"
@@ -1035,8 +1035,8 @@ paths: {}
                     {
                         new OpenApiSecurityRequirement
                         {
-                            [new OpenApiSecuritySchemeReference(securityScheme1, "securitySchemeName1")] = new List<string>(),
-                            [new OpenApiSecuritySchemeReference(securityScheme2, "securitySchemeName2")] = new List<string>
+                            [new OpenApiSecuritySchemeReference("securitySchemeName1")] = new List<string>(),
+                            [new OpenApiSecuritySchemeReference("securitySchemeName2")] = new List<string>
                             {
                                 "scope1",
                                 "scope2",
@@ -1045,6 +1045,8 @@ paths: {}
                         }
                     }
             };
+            expected.RegisterComponents();
+            expected.SetReferenceHostDocument();
 
             tagReference1.Reference.EnsureHostDocumentIsSet(expected);
             tagReference2.Reference.EnsureHostDocumentIsSet(expected);
@@ -1238,7 +1240,7 @@ paths: {}
                                 Summary = "Returns all pets",
                                 Parameters =
                                 [
-                                    new OpenApiParameterReference(parameter, "LimitParameter"),
+                                    new OpenApiParameterReference("LimitParameter"),
                                 ],
                                 Responses = new OpenApiResponses()
                             }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -1230,8 +1230,12 @@ paths: {}
                     }
                 }
             };
+            expected.RegisterComponents();
+            expected.SetReferenceHostDocument();
 
-            var expectedSerializedDoc = @"openapi: 3.0.4
+            var expectedSerializedDoc = 
+"""
+openapi: 3.0.4
 info:
   title: Pet Store with Referenceable Parameter
   version: 1.0.0
@@ -1251,7 +1255,8 @@ components:
       schema:
         type: integer
         format: int32
-        default: 10";
+        default: 10
+""";
 
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "minifiedPetStore.yaml"));
 
@@ -1261,7 +1266,6 @@ components:
             var outputDoc = (await doc.SerializeAsYamlAsync(OpenApiSpecVersion.OpenApi3_0)).MakeLineBreaksEnvironmentNeutral();
             var expectedParam = expected.Paths["/pets"].Operations[OperationType.Get].Parameters[0];
             var expectedParamReference = Assert.IsType<OpenApiParameterReference>(expectedParam);
-            expectedParamReference.Reference.EnsureHostDocumentIsSet(doc);
 
             var actualParamReference = Assert.IsType<OpenApiParameterReference>(actualParam);
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiParameterTests.cs
@@ -343,7 +343,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                                 OperationId = "findPets",
                                 Parameters =
                                 [
-                                    new OpenApiParameterReference (parameter, "tagsParameter"),
+                                    new OpenApiParameterReference("tagsParameter"),
                                 ],
                             }
                         }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiCallbackTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiCallbackTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OpenApi.Tests.Models
     [Collection("DefaultSettings")]
     public class OpenApiCallbackTests
     {
-        public static OpenApiCallback AdvancedCallback = new()
+        private static OpenApiCallback AdvancedCallback => new()
         {
             PathItems =
             {
@@ -54,9 +54,9 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static OpenApiCallbackReference CallbackProxy = new(ReferencedCallback, "simpleHook");
+        private static OpenApiCallbackReference CallbackProxy => new(ReferencedCallback, "simpleHook");
 
-        public static OpenApiCallback ReferencedCallback = new()
+        private static OpenApiCallback ReferencedCallback => new()
         {
             PathItems =
             {

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiCallbackTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiCallbackTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        private static OpenApiCallbackReference CallbackProxy => new(ReferencedCallback, "simpleHook");
+        private static OpenApiCallbackReference CallbackProxy => new("simpleHook");
 
         private static OpenApiCallback ReferencedCallback => new()
         {

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiExampleTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiExampleTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        private static OpenApiExampleReference OpenApiExampleReference => new(ReferencedExample, "example1");
+        private static OpenApiExampleReference OpenApiExampleReference => new("example1");
         private static OpenApiExample ReferencedExample => new()
         {
             Value = new JsonObject

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiExampleTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiExampleTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.OpenApi.Tests.Models
     [Collection("DefaultSettings")]
     public class OpenApiExampleTests
     {
-        public static OpenApiExample AdvancedExample = new()
+        private static OpenApiExample AdvancedExample => new()
         {
             Value = new JsonObject
             {
@@ -57,8 +57,8 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static OpenApiExampleReference OpenApiExampleReference = new(ReferencedExample, "example1");
-        public static OpenApiExample ReferencedExample = new()
+        private static OpenApiExampleReference OpenApiExampleReference => new(ReferencedExample, "example1");
+        private static OpenApiExample ReferencedExample => new()
         {
             Value = new JsonObject
             {

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiHeaderTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiHeaderTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OpenApi.Tests.Models
     [Collection("DefaultSettings")]
     public class OpenApiHeaderTests
     {
-        public static OpenApiHeader AdvancedHeader = new()
+        private static OpenApiHeader AdvancedHeader => new()
         {
             Description = "sampleHeader",
             Schema = new OpenApiSchema()
@@ -25,9 +25,9 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static OpenApiHeaderReference OpenApiHeaderReference = new(ReferencedHeader, "example1");
+        private static OpenApiHeaderReference OpenApiHeaderReference => new(ReferencedHeader, "example1");
 
-        public static OpenApiHeader ReferencedHeader = new()
+        private static OpenApiHeader ReferencedHeader => new()
         {
             Description = "sampleHeader",
             Schema = new OpenApiSchema()

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiHeaderTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiHeaderTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        private static OpenApiHeaderReference OpenApiHeaderReference => new(ReferencedHeader, "example1");
+        private static OpenApiHeaderReference OpenApiHeaderReference => new("example1");
 
         private static OpenApiHeader ReferencedHeader => new()
         {

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiLinkTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiLinkTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        private static OpenApiLinkReference LinkReference => new(ReferencedLink, "example1");
+        private static OpenApiLinkReference LinkReference => new("example1");
         private static OpenApiLink ReferencedLink => new()
         {
             OperationId = "operationId1",

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiLinkTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiLinkTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.OpenApi.Tests.Models
     [Collection("DefaultSettings")]
     public class OpenApiLinkTests
     {
-        public static readonly OpenApiLink AdvancedLink = new()
+        private static OpenApiLink AdvancedLink => new()
         {
             OperationId = "operationId1",
             Parameters =
@@ -42,8 +42,8 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static readonly OpenApiLinkReference LinkReference = new(ReferencedLink, "example1");
-        public static readonly OpenApiLink ReferencedLink = new()
+        private static OpenApiLinkReference LinkReference => new(ReferencedLink, "example1");
+        private static OpenApiLink ReferencedLink => new()
         {
             OperationId = "operationId1",
             Parameters =

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiOperationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
@@ -58,21 +59,7 @@ namespace Microsoft.OpenApi.Tests.Models
             },
             Responses = new()
             {
-                ["200"] = new OpenApiResponseReference(new OpenApiResponse()
-                {
-                    Content = new Dictionary<string, OpenApiMediaType>
-                    {
-                        ["application/json"] = new()
-                        {
-                            Schema = new OpenApiSchema()
-                            {
-                                Type = JsonSchemaType.Number,
-                                Minimum = 5,
-                                Maximum = 10
-                            }
-                        }
-                    }
-                }, "response1"),
+                ["200"] = new OpenApiResponseReference("response1"),
                 ["400"] = new OpenApiResponse()
                 {
                     Content = new Dictionary<string, OpenApiMediaType>
@@ -100,7 +87,7 @@ namespace Microsoft.OpenApi.Tests.Models
             Annotations = new Dictionary<string, object> { { "key1", "value1" }, { "key2", 2 } },
         };
 
-        private static readonly OpenApiOperation _advancedOperationWithTagsAndSecurity = new()
+        private static OpenApiOperation _advancedOperationWithTagsAndSecurity => new()
         {
             Tags = new List<OpenApiTagReference>
             {
@@ -146,21 +133,7 @@ namespace Microsoft.OpenApi.Tests.Models
             },
             Responses = new()
             {
-                ["200"] = new OpenApiResponseReference(new OpenApiResponse()
-                {
-                    Content = new Dictionary<string, OpenApiMediaType>
-                    {
-                        ["application/json"] = new()
-                        {
-                            Schema = new OpenApiSchema()
-                            {
-                                Type = JsonSchemaType.Number,
-                                Minimum = 5,
-                                Maximum = 10
-                            }
-                        }
-                    }
-                }, "response1"),
+                ["200"] = new OpenApiResponseReference("response1"),
                 ["400"] = new OpenApiResponse()
                 {
                     Content = new Dictionary<string, OpenApiMediaType>
@@ -181,8 +154,8 @@ namespace Microsoft.OpenApi.Tests.Models
             {
                 new()
                 {
-                    [new OpenApiSecuritySchemeReference(new OpenApiSecurityScheme(), "securitySchemeId1")] = new List<string>(),
-                    [new OpenApiSecuritySchemeReference(new OpenApiSecurityScheme(), "securitySchemeId2")] = new List<string>
+                    [new OpenApiSecuritySchemeReference("securitySchemeId1", __advancedOperationWithTagsAndSecurity_supportingDocument)] = new List<string>(),
+                    [new OpenApiSecuritySchemeReference("securitySchemeId2", __advancedOperationWithTagsAndSecurity_supportingDocument)] = new List<string>
                     {
                         "scopeName1",
                         "scopeName2"
@@ -198,6 +171,34 @@ namespace Microsoft.OpenApi.Tests.Models
                 }
             }
         };
+        private static OpenApiDocument __advancedOperationWithTagsAndSecurity_supportingDocument 
+        {
+            get
+            {
+                var document = new OpenApiDocument()
+                {
+                    Components = new() 
+                    {
+                        SecuritySchemes = new Dictionary<string, IOpenApiSecurityScheme>
+                        {
+                            ["securitySchemeId1"] = new OpenApiSecurityScheme
+                            {
+                                Type = SecuritySchemeType.ApiKey,
+                                Name = "apiKeyName1",
+                                In = ParameterLocation.Header,
+                            },
+                            ["securitySchemeId2"] = new OpenApiSecurityScheme
+                            {
+                                Type = SecuritySchemeType.OpenIdConnect,
+                                OpenIdConnectUrl = new("http://example.com"),
+                            }
+                        }
+                    }
+                };
+                document.RegisterComponents();
+                return document;
+            }
+        }
 
         private static readonly OpenApiOperation _operationWithFormData =
             new()
@@ -455,9 +456,7 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = await _advancedOperationWithTagsAndSecurity.SerializeAsJsonAsync(OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            actual = actual.MakeLineBreaksEnvironmentNeutral();
-            expected = expected.MakeLineBreaksEnvironmentNeutral();
-            Assert.Equal(expected, actual);
+            Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(actual)));
         }
 
         [Fact]
@@ -475,9 +474,7 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = await _basicOperation.SerializeAsJsonAsync(OpenApiSpecVersion.OpenApi2_0);
 
             // Assert
-            actual = actual.MakeLineBreaksEnvironmentNeutral();
-            expected = expected.MakeLineBreaksEnvironmentNeutral();
-            Assert.Equal(expected, actual);
+            Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(actual)));
         }
 
         [Fact]
@@ -554,9 +551,7 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = await _operationWithFormData.SerializeAsJsonAsync(OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
-            actual = actual.MakeLineBreaksEnvironmentNeutral();
-            expected = expected.MakeLineBreaksEnvironmentNeutral();
-            Assert.Equal(expected, actual);
+            Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(actual)));
         }
 
         [Fact]
@@ -610,9 +605,7 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = await _operationWithFormData.SerializeAsJsonAsync(OpenApiSpecVersion.OpenApi2_0);
 
             // Assert
-            actual = actual.MakeLineBreaksEnvironmentNeutral();
-            expected = expected.MakeLineBreaksEnvironmentNeutral();
-            Assert.Equal(expected, actual);
+            Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(actual)));
         }
 
         [Fact]
@@ -679,9 +672,7 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = await _operationWithBody.SerializeAsJsonAsync(OpenApiSpecVersion.OpenApi2_0);
 
             // Assert
-            actual = actual.MakeLineBreaksEnvironmentNeutral();
-            expected = expected.MakeLineBreaksEnvironmentNeutral();
-            Assert.Equal(expected, actual);
+            Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(actual)));
         }
 
         [Fact]
@@ -760,9 +751,7 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = await _advancedOperationWithTagsAndSecurity.SerializeAsJsonAsync(OpenApiSpecVersion.OpenApi2_0);
 
             // Assert
-            actual = actual.MakeLineBreaksEnvironmentNeutral();
-            expected = expected.MakeLineBreaksEnvironmentNeutral();
-            Assert.Equal(expected, actual);
+            Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(actual)));
         }
 
         [Fact]
@@ -785,9 +774,7 @@ namespace Microsoft.OpenApi.Tests.Models
             var actual = await operation.SerializeAsJsonAsync(OpenApiSpecVersion.OpenApi2_0);
 
             // Assert
-            actual = actual.MakeLineBreaksEnvironmentNeutral();
-            expected = expected.MakeLineBreaksEnvironmentNeutral();
-            Assert.Equal(expected, actual);
+            Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(actual)));
         }
 
         [Fact]

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
@@ -19,20 +19,20 @@ namespace Microsoft.OpenApi.Tests.Models
     [Collection("DefaultSettings")]
     public class OpenApiParameterTests
     {
-        public static OpenApiParameter BasicParameter = new()
+        private static OpenApiParameter BasicParameter => new()
         {
             Name = "name1",
             In = ParameterLocation.Path
         };
 
-        public static OpenApiParameterReference OpenApiParameterReference = new(ReferencedParameter, "example1");
-        public static OpenApiParameter ReferencedParameter = new()
+        private static OpenApiParameterReference OpenApiParameterReference => new(ReferencedParameter, "example1");
+        private static OpenApiParameter ReferencedParameter => new()
         {
             Name = "name1",
             In = ParameterLocation.Path
         };
 
-        public static OpenApiParameter AdvancedPathParameterWithSchema = new()
+        private static OpenApiParameter AdvancedPathParameterWithSchema => new()
         {
             Name = "name1",
             In = ParameterLocation.Path,
@@ -61,7 +61,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static OpenApiParameter ParameterWithFormStyleAndExplodeFalse = new()
+        private static OpenApiParameter ParameterWithFormStyleAndExplodeFalse => new()
         {
             Name = "name1",
             In = ParameterLocation.Query,
@@ -82,7 +82,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static OpenApiParameter ParameterWithFormStyleAndExplodeTrue = new()
+        private static OpenApiParameter ParameterWithFormStyleAndExplodeTrue => new()
         {
             Name = "name1",
             In = ParameterLocation.Query,
@@ -103,7 +103,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static OpenApiParameter QueryParameterWithMissingStyle = new OpenApiParameter
+        private static OpenApiParameter QueryParameterWithMissingStyle => new OpenApiParameter
         {
             Name = "id",
             In = ParameterLocation.Query,
@@ -117,7 +117,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static OpenApiParameter AdvancedHeaderParameterWithSchemaTypeObject = new()
+        private static OpenApiParameter AdvancedHeaderParameterWithSchemaTypeObject => new()
         {
             Name = "name1",
             In = ParameterLocation.Header,

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiParameterTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OpenApi.Tests.Models
             In = ParameterLocation.Path
         };
 
-        private static OpenApiParameterReference OpenApiParameterReference => new(ReferencedParameter, "example1");
+        private static OpenApiParameterReference OpenApiParameterReference => new("example1");
         private static OpenApiParameter ReferencedParameter => new()
         {
             Name = "name1",

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiRequestBodyTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiRequestBodyTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OpenApi.Tests.Models
     [Collection("DefaultSettings")]
     public class OpenApiRequestBodyTests
     {
-        public static OpenApiRequestBody AdvancedRequestBody = new()
+        private static OpenApiRequestBody AdvancedRequestBody => new()
         {
             Description = "description",
             Required = true,
@@ -31,8 +31,8 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static OpenApiRequestBodyReference OpenApiRequestBodyReference = new(ReferencedRequestBody, "example1");
-        public static OpenApiRequestBody ReferencedRequestBody = new()
+        private static OpenApiRequestBodyReference OpenApiRequestBodyReference => new(ReferencedRequestBody, "example1");
+        private static OpenApiRequestBody ReferencedRequestBody => new()
         {
             Description = "description",
             Required = true,

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiRequestBodyTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiRequestBodyTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        private static OpenApiRequestBodyReference OpenApiRequestBodyReference => new(ReferencedRequestBody, "example1");
+        private static OpenApiRequestBodyReference OpenApiRequestBodyReference => new("example1");
         private static OpenApiRequestBody ReferencedRequestBody => new()
         {
             Description = "description",

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiResponseTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiResponseTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        private static OpenApiResponseReference V2OpenApiResponseReference => new OpenApiResponseReference(ReferencedV2Response, "example1");
+        private static OpenApiResponseReference V2OpenApiResponseReference => new OpenApiResponseReference("example1");
         private static OpenApiResponse ReferencedV2Response => new OpenApiResponse
         {
             Description = "A complex object array response",
@@ -136,7 +136,7 @@ namespace Microsoft.OpenApi.Tests.Models
                 },
             }
         };
-        private static OpenApiResponseReference V3OpenApiResponseReference => new OpenApiResponseReference(ReferencedV3Response, "example1");
+        private static OpenApiResponseReference V3OpenApiResponseReference => new OpenApiResponseReference("example1");
 
         private static OpenApiResponse ReferencedV3Response => new OpenApiResponse
         {

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiResponseTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiResponseTests.cs
@@ -20,9 +20,9 @@ namespace Microsoft.OpenApi.Tests.Models
     [Collection("DefaultSettings")]
     public class OpenApiResponseTests
     {
-        public static OpenApiResponse BasicResponse = new OpenApiResponse();
+        private static OpenApiResponse BasicResponse => new OpenApiResponse();
 
-        public static OpenApiResponse AdvancedV2Response = new OpenApiResponse
+        private static OpenApiResponse AdvancedV2Response => new OpenApiResponse
         {
             Description = "A complex object array response",
             Content =
@@ -61,7 +61,7 @@ namespace Microsoft.OpenApi.Tests.Models
                 },
             }
         };
-        public static OpenApiResponse AdvancedV3Response = new OpenApiResponse
+        private static OpenApiResponse AdvancedV3Response => new OpenApiResponse
         {
             Description = "A complex object array response",
             Content =
@@ -101,8 +101,8 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static OpenApiResponseReference V2OpenApiResponseReference = new OpenApiResponseReference(ReferencedV2Response, "example1");
-        public static OpenApiResponse ReferencedV2Response = new OpenApiResponse
+        private static OpenApiResponseReference V2OpenApiResponseReference => new OpenApiResponseReference(ReferencedV2Response, "example1");
+        private static OpenApiResponse ReferencedV2Response => new OpenApiResponse
         {
             Description = "A complex object array response",
             Content =
@@ -136,9 +136,9 @@ namespace Microsoft.OpenApi.Tests.Models
                 },
             }
         };
-        public static OpenApiResponseReference V3OpenApiResponseReference = new OpenApiResponseReference(ReferencedV3Response, "example1");
+        private static OpenApiResponseReference V3OpenApiResponseReference => new OpenApiResponseReference(ReferencedV3Response, "example1");
 
-        public static OpenApiResponse ReferencedV3Response = new OpenApiResponse
+        private static OpenApiResponse ReferencedV3Response => new OpenApiResponse
         {
             Description = "A complex object array response",
             Content =

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSecuritySchemeTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSecuritySchemeTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OpenApi.Tests.Models
     [Collection("DefaultSettings")]
     public class OpenApiSecuritySchemeTests
     {
-        public static OpenApiSecurityScheme ApiKeySecurityScheme = new()
+        private static OpenApiSecurityScheme ApiKeySecurityScheme => new()
         {
             Description = "description1",
             Name = "parameterName",
@@ -25,14 +25,14 @@ namespace Microsoft.OpenApi.Tests.Models
             In = ParameterLocation.Query,
         };
 
-        public static OpenApiSecurityScheme HttpBasicSecurityScheme = new()
+        private static OpenApiSecurityScheme HttpBasicSecurityScheme => new()
         {
             Description = "description1",
             Type = SecuritySchemeType.Http,
             Scheme = OpenApiConstants.Basic
         };
 
-        public static OpenApiSecurityScheme HttpBearerSecurityScheme = new()
+        private static OpenApiSecurityScheme HttpBearerSecurityScheme => new()
         {
             Description = "description1",
             Type = SecuritySchemeType.Http,
@@ -40,7 +40,7 @@ namespace Microsoft.OpenApi.Tests.Models
             BearerFormat = OpenApiConstants.Jwt
         };
 
-        public static OpenApiSecurityScheme OAuth2SingleFlowSecurityScheme = new()
+        private static OpenApiSecurityScheme OAuth2SingleFlowSecurityScheme => new()
         {
             Description = "description1",
             Type = SecuritySchemeType.OAuth2,
@@ -58,7 +58,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static OpenApiSecurityScheme OAuth2MultipleFlowSecurityScheme = new()
+        private static OpenApiSecurityScheme OAuth2MultipleFlowSecurityScheme => new()
         {
             Description = "description1",
             Type = SecuritySchemeType.OAuth2,
@@ -96,7 +96,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static OpenApiSecurityScheme OpenIdConnectSecurityScheme = new()
+        private static OpenApiSecurityScheme OpenIdConnectSecurityScheme => new()
         {
             Description = "description1",
             Type = SecuritySchemeType.OpenIdConnect,
@@ -104,8 +104,8 @@ namespace Microsoft.OpenApi.Tests.Models
             OpenIdConnectUrl = new("https://example.com/openIdConnect")
         };
 
-        public static OpenApiSecuritySchemeReference OpenApiSecuritySchemeReference = new(ReferencedSecurityScheme, "sampleSecurityScheme");
-        public static OpenApiSecurityScheme ReferencedSecurityScheme = new()
+        private static OpenApiSecuritySchemeReference OpenApiSecuritySchemeReference => new(ReferencedSecurityScheme, "sampleSecurityScheme");
+        private static OpenApiSecurityScheme ReferencedSecurityScheme => new()
         {
             Description = "description1",
             Type = SecuritySchemeType.OpenIdConnect,

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSecuritySchemeTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSecuritySchemeTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.OpenApi.Tests.Models
             OpenIdConnectUrl = new("https://example.com/openIdConnect")
         };
 
-        private static OpenApiSecuritySchemeReference OpenApiSecuritySchemeReference => new(ReferencedSecurityScheme, "sampleSecurityScheme");
+        private static OpenApiSecuritySchemeReference OpenApiSecuritySchemeReference => new("sampleSecurityScheme");
         private static OpenApiSecurityScheme ReferencedSecurityScheme => new()
         {
             Description = "description1",

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiTagTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiTagTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OpenApi.Tests.Models
             }
         };
 
-        public static IOpenApiTag ReferencedTag = new OpenApiTagReference(AdvancedTag, "pet");
+        public static IOpenApiTag ReferencedTag = new OpenApiTagReference("pet");
 
         [Theory]
         [InlineData(true)]

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -1240,7 +1240,7 @@ namespace Microsoft.OpenApi.Models.References
         where T :  class, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, V
         where V : Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
-        protected T _target;
+        protected readonly T _target;
         protected BaseOpenApiReferenceHolder(Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<T, V> source) { }
         protected BaseOpenApiReferenceHolder(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, Microsoft.OpenApi.Models.ReferenceType referenceType, string externalResource = null) { }
         public Microsoft.OpenApi.Models.OpenApiReference Reference { get; set; }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -957,21 +957,21 @@ namespace Microsoft.OpenApi.Models
         public OpenApiPaths() { }
         public OpenApiPaths(Microsoft.OpenApi.Models.OpenApiPaths paths) { }
     }
-    public class OpenApiReference : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
+    public class OpenApiReference : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
     {
-        public bool IsFragment;
         public OpenApiReference() { }
         public OpenApiReference(Microsoft.OpenApi.Models.OpenApiReference reference) { }
         public string Description { get; set; }
-        public string ExternalResource { get; set; }
-        public Microsoft.OpenApi.Models.OpenApiDocument HostDocument { get; set; }
-        public string Id { get; set; }
         public bool IsExternal { get; }
         public bool IsLocal { get; }
         public string ReferenceV2 { get; }
         public string ReferenceV3 { get; }
         public string Summary { get; set; }
-        public Microsoft.OpenApi.Models.ReferenceType? Type { get; set; }
+        public string ExternalResource { get; init; }
+        public Microsoft.OpenApi.Models.OpenApiDocument HostDocument { get; init; }
+        public string Id { get; init; }
+        public bool IsFragment { get; init; }
+        public Microsoft.OpenApi.Models.ReferenceType? Type { get; init; }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -724,6 +724,7 @@ namespace Microsoft.OpenApi.Models
         public Microsoft.OpenApi.Services.OpenApiWorkspace? Workspace { get; set; }
         public bool AddComponent<T>(string id, T componentToRegister) { }
         public System.Threading.Tasks.Task<string> GetHashCodeAsync(System.Threading.CancellationToken cancellationToken = default) { }
+        public void RegisterComponents() { }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1240,9 +1241,8 @@ namespace Microsoft.OpenApi.Models.References
         where T :  class, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, V
         where V : Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
-        protected readonly T _target;
         protected BaseOpenApiReferenceHolder(Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<T, V> source) { }
-        protected BaseOpenApiReferenceHolder(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, Microsoft.OpenApi.Models.ReferenceType referenceType, string externalResource = null) { }
+        protected BaseOpenApiReferenceHolder(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, Microsoft.OpenApi.Models.ReferenceType referenceType, string externalResource) { }
         public virtual T Target { get; }
         public bool UnresolvedReference { get; }
         public Microsoft.OpenApi.Models.OpenApiReference Reference { get; init; }
@@ -1253,7 +1253,7 @@ namespace Microsoft.OpenApi.Models.References
     }
     public class OpenApiCallbackReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiCallback, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback
     {
-        public OpenApiCallbackReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
+        public OpenApiCallbackReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument = null, string externalResource = null) { }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; }
         public System.Collections.Generic.Dictionary<Microsoft.OpenApi.Expressions.RuntimeExpression, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem> PathItems { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback source) { }
@@ -1262,7 +1262,7 @@ namespace Microsoft.OpenApi.Models.References
     }
     public class OpenApiExampleReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiExample, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
     {
-        public OpenApiExampleReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
+        public OpenApiExampleReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument = null, string externalResource = null) { }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; }
         public string ExternalValue { get; }
@@ -1274,7 +1274,7 @@ namespace Microsoft.OpenApi.Models.References
     }
     public class OpenApiHeaderReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiHeader, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader
     {
-        public OpenApiHeaderReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
+        public OpenApiHeaderReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument = null, string externalResource = null) { }
         public bool AllowEmptyValue { get; }
         public bool AllowReserved { get; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> Content { get; }
@@ -1292,7 +1292,7 @@ namespace Microsoft.OpenApi.Models.References
     }
     public class OpenApiLinkReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiLink, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink
     {
-        public OpenApiLinkReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
+        public OpenApiLinkReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument = null, string externalResource = null) { }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; }
         public string OperationId { get; }
@@ -1306,7 +1306,7 @@ namespace Microsoft.OpenApi.Models.References
     }
     public class OpenApiParameterReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiParameter, Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter
     {
-        public OpenApiParameterReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
+        public OpenApiParameterReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument = null, string externalResource = null) { }
         public bool AllowEmptyValue { get; }
         public bool AllowReserved { get; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> Content { get; }
@@ -1326,7 +1326,7 @@ namespace Microsoft.OpenApi.Models.References
     }
     public class OpenApiPathItemReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiPathItem, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
     {
-        public OpenApiPathItemReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
+        public OpenApiPathItemReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument = null, string externalResource = null) { }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; }
         public System.Collections.Generic.IDictionary<Microsoft.OpenApi.Models.OperationType, Microsoft.OpenApi.Models.OpenApiOperation> Operations { get; }
@@ -1339,7 +1339,7 @@ namespace Microsoft.OpenApi.Models.References
     }
     public class OpenApiRequestBodyReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiRequestBody, Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody
     {
-        public OpenApiRequestBodyReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
+        public OpenApiRequestBodyReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument = null, string externalResource = null) { }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> Content { get; }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; }
@@ -1352,7 +1352,7 @@ namespace Microsoft.OpenApi.Models.References
     }
     public class OpenApiResponseReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiResponse, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse
     {
-        public OpenApiResponseReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
+        public OpenApiResponseReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument = null, string externalResource = null) { }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> Content { get; }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; }
@@ -1363,7 +1363,7 @@ namespace Microsoft.OpenApi.Models.References
     }
     public class OpenApiSchemaReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiSchema, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema
     {
-        public OpenApiSchemaReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
+        public OpenApiSchemaReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument = null, string externalResource = null) { }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema AdditionalProperties { get; }
         public bool AdditionalPropertiesAllowed { get; }
         public System.Collections.Generic.IList<Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema> AllOf { get; }
@@ -1424,7 +1424,7 @@ namespace Microsoft.OpenApi.Models.References
     }
     public class OpenApiSecuritySchemeReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiSecurityScheme, Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme
     {
-        public OpenApiSecuritySchemeReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, string externalResource = null) { }
+        public OpenApiSecuritySchemeReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument = null, string externalResource = null) { }
         public string BearerFormat { get; }
         public string Description { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; }
@@ -1439,7 +1439,7 @@ namespace Microsoft.OpenApi.Models.References
     }
     public class OpenApiTagReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiTag, Microsoft.OpenApi.Models.Interfaces.IOpenApiTag>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiTag>, Microsoft.OpenApi.Models.Interfaces.IOpenApiReadOnlyDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiTag
     {
-        public OpenApiTagReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument) { }
+        public OpenApiTagReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument = null, string externalResource = null) { }
         public string Description { get; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension> Extensions { get; }
         public Microsoft.OpenApi.Models.OpenApiExternalDocs ExternalDocs { get; }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -224,8 +224,8 @@ namespace Microsoft.OpenApi.Interfaces
     }
     public interface IOpenApiReferenceHolder : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
-        Microsoft.OpenApi.Models.OpenApiReference Reference { get; set; }
         bool UnresolvedReference { get; }
+        Microsoft.OpenApi.Models.OpenApiReference Reference { get; init; }
     }
     public interface IOpenApiReferenceHolder<out T, V> : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReferenceHolder, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
         where out T : Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, V
@@ -1243,9 +1243,9 @@ namespace Microsoft.OpenApi.Models.References
         protected readonly T _target;
         protected BaseOpenApiReferenceHolder(Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<T, V> source) { }
         protected BaseOpenApiReferenceHolder(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument hostDocument, Microsoft.OpenApi.Models.ReferenceType referenceType, string externalResource = null) { }
-        public Microsoft.OpenApi.Models.OpenApiReference Reference { get; set; }
         public virtual T Target { get; }
         public bool UnresolvedReference { get; }
+        public Microsoft.OpenApi.Models.OpenApiReference Reference { get; init; }
         public abstract V CopyReferenceAsTargetElementWithOverrides(V source);
         public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiReferenceValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiReferenceValidationTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OpenApi.Tests.Validations
                                     {
                                         ["application/json"] = new()
                                         {
-                                            Schema = new OpenApiSchemaReference(sharedSchema, "test")
+                                            Schema = new OpenApiSchemaReference("test")
                                         }
                                     }
                                 }
@@ -104,7 +104,7 @@ namespace Microsoft.OpenApi.Tests.Validations
                                     {
                                         ["application/json"] = new()
                                         {
-                                            Schema = new OpenApiSchemaReference(sharedSchema, "test")
+                                            Schema = new OpenApiSchemaReference("test")
                                         }
                                     }
                                 }

--- a/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
@@ -166,14 +166,14 @@ namespace Microsoft.OpenApi.Tests.Walkers
 
             var derivedSchema = new OpenApiSchema
             {
-                AnyOf = new List<IOpenApiSchema> { new OpenApiSchemaReference(baseSchema, "base") },
+                AnyOf = new List<IOpenApiSchema> { new OpenApiSchemaReference("base") },
             };
 
             var testHeader = new OpenApiHeader()
             {
-                Schema = new OpenApiSchemaReference(derivedSchema, "derived"),
+                Schema = new OpenApiSchemaReference("derived"),
             };
-            var testHeaderReference = new OpenApiHeaderReference(testHeader, "test-header");
+            var testHeaderReference = new OpenApiHeaderReference("test-header");
 
             var doc = new OpenApiDocument
             {
@@ -193,7 +193,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
                                         {
                                             ["application/json"] = new()
                                             {
-                                                Schema = new OpenApiSchemaReference(derivedSchema, "derived")
+                                                Schema = new OpenApiSchemaReference("derived")
                                             }
                                         },
                                         Headers =
@@ -219,7 +219,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
                     },
                     SecuritySchemes = new Dictionary<string, IOpenApiSecurityScheme>
                     {
-                        ["test-secScheme"] = new OpenApiSecuritySchemeReference("reference-to-scheme", null, null)
+                        ["test-secScheme"] = new OpenApiSecuritySchemeReference("reference-to-scheme")
                     }
                 }
             };

--- a/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiWorkspaceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiWorkspaceTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.OpenApi.Tests
                                         {
                                             ["application/json"] = new OpenApiMediaType()
                                             {
-                                                Schema = new OpenApiSchemaReference(testSchema, "test")
+                                                Schema = new OpenApiSchemaReference("test")
                                             }
                                         }
                                     }

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiYamlWriterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiYamlWriterTests.cs
@@ -463,10 +463,10 @@ namespace Microsoft.OpenApi.Tests.Writers
                                     {
                                         Description = "OK",
                                         Content = {
-                                             ["application/json"] = new()
-                                             {
-                                                     Schema = new OpenApiSchemaReference(thingSchema, "thing")
-                                             }
+                                            ["application/json"] = new()
+                                            {
+                                                Schema = new OpenApiSchemaReference("thing")
+                                            }
                                         }
                                     }
                                 }
@@ -480,6 +480,8 @@ namespace Microsoft.OpenApi.Tests.Writers
                         ["thing"] = thingSchema}
                 }
             };
+            doc.RegisterComponents();
+            doc.SetReferenceHostDocument();
 
             return doc;
         }


### PR DESCRIPTION
makes document for references optional. Cleans up internal constructors for references, makes references immutable to avoid side effects

related #1998