### PR TITLE
fix/load external references

### DIFF
--- a/src/Microsoft.OpenApi/Interfaces/IStreamLoader.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IStreamLoader.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Models;
 
@@ -17,7 +18,8 @@ namespace Microsoft.OpenApi.Interfaces
         /// Use Uri to locate data and convert into an input object.
         /// </summary>
         /// <param name="uri">Identifier of some source of an OpenAPI Description</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A data object that can be processed by a reader to generate an <see cref="OpenApiDocument"/></returns>
-        Task<Stream> LoadAsync(Uri uri);
+        Task<Stream> LoadAsync(Uri uri, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.OpenApi/Reader/Services/DefaultStreamLoader.cs
+++ b/src/Microsoft.OpenApi/Reader/Services/DefaultStreamLoader.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Interfaces;
@@ -35,7 +36,7 @@ namespace Microsoft.OpenApi.Reader.Services
             {
                 (true, _, _) => new Uri(Path.Combine(Directory.GetCurrentDirectory(), uri.ToString())),
                 // this overcomes a URI concatenation issue for local paths on linux OSes
-                (_, true, false) when baseUrl.Scheme.Equals("file", StringComparison.OrdinalIgnoreCase) =>
+                (_, true, false) when baseUrl.Scheme.Equals("file", StringComparison.OrdinalIgnoreCase) && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) =>
                     new Uri(Path.Combine(baseUrl.AbsoluteUri, uri.ToString())),
                 (_, _, _) => new Uri(baseUrl, uri),
             };

--- a/src/Microsoft.OpenApi/Reader/Services/OpenApiWorkspaceLoader.cs
+++ b/src/Microsoft.OpenApi/Reader/Services/OpenApiWorkspaceLoader.cs
@@ -45,8 +45,8 @@ namespace Microsoft.OpenApi.Reader.Services
                 // If not already in workspace, load it and process references
                 if (!_workspace.Contains(item.ExternalResource))
                 {
-                    var input = await _loader.LoadAsync(new(item.ExternalResource, UriKind.RelativeOrAbsolute));
-                    var result = await OpenApiDocument.LoadAsync(input, format, _readerSettings, cancellationToken);
+                    var input = await _loader.LoadAsync(new(item.ExternalResource, UriKind.RelativeOrAbsolute), cancellationToken).ConfigureAwait(false);
+                    var result = await OpenApiDocument.LoadAsync(input, format, _readerSettings, cancellationToken).ConfigureAwait(false);
                     // Merge diagnostics
                     if (result.Diagnostic != null)
                     {
@@ -54,7 +54,7 @@ namespace Microsoft.OpenApi.Reader.Services
                     }
                     if (result.Document != null)
                     {
-                        var loadDiagnostic = await LoadAsync(item, result.Document, format, diagnostic, cancellationToken);
+                        var loadDiagnostic = await LoadAsync(item, result.Document, format, diagnostic, cancellationToken).ConfigureAwait(false);
                         diagnostic = loadDiagnostic;
                     }
                 }

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiDiagnosticTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiDiagnosticTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Threading;
 using System.Threading.Tasks;
 using System;
 using Microsoft.OpenApi.Models;
@@ -64,7 +65,7 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
             return null;
         }
 
-        public Task<Stream> LoadAsync(Uri uri)
+        public Task<Stream> LoadAsync(Uri uri, CancellationToken cancellationToken = default)
         {
             var path = new Uri(new("http://example.org/OpenApiReaderTests/Samples/OpenApiDiagnosticReportMerged/"), uri).AbsolutePath;
             path = path[1..]; // remove leading slash

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiWorkspaceTests/OpenApiWorkspaceStreamTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiWorkspaceTests/OpenApiWorkspaceStreamTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
@@ -80,7 +81,7 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiWorkspaceTests
             return null;
         }
 
-        public Task<Stream> LoadAsync(Uri uri)
+        public Task<Stream> LoadAsync(Uri uri, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<Stream>(null);
         }
@@ -93,7 +94,7 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiWorkspaceTests
             return null;
         }
 
-        public Task<Stream> LoadAsync(Uri uri)
+        public Task<Stream> LoadAsync(Uri uri, CancellationToken cancellationToken = default)
         {
             var path = new Uri(new("http://example.org/V3Tests/Samples/OpenApiWorkspace/"), uri).AbsolutePath;
             path = path[1..]; // remove leading slash

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -246,7 +246,7 @@ namespace Microsoft.OpenApi.Interfaces
     }
     public interface IStreamLoader
     {
-        System.Threading.Tasks.Task<System.IO.Stream> LoadAsync(System.Uri uri);
+        System.Threading.Tasks.Task<System.IO.Stream> LoadAsync(System.Uri uri, System.Threading.CancellationToken cancellationToken = default);
     }
 }
 namespace Microsoft.OpenApi
@@ -1554,7 +1554,7 @@ namespace Microsoft.OpenApi.Reader.Services
     public class DefaultStreamLoader : Microsoft.OpenApi.Interfaces.IStreamLoader
     {
         public DefaultStreamLoader(System.Uri baseUrl) { }
-        public System.Threading.Tasks.Task<System.IO.Stream> LoadAsync(System.Uri uri) { }
+        public System.Threading.Tasks.Task<System.IO.Stream> LoadAsync(System.Uri uri, System.Threading.CancellationToken cancellationToken = default) { }
     }
 }
 namespace Microsoft.OpenApi.Services


### PR DESCRIPTION
- **fix: adds a cancellation token argument to external document loading**
- **fix: a bug where external reference loading for local files would not work on linux**
- **chore: makes the fix specific to non-windows**
- **chore: updates public api surface**
