### PR TITLE
fix: refactor ToIdentifier() to normalize flaggable enums

### DIFF
--- a/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
@@ -72,6 +72,21 @@ namespace Microsoft.OpenApi.Extensions
             };
         }
 
+        /// <summary>
+        /// Converts a schema type's identifier into the enum equivalent
+        /// </summary>
+        /// <param name="identifier"></param>
+        /// <returns></returns>
+        public static JsonSchemaType ToJsonSchemaType(this string[] identifier)
+        {
+            JsonSchemaType type = 0;
+            foreach (var id in identifier)
+            {
+                type |= id.ToJsonSchemaType();
+            }
+            return type;
+        }
+
         private static readonly Dictionary<Type, Func<OpenApiSchema>> _simpleTypeToOpenApiSchema = new()
         {
             [typeof(bool)] = () => new() { Type = JsonSchemaType.Boolean },

--- a/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
@@ -59,8 +59,7 @@ namespace Microsoft.OpenApi.Extensions
         /// <returns></returns>
         internal static string ToFirstIdentifier(this JsonSchemaType schemaType)
         {
-            var identifier = schemaType.ToIdentifiers();
-            return identifier[0];
+            return schemaType.ToIdentifiersInternal().First();
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
@@ -38,15 +38,18 @@ namespace Microsoft.OpenApi.Extensions
         {
             return schemaType.ToIdentifiersInternal().ToArray();
         }
-        private static readonly Dictionary<JsonSchemaType, string> allSchemaTypes = [
-            { JsonSchemaType.Boolean, "boolean"},
+
+        private static readonly Dictionary<JsonSchemaType, string> allSchemaTypes = new()
+        {
+            { JsonSchemaType.Boolean, "boolean" },
             { JsonSchemaType.Integer, "integer" },
             { JsonSchemaType.Number, "number" },
             { JsonSchemaType.String, "string" },
             { JsonSchemaType.Object, "object" },
             { JsonSchemaType.Array, "array" },
-            { JsonSchemaType.Null, "null" },
-        ];
+            { JsonSchemaType.Null, "null" }
+        };
+
         private static IEnumerable<string> ToIdentifiersInternal(this JsonSchemaType schemaType)
         {
             return allSchemaTypes.Where(kvp => schemaType.HasFlag(kvp.Key)).Select(static kvp => kvp.Value);

--- a/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
@@ -73,7 +73,7 @@ namespace Microsoft.OpenApi.Extensions
             {
                 throw new OpenApiException($"Schema type {schemaType} must have exactly one identifier.");
             }
-            return schemaType.ToFirstIdentifier();
+            return schemaType.ToIdentifiersInternal().Single();
         }
 
 #nullable restore

--- a/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OpenApi.Extensions
         /// </summary>
         /// <param name="schemaType"></param>
         /// <returns></returns>
-        internal static string FirstIdentifier(this JsonSchemaType schemaType)
+        internal static string ToFirstIdentifier(this JsonSchemaType schemaType)
         {
             var identifier = schemaType.ToIdentifier();
             return identifier[0];

--- a/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
@@ -49,6 +49,17 @@ namespace Microsoft.OpenApi.Extensions
             return types.ToArray();
         }
 
+        /// <summary>
+        /// Returns the first identifier from a string array.
+        /// </summary>
+        /// <param name="schemaType"></param>
+        /// <returns></returns>
+        public static string FirstIdentifier(this JsonSchemaType schemaType)
+        {
+            var identifier = schemaType.ToIdentifier();
+            return identifier[0];
+        }
+
 #nullable restore
 
         /// <summary>
@@ -77,8 +88,13 @@ namespace Microsoft.OpenApi.Extensions
         /// </summary>
         /// <param name="identifier"></param>
         /// <returns></returns>
-        public static JsonSchemaType ToJsonSchemaType(this string[] identifier)
+        public static JsonSchemaType? ToJsonSchemaType(this string[] identifier)
         {
+            if (identifier == null)
+            {
+                return null;
+            }
+
             JsonSchemaType type = 0;
             foreach (var id in identifier)
             {
@@ -170,7 +186,7 @@ namespace Microsoft.OpenApi.Extensions
                 throw new ArgumentNullException(nameof(schema));
             }
             var isNullable = (schema.Type & JsonSchemaType.Null) == JsonSchemaType.Null;
-            var nonNullable = (schema.Type & ~JsonSchemaType.Null).ToIdentifier().FirstOrDefault();
+            var nonNullable = (schema.Type & ~JsonSchemaType.Null)?.FirstIdentifier();
 
             var type = (nonNullable, schema.Format?.ToLowerInvariant(), isNullable) switch
             {

--- a/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OpenApi.Extensions
         /// </summary>
         /// <param name="schemaType"></param>
         /// <returns></returns>
-        public static string FirstIdentifier(this JsonSchemaType schemaType)
+        internal static string FirstIdentifier(this JsonSchemaType schemaType)
         {
             var identifier = schemaType.ToIdentifier();
             return identifier[0];

--- a/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
@@ -72,10 +72,6 @@ namespace Microsoft.OpenApi.Extensions
         /// <returns></returns>
         public static string ToSingleIdentifier(this JsonSchemaType schemaType)
         {
-            if (schemaType.ToIdentifiers().Length != 1)
-            {
-                throw new OpenApiException($"Schema type {schemaType} must have exactly one identifier.");
-            }
             return schemaType.ToIdentifiersInternal().Single();
         }
 

--- a/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
@@ -36,17 +36,20 @@ namespace Microsoft.OpenApi.Extensions
         /// <returns></returns>
         public static string[] ToIdentifiers(this JsonSchemaType schemaType)
         {
-            var types = new List<string>();
-            
-            if (schemaType.HasFlag(JsonSchemaType.Boolean)) types.Add("boolean");
-            if (schemaType.HasFlag(JsonSchemaType.Integer)) types.Add("integer");
-            if (schemaType.HasFlag(JsonSchemaType.Number)) types.Add("number");
-            if (schemaType.HasFlag(JsonSchemaType.String)) types.Add("string");
-            if (schemaType.HasFlag(JsonSchemaType.Object)) types.Add("object");
-            if (schemaType.HasFlag(JsonSchemaType.Array)) types.Add("array");
-            if (schemaType.HasFlag(JsonSchemaType.Null)) types.Add("null");
-
-            return types.ToArray();
+            return schemaType.ToIdentifiersInternal().ToArray();
+        }
+        private static readonly Dictionary<JsonSchemaType, string> allSchemaTypes = [
+            { JsonSchemaType.Boolean, "boolean"},
+            { JsonSchemaType.Integer, "integer" },
+            { JsonSchemaType.Number, "number" },
+            { JsonSchemaType.String, "string" },
+            { JsonSchemaType.Object, "object" },
+            { JsonSchemaType.Array, "array" },
+            { JsonSchemaType.Null, "null" },
+        ];
+        private static IEnumerable<string> ToIdentifiersInternal(this JsonSchemaType schemaType)
+        {
+            return allSchemaTypes.Where(kvp => schemaType.HasFlag(kvp.Key)).Select(static kvp => kvp.Value);
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.OpenApi.Extensions
         /// </summary>
         /// <param name="schemaType"></param>
         /// <returns></returns>
-        public static string[] ToIdentifier(this JsonSchemaType schemaType)
+        public static string[] ToIdentifiers(this JsonSchemaType schemaType)
         {
             var types = new List<string>();
             

--- a/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
@@ -169,9 +169,8 @@ namespace Microsoft.OpenApi.Extensions
             {
                 throw new ArgumentNullException(nameof(schema));
             }
-            var typeIdentifier = schema.Type.ToIdentifier();
-            var isNullable = typeIdentifier.Contains("null");
-            var nonNullable = typeIdentifier.FirstOrDefault(t => t != "null");
+            var isNullable = (schema.Type & JsonSchemaType.Null) == JsonSchemaType.Null;
+            var nonNullable = (schema.Type & ~JsonSchemaType.Null).ToIdentifier().FirstOrDefault();
 
             var type = (nonNullable, schema.Format?.ToLowerInvariant(), isNullable) switch
             {

--- a/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiTypeMapper.cs
@@ -70,7 +70,7 @@ namespace Microsoft.OpenApi.Extensions
         /// </summary>
         /// <param name="schemaType"></param>
         /// <returns></returns>
-        public static string ToSingleIdentifier(this JsonSchemaType schemaType)
+        internal static string ToSingleIdentifier(this JsonSchemaType schemaType)
         {
             return schemaType.ToIdentifiersInternal().Single();
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -413,7 +413,7 @@ namespace Microsoft.OpenApi.Models
         internal void WriteAsItemsProperties(IOpenApiWriter writer)
         {
             // type
-            writer.WriteProperty(OpenApiConstants.Type, (Type & ~JsonSchemaType.Null)?.FirstIdentifier());
+            writer.WriteProperty(OpenApiConstants.Type, (Type & ~JsonSchemaType.Null)?.ToFirstIdentifier());
 
             // format
             WriteFormatProperty(writer);
@@ -651,14 +651,14 @@ namespace Microsoft.OpenApi.Models
                         break;
                     case OpenApiSpecVersion.OpenApi3_0 when isNullable && type.Value == JsonSchemaType.Null:
                         writer.WriteProperty(OpenApiConstants.Nullable, true);
-                        writer.WriteProperty(OpenApiConstants.Type, JsonSchemaType.Object.FirstIdentifier());
+                        writer.WriteProperty(OpenApiConstants.Type, JsonSchemaType.Object.ToFirstIdentifier());
                         break;
                     case OpenApiSpecVersion.OpenApi3_0 when isNullable && type.Value != JsonSchemaType.Null:
                         writer.WriteProperty(OpenApiConstants.Nullable, true);
-                        writer.WriteProperty(OpenApiConstants.Type, type.Value.FirstIdentifier());
+                        writer.WriteProperty(OpenApiConstants.Type, type.Value.ToFirstIdentifier());
                         break;
                     default:
-                        writer.WriteProperty(OpenApiConstants.Type, type.Value.FirstIdentifier());
+                        writer.WriteProperty(OpenApiConstants.Type, type.Value.ToFirstIdentifier());
                         break;
                 }
             }
@@ -676,7 +676,7 @@ namespace Microsoft.OpenApi.Models
                                 select flag).ToList();
                     writer.WriteOptionalCollection(OpenApiConstants.Type, list, (w, s) =>
                     {
-                        foreach(var item in s.ToIdentifier())
+                        foreach(var item in s.ToIdentifiers())
                         {
                             w.WriteValue(item);
                         }
@@ -703,7 +703,7 @@ namespace Microsoft.OpenApi.Models
             var temporaryType = type | JsonSchemaType.Null;
             var list = (from JsonSchemaType flag in jsonSchemaTypeValues// Check if the flag is set in 'type' using a bitwise AND operation
                         where temporaryType.HasFlag(flag)
-                        select flag.FirstIdentifier()).ToList();
+                        select flag.ToFirstIdentifier()).ToList();
             if (list.Count > 1)
             {
                 writer.WriteOptionalCollection(OpenApiConstants.Type, list, (w, s) => w.WriteValue(s));
@@ -740,7 +740,7 @@ namespace Microsoft.OpenApi.Models
                     if (schemaType.HasFlag(flag) && flag != JsonSchemaType.Null)
                     {
                         // Write the non-null flag value to the writer
-                        writer.WriteProperty(OpenApiConstants.Type, flag.FirstIdentifier());
+                        writer.WriteProperty(OpenApiConstants.Type, flag.ToFirstIdentifier());
                     }
                 }
                 writer.WriteProperty(nullableProp, true);
@@ -753,7 +753,7 @@ namespace Microsoft.OpenApi.Models
                 }
                 else
                 {
-                    writer.WriteProperty(OpenApiConstants.Type, schemaType.FirstIdentifier());
+                    writer.WriteProperty(OpenApiConstants.Type, schemaType.ToFirstIdentifier());
                 }
             }
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -413,7 +413,7 @@ namespace Microsoft.OpenApi.Models
         internal void WriteAsItemsProperties(IOpenApiWriter writer)
         {
             // type
-            writer.WriteProperty(OpenApiConstants.Type, (Type & ~JsonSchemaType.Null).ToIdentifier()?.FirstOrDefault());
+            writer.WriteProperty(OpenApiConstants.Type, (Type & ~JsonSchemaType.Null)?.FirstIdentifier());
 
             // format
             WriteFormatProperty(writer);
@@ -651,14 +651,14 @@ namespace Microsoft.OpenApi.Models
                         break;
                     case OpenApiSpecVersion.OpenApi3_0 when isNullable && type.Value == JsonSchemaType.Null:
                         writer.WriteProperty(OpenApiConstants.Nullable, true);
-                        writer.WriteProperty(OpenApiConstants.Type, JsonSchemaType.Object.ToIdentifier().FirstOrDefault());
+                        writer.WriteProperty(OpenApiConstants.Type, JsonSchemaType.Object.FirstIdentifier());
                         break;
                     case OpenApiSpecVersion.OpenApi3_0 when isNullable && type.Value != JsonSchemaType.Null:
                         writer.WriteProperty(OpenApiConstants.Nullable, true);
-                        writer.WriteProperty(OpenApiConstants.Type, type.Value.ToIdentifier().FirstOrDefault());
+                        writer.WriteProperty(OpenApiConstants.Type, type.Value.FirstIdentifier());
                         break;
                     default:
-                        writer.WriteProperty(OpenApiConstants.Type, type.Value.ToIdentifier().FirstOrDefault());
+                        writer.WriteProperty(OpenApiConstants.Type, type.Value.FirstIdentifier());
                         break;
                 }
             }
@@ -703,7 +703,7 @@ namespace Microsoft.OpenApi.Models
             var temporaryType = type | JsonSchemaType.Null;
             var list = (from JsonSchemaType flag in jsonSchemaTypeValues// Check if the flag is set in 'type' using a bitwise AND operation
                         where temporaryType.HasFlag(flag)
-                        select flag.ToIdentifier().FirstOrDefault()).ToList();
+                        select flag.FirstIdentifier()).ToList();
             if (list.Count > 1)
             {
                 writer.WriteOptionalCollection(OpenApiConstants.Type, list, (w, s) => w.WriteValue(s));
@@ -740,7 +740,7 @@ namespace Microsoft.OpenApi.Models
                     if (schemaType.HasFlag(flag) && flag != JsonSchemaType.Null)
                     {
                         // Write the non-null flag value to the writer
-                        writer.WriteProperty(OpenApiConstants.Type, flag.ToIdentifier().FirstOrDefault());
+                        writer.WriteProperty(OpenApiConstants.Type, flag.FirstIdentifier());
                     }
                 }
                 writer.WriteProperty(nullableProp, true);
@@ -753,7 +753,7 @@ namespace Microsoft.OpenApi.Models
                 }
                 else
                 {
-                    writer.WriteProperty(OpenApiConstants.Type, schemaType.ToIdentifier().FirstOrDefault());
+                    writer.WriteProperty(OpenApiConstants.Type, schemaType.FirstIdentifier());
                 }
             }
         }

--- a/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
@@ -56,7 +56,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             // convert value to JsonElement and access the ValueKind property to determine the type.
             var valueKind = value.GetValueKind();
 
-            var type = schema.Type.ToIdentifier().FirstOrDefault(x => x is not null);
+            var type = (schema.Type & ~JsonSchemaType.Null)?.FirstIdentifier();
             var format = schema.Format;
 
             // Before checking the type, check first if the schema allows null.

--- a/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.OpenApi.Extensions;
@@ -55,7 +56,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             // convert value to JsonElement and access the ValueKind property to determine the type.
             var valueKind = value.GetValueKind();
 
-            var type = schema.Type.ToIdentifier();
+            var type = schema.Type.ToIdentifier().FirstOrDefault(x => x is not null);
             var format = schema.Format;
 
             // Before checking the type, check first if the schema allows null.

--- a/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/RuleHelpers.cs
@@ -56,7 +56,7 @@ namespace Microsoft.OpenApi.Validations.Rules
             // convert value to JsonElement and access the ValueKind property to determine the type.
             var valueKind = value.GetValueKind();
 
-            var type = (schema.Type & ~JsonSchemaType.Null)?.FirstIdentifier();
+            var type = (schema.Type & ~JsonSchemaType.Null)?.ToFirstIdentifier();
             var format = schema.Format;
 
             // Before checking the type, check first if the schema allows null.

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiSchemaTests.cs
@@ -15,6 +15,7 @@ using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Tests;
 using Microsoft.OpenApi.Writers;
 using Xunit;
+using Microsoft.OpenApi.Exceptions;
 
 namespace Microsoft.OpenApi.Readers.Tests.V31Tests
 {
@@ -532,7 +533,7 @@ description: Schema for a person object
                 Type = type
             };
 
-            var actual = schema.Type.ToIdentifier();
+            var actual = schema.Type.ToIdentifiers();
             Assert.Equal(expected, actual);
         }
 
@@ -551,6 +552,16 @@ description: Schema for a person object
         {
             var actual = "integer".ToJsonSchemaType();
             Assert.Equal(JsonSchemaType.Integer, actual);
+        }
+
+        [Fact]
+        public void ReturnSingleIdentifierWorks()
+        {
+            var type = JsonSchemaType.Integer;
+            var types = JsonSchemaType.Integer | JsonSchemaType.Null;
+
+            Assert.Equal("integer", type.ToSingleIdentifier());
+            Assert.Throws<OpenApiException>(() => types.ToSingleIdentifier());
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiSchemaTests.cs
@@ -16,6 +16,7 @@ using Microsoft.OpenApi.Tests;
 using Microsoft.OpenApi.Writers;
 using Xunit;
 using Microsoft.OpenApi.Exceptions;
+using System;
 
 namespace Microsoft.OpenApi.Readers.Tests.V31Tests
 {
@@ -561,7 +562,7 @@ description: Schema for a person object
             var types = JsonSchemaType.Integer | JsonSchemaType.Null;
 
             Assert.Equal("integer", type.ToSingleIdentifier());
-            Assert.Throws<OpenApiException>(() => types.ToSingleIdentifier());
+            Assert.Throws<InvalidOperationException>(() => types.ToSingleIdentifier());
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -193,7 +193,7 @@ namespace Microsoft.OpenApi.Extensions
         public static string[] ToIdentifier(this Microsoft.OpenApi.Models.JsonSchemaType schemaType) { }
         public static string[]? ToIdentifier(this Microsoft.OpenApi.Models.JsonSchemaType? schemaType) { }
         public static Microsoft.OpenApi.Models.JsonSchemaType ToJsonSchemaType(this string identifier) { }
-        public static Microsoft.OpenApi.Models.JsonSchemaType ToJsonSchemaType(this string[] identifier) { }
+        public static Microsoft.OpenApi.Models.JsonSchemaType? ToJsonSchemaType(this string[] identifier) { }
     }
 }
 namespace Microsoft.OpenApi.Interfaces

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -194,7 +194,6 @@ namespace Microsoft.OpenApi.Extensions
         public static string[]? ToIdentifiers(this Microsoft.OpenApi.Models.JsonSchemaType? schemaType) { }
         public static Microsoft.OpenApi.Models.JsonSchemaType ToJsonSchemaType(this string identifier) { }
         public static Microsoft.OpenApi.Models.JsonSchemaType? ToJsonSchemaType(this string[] identifier) { }
-        public static string ToSingleIdentifier(this Microsoft.OpenApi.Models.JsonSchemaType schemaType) { }
     }
 }
 namespace Microsoft.OpenApi.Interfaces

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -190,10 +190,11 @@ namespace Microsoft.OpenApi.Extensions
     {
         public static System.Type MapOpenApiPrimitiveTypeToSimpleType(this Microsoft.OpenApi.Models.OpenApiSchema schema) { }
         public static Microsoft.OpenApi.Models.OpenApiSchema MapTypeToOpenApiPrimitiveType(this System.Type type) { }
-        public static string[] ToIdentifier(this Microsoft.OpenApi.Models.JsonSchemaType schemaType) { }
-        public static string[]? ToIdentifier(this Microsoft.OpenApi.Models.JsonSchemaType? schemaType) { }
+        public static string[] ToIdentifiers(this Microsoft.OpenApi.Models.JsonSchemaType schemaType) { }
+        public static string[]? ToIdentifiers(this Microsoft.OpenApi.Models.JsonSchemaType? schemaType) { }
         public static Microsoft.OpenApi.Models.JsonSchemaType ToJsonSchemaType(this string identifier) { }
         public static Microsoft.OpenApi.Models.JsonSchemaType? ToJsonSchemaType(this string[] identifier) { }
+        public static string ToSingleIdentifier(this Microsoft.OpenApi.Models.JsonSchemaType schemaType) { }
     }
 }
 namespace Microsoft.OpenApi.Interfaces

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -190,9 +190,10 @@ namespace Microsoft.OpenApi.Extensions
     {
         public static System.Type MapOpenApiPrimitiveTypeToSimpleType(this Microsoft.OpenApi.Models.OpenApiSchema schema) { }
         public static Microsoft.OpenApi.Models.OpenApiSchema MapTypeToOpenApiPrimitiveType(this System.Type type) { }
-        public static string? ToIdentifier(this Microsoft.OpenApi.Models.JsonSchemaType schemaType) { }
-        public static string? ToIdentifier(this Microsoft.OpenApi.Models.JsonSchemaType? schemaType) { }
+        public static string[] ToIdentifier(this Microsoft.OpenApi.Models.JsonSchemaType schemaType) { }
+        public static string[]? ToIdentifier(this Microsoft.OpenApi.Models.JsonSchemaType? schemaType) { }
         public static Microsoft.OpenApi.Models.JsonSchemaType ToJsonSchemaType(this string identifier) { }
+        public static Microsoft.OpenApi.Models.JsonSchemaType ToJsonSchemaType(this string[] identifier) { }
     }
 }
 namespace Microsoft.OpenApi.Interfaces


### PR DESCRIPTION
- Adds support for normalizing flaggable enums by returning an array of strings
- Supports casting of type arrays to the flaggable enum type
- Adds tests to validate

Fixes #2078
Fixes #1924