### PR TITLE
Rename `OpenApiDocument.SecurityRequirements` as `Security`. Fixes #2155

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -73,7 +73,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// A declaration of which security mechanisms can be used across the API.
         /// </summary>
-        public IList<OpenApiSecurityRequirement>? SecurityRequirements { get; set; } =
+        public IList<OpenApiSecurityRequirement>? Security { get; set; } =
             new List<OpenApiSecurityRequirement>();
 
         private HashSet<OpenApiTag>? _tags;
@@ -139,7 +139,7 @@ namespace Microsoft.OpenApi.Models
             Paths = document?.Paths != null ? new(document?.Paths) : new OpenApiPaths();
             Webhooks = document?.Webhooks != null ? new Dictionary<string, IOpenApiPathItem>(document.Webhooks) : null;
             Components = document?.Components != null ? new(document?.Components) : null;
-            SecurityRequirements = document?.SecurityRequirements != null ? new List<OpenApiSecurityRequirement>(document.SecurityRequirements) : null;
+            Security = document?.Security != null ? new List<OpenApiSecurityRequirement>(document.Security) : null;
             Tags = document?.Tags != null ? new HashSet<OpenApiTag>(document.Tags, OpenApiTagComparer.Instance) : null;
             ExternalDocs = document?.ExternalDocs != null ? new(document?.ExternalDocs) : null;
             Extensions = document?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(document.Extensions) : null;
@@ -223,7 +223,7 @@ namespace Microsoft.OpenApi.Models
             // security
             writer.WriteOptionalCollection(
                 OpenApiConstants.Security,
-                SecurityRequirements,
+                Security,
                 callback);
 
             // tags
@@ -361,7 +361,7 @@ namespace Microsoft.OpenApi.Models
                 // security
                 writer.WriteOptionalCollection(
                     OpenApiConstants.Security,
-                    SecurityRequirements,
+                    Security,
                     (w, s) => s.SerializeAsV2(w));
 
                 // tags

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiDocumentDeserializer.cs
@@ -103,7 +103,7 @@ namespace Microsoft.OpenApi.Reader.V2
                     o.Components.SecuritySchemes = n.CreateMap(LoadSecurityScheme, o);
                 }
             },
-            {"security", (o, n, _) => o.SecurityRequirements = n.CreateList(LoadSecurityRequirement, o)},
+            {"security", (o, n, _) => o.Security = n.CreateList(LoadSecurityRequirement, o)},
             {"tags", (o, n, _) => { if (n.CreateList(LoadTag, o) is {Count:> 0} tags) {o.Tags = new HashSet<OpenApiTag>(tags, OpenApiTagComparer.Instance); } } },
             {"externalDocs", (o, n, _) => o.ExternalDocs = LoadExternalDocs(n, o)}
         };

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiDocumentDeserializer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.OpenApi.Reader.V3
             {"components", (o, n, _) => o.Components = LoadComponents(n, o)},
             {"tags", (o, n, _) => { if (n.CreateList(LoadTag, o) is {Count:> 0} tags) {o.Tags = new HashSet<OpenApiTag>(tags, OpenApiTagComparer.Instance); } } },
             {"externalDocs", (o, n, _) => o.ExternalDocs = LoadExternalDocs(n, o)},
-            {"security", (o, n, _) => o.SecurityRequirements = n.CreateList(LoadSecurityRequirement, o)}
+            {"security", (o, n, _) => o.Security = n.CreateList(LoadSecurityRequirement, o)}
         };
 
         private static readonly PatternFieldMap<OpenApiDocument> _openApiPatternFields = new PatternFieldMap<OpenApiDocument>

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiDocumentDeserializer.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OpenApi.Reader.V31
             {"components", (o, n, _) => o.Components = LoadComponents(n, o)},
             {"tags", (o, n, _) => { if (n.CreateList(LoadTag, o) is {Count:> 0} tags) {o.Tags = new HashSet<OpenApiTag>(tags, OpenApiTagComparer.Instance); } } },
             {"externalDocs", (o, n, _) => o.ExternalDocs = LoadExternalDocs(n, o)},
-            {"security", (o, n, _) => o.SecurityRequirements = n.CreateList(LoadSecurityRequirement, o)}
+            {"security", (o, n, _) => o.Security = n.CreateList(LoadSecurityRequirement, o)}
         };
 
         private static readonly PatternFieldMap<OpenApiDocument> _openApiPatternFields = new()

--- a/src/Microsoft.OpenApi/Services/OpenApiFilterService.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiFilterService.cs
@@ -80,7 +80,7 @@ namespace Microsoft.OpenApi.Services
                 },
 
                 Components = components,
-                SecurityRequirements = source.SecurityRequirements,
+                Security = source.Security,
                 Servers = source.Servers
             };
 

--- a/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.Services
             Walk(OpenApiConstants.Paths, () => Walk(doc.Paths));
             Walk(OpenApiConstants.Webhooks, () => Walk(doc.Webhooks));
             Walk(OpenApiConstants.Components, () => Walk(doc.Components));
-            Walk(OpenApiConstants.Security, () => Walk(doc.SecurityRequirements));
+            Walk(OpenApiConstants.Security, () => Walk(doc.Security));
             Walk(OpenApiConstants.ExternalDocs, () => Walk(doc.ExternalDocs));
             Walk(OpenApiConstants.Tags, () => Walk(doc.Tags));
             Walk(doc as IOpenApiExtensible);

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -1008,7 +1008,7 @@ paths: {}
                             Description = "tagDescription2"
                         }
                     },
-                SecurityRequirements = new List<OpenApiSecurityRequirement>
+                Security = new List<OpenApiSecurityRequirement>
                     {
                         new OpenApiSecurityRequirement
                         {
@@ -1052,7 +1052,7 @@ paths: {}
         {
             var result = await OpenApiDocument.LoadAsync(Path.Combine(SampleFolderPath, "securedApi.yaml"), SettingsFixture.ReaderSettings);
 
-            var securityRequirement = result.Document.SecurityRequirements[0];
+            var securityRequirement = result.Document.Security[0];
 
             Assert.Equivalent(result.Document.Components.SecuritySchemes.First().Value, securityRequirement.Keys.First());
         }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -720,7 +720,7 @@ namespace Microsoft.OpenApi.Models
         public Microsoft.OpenApi.Models.OpenApiInfo Info { get; set; }
         public string? JsonSchemaDialect { get; set; }
         public Microsoft.OpenApi.Models.OpenApiPaths Paths { get; set; }
-        public System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiSecurityRequirement>? SecurityRequirements { get; set; }
+        public System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiSecurityRequirement>? Security { get; set; }
         public System.Collections.Generic.IList<Microsoft.OpenApi.Models.OpenApiServer>? Servers { get; set; }
         public System.Collections.Generic.ISet<Microsoft.OpenApi.Models.OpenApiTag>? Tags { get; set; }
         public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>? Webhooks { get; set; }


### PR DESCRIPTION
fixes #2155