### PR TITLE
fix: fixes serialization of openApidocs with operation tags with settings to inline references

### DIFF
--- a/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+++ b/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
@@ -33,7 +33,7 @@
         </PackageReference>
 
         <PackageReference Include="SharpYaml" Version="2.1.1" />
-        <PackageReference Include="System.Text.Json" Version="[8.0,)" />
+        <PackageReference Include="System.Text.Json" Version="[8.0.5,)" />
         <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hh2w-p6rv-4g7w" />
         <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
     </ItemGroup>

--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -23,7 +23,7 @@
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     </PropertyGroup>
     <ItemGroup>        
-        <PackageReference Include="System.Text.Json" Version="[8.0,)" />
+        <PackageReference Include="System.Text.Json" Version="[8.0.5,)" />
         <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hh2w-p6rv-4g7w" />
         <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
     </ItemGroup>

--- a/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
+++ b/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
@@ -63,7 +63,8 @@ public abstract class BaseOpenApiReferenceHolder<T, V> : IOpenApiReferenceHolder
     /// <inheritdoc/>
     public virtual void SerializeAsV3(IOpenApiWriter writer)
     {
-        if (!writer.GetSettings().ShouldInlineReference(Reference))
+        if (!writer.GetSettings().ShouldInlineReference(Reference) 
+            || Reference.Type == ReferenceType.Tag) // tags are held as references need to drop in.
         {
             Reference.SerializeAsV3(writer);
         }

--- a/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiFilterServiceTests.cs
+++ b/test/Microsoft.OpenApi.Hidi.Tests/Services/OpenApiFilterServiceTests.cs
@@ -1,13 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Globalization;
 using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.Interfaces;
 using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Services;
 using Microsoft.OpenApi.Tests.UtilityFiles;
+using Microsoft.OpenApi.Writers;
 using Moq;
 using Xunit;
 
@@ -235,7 +238,14 @@ namespace Microsoft.OpenApi.Hidi.Tests
             using var stream = File.OpenRead(filePath);
             var settings = new OpenApiReaderSettings();
             settings.AddYamlReader();
-            var doc = (await OpenApiDocument.LoadAsync(stream, "yaml", settings)).Document;            
+            var doc = (await OpenApiDocument.LoadAsync(stream, "yaml", settings)).Document;
+            
+            // validated the tags are read as references
+            var openApiOperationTags = doc.Paths["/items"].Operations[OperationType.Get].Tags?.ToArray();
+            Assert.NotNull(openApiOperationTags);
+            Assert.Single(openApiOperationTags);
+            Assert.True(openApiOperationTags[0].UnresolvedReference);
+            
             var predicate = OpenApiFilterService.CreatePredicate(operationIds: operationIds);
             var subsetOpenApiDocument = OpenApiFilterService.CreateFilteredDocument(doc, predicate);
 
@@ -255,6 +265,26 @@ namespace Microsoft.OpenApi.Hidi.Tests
             Assert.Single(targetHeaders);
             Assert.NotNull(targetExamples);
             Assert.Single(targetExamples);
+            // validated the tags of the trimmed document are read as references
+            var trimmedOpenApiOperationTags = subsetOpenApiDocument.Paths["/items"].Operations[OperationType.Get].Tags?.ToArray();
+            Assert.NotNull(trimmedOpenApiOperationTags);
+            Assert.Single(trimmedOpenApiOperationTags);
+            Assert.True(trimmedOpenApiOperationTags[0].UnresolvedReference);
+            
+            // Finally try to write the trimmed document as v3 document
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiJsonWriter(outputStringWriter)
+            {
+                Settings = new OpenApiWriterSettings()
+                {
+                    InlineExternalReferences = true,
+                    InlineLocalReferences = true
+                }
+            };
+            subsetOpenApiDocument.SerializeAsV3(writer);
+            await writer.FlushAsync();
+            var result = outputStringWriter.ToString();
+            Assert.NotEmpty(result);
         }
 
         [Theory]

--- a/test/Microsoft.OpenApi.Hidi.Tests/UtilityFiles/docWithReusableHeadersAndExamples.yaml
+++ b/test/Microsoft.OpenApi.Hidi.Tests/UtilityFiles/docWithReusableHeadersAndExamples.yaml
@@ -7,6 +7,8 @@ servers:
 paths:
   /items:
     get:
+      tags:
+        - list.items
       operationId: getItems
       summary: Get a list of items
       responses:


### PR DESCRIPTION
fix: fixes serialization of openApidocs with operation tags with settings to inline references

Fixes #https://github.com/microsoft/OpenAPI.NET/issues/2233