### PR TITLE
Fix: relative references in subdirectory documents are not loading #1674

### DIFF
--- a/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
+++ b/src/Microsoft.OpenApi.Readers/OpenApiYamlReader.cs
@@ -26,25 +26,27 @@ namespace Microsoft.OpenApi.Readers
 
         /// <inheritdoc/>
         public async Task<ReadResult> ReadAsync(Stream input,
+                                                Uri location,
                                                 OpenApiReaderSettings settings,
                                                 CancellationToken cancellationToken = default)
         {
             if (input is null) throw new ArgumentNullException(nameof(input));
             if (input is MemoryStream memoryStream)
             {
-                return Read(memoryStream, settings);
+                return Read(memoryStream, location, settings);
             } 
             else 
             {
                 using var preparedStream = new MemoryStream();
                 await input.CopyToAsync(preparedStream, copyBufferSize, cancellationToken).ConfigureAwait(false);
                 preparedStream.Position = 0;
-                return Read(preparedStream, settings);
+                return Read(preparedStream, location, settings);
             }
         }
 
         /// <inheritdoc/>
         public ReadResult Read(MemoryStream input,
+                               Uri location,
                                OpenApiReaderSettings settings)
         {
             if (input is null) throw new ArgumentNullException(nameof(input));
@@ -74,13 +76,13 @@ namespace Microsoft.OpenApi.Readers
                 };
             }
 
-            return Read(jsonNode, settings);
+            return Read(jsonNode, location, settings);
         }
 
         /// <inheritdoc/>
-        public static ReadResult Read(JsonNode jsonNode, OpenApiReaderSettings settings)
+        public static ReadResult Read(JsonNode jsonNode, Uri location, OpenApiReaderSettings settings)
         {
-            return _jsonReader.Read(jsonNode, settings);
+            return _jsonReader.Read(jsonNode, location, settings);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiReader.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiReader.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,18 +19,20 @@ namespace Microsoft.OpenApi.Interfaces
         /// Async method to reads the stream and parse it into an Open API document.
         /// </summary>
         /// <param name="input">The stream input.</param>
+        /// <param name="location">Location of where the document that is getting loaded is saved</param>
         /// <param name="settings"> The OpenApi reader settings.</param>
         /// <param name="cancellationToken">Propagates notification that an operation should be cancelled.</param>
         /// <returns></returns>
-        Task<ReadResult> ReadAsync(Stream input, OpenApiReaderSettings settings, CancellationToken cancellationToken = default);
+        Task<ReadResult> ReadAsync(Stream input, Uri location, OpenApiReaderSettings settings, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Provides a synchronous method to read the input memory stream and parse it into an Open API document.
         /// </summary>
         /// <param name="input"></param>
+        /// <param name="location">Location of where the document that is getting loaded is saved</param>
         /// <param name="settings"></param>
         /// <returns></returns>
-        ReadResult Read(MemoryStream input, OpenApiReaderSettings settings);
+        ReadResult Read(MemoryStream input, Uri location, OpenApiReaderSettings settings);
 
         /// <summary>
         /// Reads the MemoryStream and parses the fragment of an OpenAPI description into an Open API Element.

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiVersionService.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiVersionService.cs
@@ -1,6 +1,7 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Reader.ParseNodes;
 
@@ -34,8 +35,9 @@ namespace Microsoft.OpenApi.Interfaces
         /// Converts a generic RootNode instance into a strongly typed OpenApiDocument
         /// </summary>
         /// <param name="rootNode">RootNode containing the information to be converted into an OpenAPI Document</param>
+        /// <param name="location">Location of where the document that is getting loaded is saved</param>
         /// <returns>Instance of OpenApiDocument populated with data from rootNode</returns>
-        OpenApiDocument LoadDocument(RootNode rootNode);
+        OpenApiDocument LoadDocument(RootNode rootNode, Uri location);
 
         /// <summary>
         /// Gets the description and summary scalar values in a reference object for V3.1 support

--- a/src/Microsoft.OpenApi/Interfaces/IStreamLoader.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IStreamLoader.cs
@@ -17,9 +17,11 @@ namespace Microsoft.OpenApi.Interfaces
         /// <summary>
         /// Use Uri to locate data and convert into an input object.
         /// </summary>
+        /// <param name="baseUrl">Base URL of parent to which a relative reference could be loaded. 
+        /// If the <paramref name="uri"/> is an absolute parameter the value of this parameter will be ignored</param>
         /// <param name="uri">Identifier of some source of an OpenAPI Description</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>A data object that can be processed by a reader to generate an <see cref="OpenApiDocument"/></returns>
-        Task<Stream> LoadAsync(Uri uri, CancellationToken cancellationToken = default);
+        Task<Stream> LoadAsync(Uri baseUrl, Uri uri, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -112,9 +112,9 @@ namespace Microsoft.OpenApi.Models
         public IDictionary<string, object>? Metadata { get; set; }
 
         /// <summary>
-        /// Implements IBaseDocument
+        /// Absolute location of the document or a generated placeholder if location is not given
         /// </summary>
-        public Uri BaseUri { get; }
+        public Uri BaseUri { get; internal set; }
 
         /// <summary>
         /// Parameter-less constructor
@@ -533,14 +533,15 @@ namespace Microsoft.OpenApi.Models
             }
             else
             {
-                string relativePath = OpenApiConstants.ComponentsSegment + reference.Type.GetDisplayName() + "/" + reference.Id;
+                string relativePath = $"#{OpenApiConstants.ComponentsSegment}{reference.Type.GetDisplayName()}/{reference.Id}";
+                Uri? externalResourceUri = useExternal ? Workspace?.GetDocumentId(reference.ExternalResource) : null;
 
-                uriLocation = useExternal
-                    ? Workspace?.GetDocumentId(reference.ExternalResource)?.OriginalString + relativePath
+                uriLocation = useExternal && externalResourceUri is not null
+                    ? externalResourceUri.AbsoluteUri + relativePath
                     : BaseUri + relativePath;
             }
 
-            return Workspace?.ResolveReference<IOpenApiReferenceable>(uriLocation);
+            return Workspace?.ResolveReference<IOpenApiReferenceable>(new Uri(uriLocation).AbsoluteUri);
         }
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
@@ -25,9 +25,11 @@ namespace Microsoft.OpenApi.Reader
         /// Reads the memory stream input and parses it into an Open API document.
         /// </summary>
         /// <param name="input">Memory stream containing OpenAPI description to parse.</param>
+        /// <param name="location">Location of where the document that is getting loaded is saved</param>
         /// <param name="settings">The Reader settings to be used during parsing.</param>
         /// <returns></returns>
         public ReadResult Read(MemoryStream input,
+                               Uri location,
                                OpenApiReaderSettings settings)
         {
             if (input is null) throw new ArgumentNullException(nameof(input));
@@ -52,16 +54,18 @@ namespace Microsoft.OpenApi.Reader
                 };
             }
 
-            return Read(jsonNode, settings);
+            return Read(jsonNode, location, settings);
         }
 
         /// <summary>
         /// Parses the JsonNode input into an Open API document.
         /// </summary>
         /// <param name="jsonNode">The JsonNode input.</param>
+        /// <param name="location">Location of where the document that is getting loaded is saved</param>
         /// <param name="settings">The Reader settings to be used during parsing.</param>
         /// <returns></returns>
         public ReadResult Read(JsonNode jsonNode,
+                               Uri location,
                                OpenApiReaderSettings settings)
         {
             if (jsonNode is null) throw new ArgumentNullException(nameof(jsonNode));
@@ -79,7 +83,7 @@ namespace Microsoft.OpenApi.Reader
             try
             {
                 // Parse the OpenAPI Document
-                document = context.Parse(jsonNode);
+                document = context.Parse(jsonNode, location);
                 document.SetReferenceHostDocument();
             }
             catch (OpenApiException ex)
@@ -112,10 +116,12 @@ namespace Microsoft.OpenApi.Reader
         /// Reads the stream input asynchronously and parses it into an Open API document.
         /// </summary>
         /// <param name="input">Memory stream containing OpenAPI description to parse.</param>
+        /// <param name="location">Location of where the document that is getting loaded is saved</param>
         /// <param name="settings">The Reader settings to be used during parsing.</param>
         /// <param name="cancellationToken">Propagates notifications that operations should be cancelled.</param>
         /// <returns></returns>
         public async Task<ReadResult> ReadAsync(Stream input,
+                                                Uri location,
                                                 OpenApiReaderSettings settings,
                                                 CancellationToken cancellationToken = default)
         {
@@ -140,7 +146,7 @@ namespace Microsoft.OpenApi.Reader
                 };
             }
 
-            return Read(jsonNode, settings);
+            return Read(jsonNode, location, settings);
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi/Reader/ParsingContext.cs
+++ b/src/Microsoft.OpenApi/Reader/ParsingContext.cs
@@ -62,8 +62,9 @@ namespace Microsoft.OpenApi.Reader
         /// Initiates the parsing process.  Not thread safe and should only be called once on a parsing context
         /// </summary>
         /// <param name="jsonNode">Set of Json nodes to parse.</param>
+        /// <param name="location">Location of where the document that is getting loaded is saved</param>
         /// <returns>An OpenApiDocument populated based on the passed yamlDocument </returns>
-        public OpenApiDocument Parse(JsonNode jsonNode)
+        public OpenApiDocument Parse(JsonNode jsonNode, Uri location)
         {
             RootNode = new RootNode(this, jsonNode);
 
@@ -75,20 +76,20 @@ namespace Microsoft.OpenApi.Reader
             {
                 case string version when version.is2_0():
                     VersionService = new OpenApiV2VersionService(Diagnostic);
-                    doc = VersionService.LoadDocument(RootNode);
+                    doc = VersionService.LoadDocument(RootNode, location);
                     this.Diagnostic.SpecificationVersion = OpenApiSpecVersion.OpenApi2_0;
                     ValidateRequiredFields(doc, version);
                     break;
 
                 case string version when version.is3_0():
                     VersionService = new OpenApiV3VersionService(Diagnostic);
-                    doc = VersionService.LoadDocument(RootNode);
+                    doc = VersionService.LoadDocument(RootNode, location);
                     this.Diagnostic.SpecificationVersion = version.is3_1() ? OpenApiSpecVersion.OpenApi3_1 : OpenApiSpecVersion.OpenApi3_0;
                     ValidateRequiredFields(doc, version);
                     break;
                 case string version when version.is3_1():
                     VersionService = new OpenApiV31VersionService(Diagnostic);
-                    doc = VersionService.LoadDocument(RootNode);
+                    doc = VersionService.LoadDocument(RootNode, location);
                     this.Diagnostic.SpecificationVersion = OpenApiSpecVersion.OpenApi3_1;
                     ValidateRequiredFields(doc, version);
                     break;

--- a/src/Microsoft.OpenApi/Reader/Services/DefaultStreamLoader.cs
+++ b/src/Microsoft.OpenApi/Reader/Services/DefaultStreamLoader.cs
@@ -17,22 +17,19 @@ namespace Microsoft.OpenApi.Reader.Services
     /// </summary>
     public class DefaultStreamLoader : IStreamLoader
     {
-        private readonly Uri baseUrl;
         private readonly HttpClient _httpClient;
 
         /// <summary>
         /// The default stream loader
         /// </summary>
-        /// <param name="baseUrl"></param>
         /// <param name="httpClient">The HttpClient to use to retrieve documents when needed</param>
-        public DefaultStreamLoader(Uri baseUrl, HttpClient httpClient)
+        public DefaultStreamLoader(HttpClient httpClient)
         {
-            this.baseUrl = baseUrl;
             _httpClient = Utils.CheckArgumentNull(httpClient);
         }
 
         /// <inheritdoc/>
-        public async Task<Stream> LoadAsync(Uri uri, CancellationToken cancellationToken = default)
+        public async Task<Stream> LoadAsync(Uri baseUrl, Uri uri, CancellationToken cancellationToken = default)
         {
             var absoluteUri = (baseUrl.AbsoluteUri.Equals(OpenApiConstants.BaseRegistryUri), baseUrl.IsAbsoluteUri, uri.IsAbsoluteUri) switch
             {

--- a/src/Microsoft.OpenApi/Reader/Services/OpenApiWorkspaceLoader.cs
+++ b/src/Microsoft.OpenApi/Reader/Services/OpenApiWorkspaceLoader.cs
@@ -45,7 +45,8 @@ namespace Microsoft.OpenApi.Reader.Services
                 // If not already in workspace, load it and process references
                 if (!_workspace.Contains(item.ExternalResource))
                 {
-                    var input = await _loader.LoadAsync(new(item.ExternalResource, UriKind.RelativeOrAbsolute), cancellationToken).ConfigureAwait(false);
+                    var uri = new Uri(item.ExternalResource, UriKind.RelativeOrAbsolute);
+                    var input = await _loader.LoadAsync(item.HostDocument.BaseUri, uri, cancellationToken).ConfigureAwait(false);
                     var result = await OpenApiDocument.LoadAsync(input, format, _readerSettings, cancellationToken).ConfigureAwait(false);
                     // Merge diagnostics
                     if (result.Diagnostic != null)

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiDocumentDeserializer.cs
@@ -221,9 +221,12 @@ namespace Microsoft.OpenApi.Reader.V2
             return uriBuilder.ToString();
         }
 
-        public static OpenApiDocument LoadOpenApi(RootNode rootNode)
+        public static OpenApiDocument LoadOpenApi(RootNode rootNode, Uri location)
         {
-            var openApiDoc = new OpenApiDocument();
+            var openApiDoc = new OpenApiDocument
+            {
+                BaseUri = location
+            };
 
             var openApiNode = rootNode.GetMap();
 

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiV2VersionService.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiV2VersionService.cs
@@ -209,9 +209,9 @@ namespace Microsoft.OpenApi.Reader.V2
             throw new OpenApiException(string.Format(SRResource.ReferenceHasInvalidFormat, reference));
         }
 
-        public OpenApiDocument LoadDocument(RootNode rootNode)
+        public OpenApiDocument LoadDocument(RootNode rootNode, Uri location)
         {
-            return OpenApiV2Deserializer.LoadOpenApi(rootNode);
+            return OpenApiV2Deserializer.LoadOpenApi(rootNode, location);
         }
 
         public T LoadElement<T>(ParseNode node, OpenApiDocument doc) where T : IOpenApiElement

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiDocumentDeserializer.cs
@@ -38,9 +38,12 @@ namespace Microsoft.OpenApi.Reader.V3
             {s => s.StartsWith(OpenApiConstants.ExtensionFieldNamePrefix, StringComparison.OrdinalIgnoreCase), (o, p, n, _) => o.AddExtension(p, LoadExtension(p, n))}
         };
 
-        public static OpenApiDocument LoadOpenApi(RootNode rootNode)
+        public static OpenApiDocument LoadOpenApi(RootNode rootNode, Uri location)
         {
-            var openApiDoc = new OpenApiDocument();
+            var openApiDoc = new OpenApiDocument
+            {
+                BaseUri = location
+            };
             var openApiNode = rootNode.GetMap();
 
             ParseMap(openApiNode, openApiDoc, _openApiFixedFields, _openApiPatternFields, openApiDoc);

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiV3VersionService.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiV3VersionService.cs
@@ -170,9 +170,9 @@ namespace Microsoft.OpenApi.Reader.V3
             throw new OpenApiException(string.Format(SRResource.ReferenceHasInvalidFormat, reference));
         }
 
-        public OpenApiDocument LoadDocument(RootNode rootNode)
+        public OpenApiDocument LoadDocument(RootNode rootNode, Uri location)
         {
-            return OpenApiV3Deserializer.LoadOpenApi(rootNode);
+            return OpenApiV3Deserializer.LoadOpenApi(rootNode, location);
         }
 
         public T LoadElement<T>(ParseNode node, OpenApiDocument doc) where T : IOpenApiElement

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiDocumentDeserializer.cs
@@ -36,9 +36,12 @@ namespace Microsoft.OpenApi.Reader.V31
             {s => s.StartsWith(OpenApiConstants.ExtensionFieldNamePrefix, StringComparison.OrdinalIgnoreCase), (o, p, n, _) => o.AddExtension(p, LoadExtension(p, n))}
         };
 
-        public static OpenApiDocument LoadOpenApi(RootNode rootNode)
+        public static OpenApiDocument LoadOpenApi(RootNode rootNode, Uri location)
         {
-            var openApiDoc = new OpenApiDocument();
+            var openApiDoc = new OpenApiDocument
+            {
+                BaseUri = location
+            };
             var openApiNode = rootNode.GetMap();
 
             ParseMap(openApiNode, openApiDoc, _openApiFixedFields, _openApiPatternFields, openApiDoc);

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiV31VersionService.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiV31VersionService.cs
@@ -153,9 +153,9 @@ namespace Microsoft.OpenApi.Reader.V31
             throw new OpenApiException(string.Format(SRResource.ReferenceHasInvalidFormat, reference));
         }
 
-        public OpenApiDocument LoadDocument(RootNode rootNode)
+        public OpenApiDocument LoadDocument(RootNode rootNode, Uri location)
         {
-            return OpenApiV31Deserializer.LoadOpenApi(rootNode);
+            return OpenApiV31Deserializer.LoadOpenApi(rootNode, location);
         }
 
         public T LoadElement<T>(ParseNode node, OpenApiDocument doc) where T : IOpenApiElement

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiDiagnosticTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiDiagnosticTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
             return null;
         }
 
-        public Task<Stream> LoadAsync(Uri uri, CancellationToken cancellationToken = default)
+        public Task<Stream> LoadAsync(Uri baseUrl, Uri uri, CancellationToken cancellationToken = default)
         {
             var path = new Uri(new("http://example.org/OpenApiReaderTests/Samples/OpenApiDiagnosticReportMerged/"), uri).AbsolutePath;
             path = path[1..]; // remove leading slash

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiWorkspaceTests/OpenApiWorkspaceStreamTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiWorkspaceTests/OpenApiWorkspaceStreamTests.cs
@@ -1,9 +1,12 @@
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
+using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Reader;
 using Xunit;
 
@@ -59,13 +62,69 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiWorkspaceTests
             result = await OpenApiDocument.LoadAsync("V3Tests/Samples/OpenApiWorkspace/TodoMain.yaml", settings);
 
             var externalDocBaseUri = result.Document.Workspace.GetDocumentId("./TodoComponents.yaml");
-            var schemasPath = "/components/schemas/";
-            var parametersPath = "/components/parameters/";
+            var schemasPath = "#/components/schemas/";
+            var parametersPath = "#/components/parameters/";
 
             Assert.NotNull(externalDocBaseUri);
             Assert.True(result.Document.Workspace.Contains(externalDocBaseUri + schemasPath + "todo"));
             Assert.True(result.Document.Workspace.Contains(externalDocBaseUri + schemasPath + "entity"));
             Assert.True(result.Document.Workspace.Contains(externalDocBaseUri + parametersPath + "filter"));
+        }
+
+        [Fact]
+        public async Task LoadDocumentWithExternalReferencesInSubDirectories()
+        {
+            var sampleFolderPath = $"V3Tests/Samples/OpenApiWorkspace/ExternalReferencesInSubDirectories";
+            var referenceBaseUri = "file://" + Path.GetFullPath(sampleFolderPath);
+
+            // Create a reader that will resolve all references also of documentes located in the non-root directory
+            var settings = new OpenApiReaderSettings()
+            {
+                LoadExternalRefs = true,
+                BaseUrl = new Uri("file://")
+            };
+            settings.AddYamlReader();
+
+            // Act
+            var result = await OpenApiDocument.LoadAsync($"{sampleFolderPath}/Root.yaml", settings);
+            var document = result.Document;
+            var workspace = result.Document.Workspace;
+
+            // Assert
+            Assert.True(workspace.Contains($"{Path.Combine(referenceBaseUri, "Directory", "PetsPage.yaml")}#/components/schemas/PetsPage"));
+            Assert.True(workspace.Contains($"{Path.Combine(referenceBaseUri, "Directory", "Pets.yaml")}#/components/schemas/Pets"));
+            Assert.True(workspace.Contains($"{Path.Combine(referenceBaseUri, "Directory", "Pets.yaml")}#/components/schemas/Pet"));
+
+            var operationResponseSchema = document.Paths["/pets"].Operations[OperationType.Get].Responses["200"].Content["application/json"].Schema;
+            Assert.IsType<OpenApiSchemaReference>(operationResponseSchema);
+            
+            var petsSchema = operationResponseSchema.Properties["pets"];
+            Assert.IsType<OpenApiSchemaReference>(petsSchema);
+            Assert.Equal(JsonSchemaType.Array, petsSchema.Type);
+                        
+            var petSchema = petsSchema.Items;
+            Assert.IsType<OpenApiSchemaReference>(petSchema);
+
+            Assert.Equivalent(new OpenApiSchema
+            {
+                Required = new HashSet<string> { "id", "name" },
+                Properties = new Dictionary<string, IOpenApiSchema>
+                {
+                    ["id"] = new OpenApiSchema
+                    {
+                        Type =  JsonSchemaType.Integer,
+                        Format = "int64"
+                    },
+                    ["name"] = new OpenApiSchema
+                    {
+                        Type = JsonSchemaType.String
+                    },
+                    ["tag"] = new OpenApiSchema
+                    {
+                        Type = JsonSchemaType.String
+                    }
+                }
+            }, petSchema);
         }
     }
 
@@ -76,7 +135,7 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiWorkspaceTests
             return null;
         }
 
-        public Task<Stream> LoadAsync(Uri uri, CancellationToken cancellationToken = default)
+        public Task<Stream> LoadAsync(Uri baseUrl, Uri uri, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<Stream>(null);
         }
@@ -89,7 +148,7 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiWorkspaceTests
             return null;
         }
 
-        public Task<Stream> LoadAsync(Uri uri, CancellationToken cancellationToken = default)
+        public Task<Stream> LoadAsync(Uri baseUrl, Uri uri, CancellationToken cancellationToken = default)
         {
             var path = new Uri(new("http://example.org/V3Tests/Samples/OpenApiWorkspace/"), uri).AbsolutePath;
             path = path[1..]; // remove leading slash

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiDocumentTests.cs
@@ -527,7 +527,12 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             var responseSchema = result.Document.Paths["/resource"].Operations[OperationType.Get].Responses["200"].Content["application/json"].Schema;
 
             // Assert
-            result.Document.Workspace.Contains("./externalResource.yaml");
+            var externalResourceUri = new Uri(
+                "file://" + 
+                Path.Combine(Path.GetFullPath(SampleFolderPath), 
+                "externalResource.yaml#/components/schemas/todo")).AbsoluteUri;
+
+            Assert.True(result.Document.Workspace.Contains(externalResourceUri));
             Assert.Equal(2, responseSchema.Properties.Count); // reference has been resolved
         }
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiWorkspace/ExternalReferencesInSubDirectories/Directory/Pets.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiWorkspace/ExternalReferencesInSubDirectories/Directory/Pets.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Pet(s) Schema
+paths: {}
+components:
+  schemas:
+    Pets:
+      type: array
+      items:
+        "$ref": "#/components/schemas/Pet"
+    Pet:
+      required:
+      - id
+      - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiWorkspace/ExternalReferencesInSubDirectories/Directory/PetsPage.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiWorkspace/ExternalReferencesInSubDirectories/Directory/PetsPage.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: AllPets Schema
+paths: {}
+components:
+  schemas:
+    PetsPage:
+      type: object
+      properties:
+        pageNumber: 
+          type: integer
+          minimum: 0
+          maximum: 100
+        pets:
+          "$ref": "./Pets.yaml#/components/schemas/Pets"

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiWorkspace/ExternalReferencesInSubDirectories/Root.yaml
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiWorkspace/ExternalReferencesInSubDirectories/Root.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Example using relative references into sub directories
+paths:
+  "/pets":
+    get:
+      summary: List all pets
+      operationId: listPets
+      responses:
+        '200':
+          description: An array of pets
+          content:
+            application/json:
+              schema:
+                "$ref": "./Directory/PetsPage.yaml#/components/schemas/PetsPage"

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -218,8 +218,8 @@ namespace Microsoft.OpenApi.Interfaces
     }
     public interface IOpenApiReader
     {
-        Microsoft.OpenApi.Reader.ReadResult Read(System.IO.MemoryStream input, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings);
-        System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.IO.Stream input, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings, System.Threading.CancellationToken cancellationToken = default);
+        Microsoft.OpenApi.Reader.ReadResult Read(System.IO.MemoryStream input, System.Uri location, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings);
+        System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.IO.Stream input, System.Uri location, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings, System.Threading.CancellationToken cancellationToken = default);
         T ReadFragment<T>(System.IO.MemoryStream input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Models.OpenApiDocument openApiDocument, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement;
     }
@@ -247,7 +247,7 @@ namespace Microsoft.OpenApi.Interfaces
     }
     public interface IStreamLoader
     {
-        System.Threading.Tasks.Task<System.IO.Stream> LoadAsync(System.Uri uri, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<System.IO.Stream> LoadAsync(System.Uri baseUrl, System.Uri uri, System.Threading.CancellationToken cancellationToken = default);
     }
 }
 namespace Microsoft.OpenApi
@@ -1461,9 +1461,9 @@ namespace Microsoft.OpenApi.Reader
     public class OpenApiJsonReader : Microsoft.OpenApi.Interfaces.IOpenApiReader
     {
         public OpenApiJsonReader() { }
-        public Microsoft.OpenApi.Reader.ReadResult Read(System.IO.MemoryStream input, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings) { }
-        public Microsoft.OpenApi.Reader.ReadResult Read(System.Text.Json.Nodes.JsonNode jsonNode, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings) { }
-        public System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.IO.Stream input, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings, System.Threading.CancellationToken cancellationToken = default) { }
+        public Microsoft.OpenApi.Reader.ReadResult Read(System.IO.MemoryStream input, System.Uri location, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings) { }
+        public Microsoft.OpenApi.Reader.ReadResult Read(System.Text.Json.Nodes.JsonNode jsonNode, System.Uri location, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings) { }
+        public System.Threading.Tasks.Task<Microsoft.OpenApi.Reader.ReadResult> ReadAsync(System.IO.Stream input, System.Uri location, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings, System.Threading.CancellationToken cancellationToken = default) { }
         public T ReadFragment<T>(System.IO.MemoryStream input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Models.OpenApiDocument openApiDocument, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
         public T ReadFragment<T>(System.Text.Json.Nodes.JsonNode input, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Models.OpenApiDocument openApiDocument, out Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnostic, Microsoft.OpenApi.Reader.OpenApiReaderSettings settings = null)
@@ -1516,7 +1516,7 @@ namespace Microsoft.OpenApi.Reader
         public void EndObject() { }
         public T GetFromTempStorage<T>(string key, object scope = null) { }
         public string GetLocation() { }
-        public Microsoft.OpenApi.Models.OpenApiDocument Parse(System.Text.Json.Nodes.JsonNode jsonNode) { }
+        public Microsoft.OpenApi.Models.OpenApiDocument Parse(System.Text.Json.Nodes.JsonNode jsonNode, System.Uri location) { }
         public T ParseFragment<T>(System.Text.Json.Nodes.JsonNode jsonNode, Microsoft.OpenApi.OpenApiSpecVersion version, Microsoft.OpenApi.Models.OpenApiDocument openApiDocument)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
         public void PopLoop(string loopid) { }
@@ -1543,8 +1543,8 @@ namespace Microsoft.OpenApi.Reader.Services
 {
     public class DefaultStreamLoader : Microsoft.OpenApi.Interfaces.IStreamLoader
     {
-        public DefaultStreamLoader(System.Uri baseUrl, System.Net.Http.HttpClient httpClient) { }
-        public System.Threading.Tasks.Task<System.IO.Stream> LoadAsync(System.Uri uri, System.Threading.CancellationToken cancellationToken = default) { }
+        public DefaultStreamLoader(System.Net.Http.HttpClient httpClient) { }
+        public System.Threading.Tasks.Task<System.IO.Stream> LoadAsync(System.Uri baseUrl, System.Uri uri, System.Threading.CancellationToken cancellationToken = default) { }
     }
 }
 namespace Microsoft.OpenApi.Services
@@ -1674,7 +1674,7 @@ namespace Microsoft.OpenApi.Services
         public void AddDocumentId(string key, System.Uri value) { }
         public int ComponentsCount() { }
         public bool Contains(string location) { }
-        public System.Uri GetDocumentId(string key) { }
+        public System.Uri? GetDocumentId(string key) { }
         public bool RegisterComponentForDocument<T>(Microsoft.OpenApi.Models.OpenApiDocument openApiDocument, T componentToRegister, string id) { }
         public void RegisterComponents(Microsoft.OpenApi.Models.OpenApiDocument document) { }
         public T? ResolveReference<T>(string location) { }


### PR DESCRIPTION
Use OpenApiDocuments BaseUri as location of the document. This allows to have during loading further documents a base Url for retrieval, which can be combined with a relative Uri to get an absolute.