### PR TITLE
Remove duplicate property UnEvaluatedProperties 

### DIFF
--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiSchema.cs
@@ -65,11 +65,6 @@ public interface IOpenApiSchema : IOpenApiDescribedElement, IOpenApiReadOnlyExte
 
     /// <summary>
     /// Follow JSON Schema definition: https://tools.ietf.org/html/draft-fge-json-schema-validation-00
-    /// </summary>
-    public bool UnEvaluatedProperties { get; }     
-
-    /// <summary>
-    /// Follow JSON Schema definition: https://tools.ietf.org/html/draft-fge-json-schema-validation-00
     /// Value MUST be a string in V2 and V3.
     /// </summary>
     public JsonSchemaType? Type { get; }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
@@ -64,8 +64,6 @@ namespace Microsoft.OpenApi.Models.References
         /// <inheritdoc/>
         public decimal? ExclusiveMinimum { get => Target?.ExclusiveMinimum; }
         /// <inheritdoc/>
-        public bool UnEvaluatedProperties { get => Target?.UnEvaluatedProperties ?? false; }
-        /// <inheritdoc/>
         public JsonSchemaType? Type { get => Target?.Type; }
         /// <inheritdoc/>
         public string? Const { get => Target?.Const; }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -454,7 +454,6 @@ namespace Microsoft.OpenApi.Models.Interfaces
         System.Uri? Schema { get; }
         string? Title { get; }
         Microsoft.OpenApi.Models.JsonSchemaType? Type { get; }
-        bool UnEvaluatedProperties { get; }
         bool UnevaluatedProperties { get; }
         bool? UniqueItems { get; }
         System.Collections.Generic.IDictionary<string, System.Text.Json.Nodes.JsonNode>? UnrecognizedKeywords { get; }
@@ -1391,7 +1390,6 @@ namespace Microsoft.OpenApi.Models.References
         public System.Uri? Schema { get; }
         public string? Title { get; }
         public Microsoft.OpenApi.Models.JsonSchemaType? Type { get; }
-        public bool UnEvaluatedProperties { get; }
         public bool UnevaluatedProperties { get; }
         public bool? UniqueItems { get; }
         public System.Collections.Generic.IDictionary<string, System.Text.Json.Nodes.JsonNode>? UnrecognizedKeywords { get; }


### PR DESCRIPTION
IOpenApiSchema interface already contains a UnevaluatedProperties property (different case).