### PR TITLE
fix: always serialize security schemes in components

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models.Interfaces;
 using Microsoft.OpenApi.Models.References;
@@ -110,7 +111,7 @@ namespace Microsoft.OpenApi.Models
             // however if they have cycles, then we will need a component rendered
             if (writer.GetSettings().InlineLocalReferences)
             {
-                RenderComponents(writer, (writer, element) => element.SerializeAsV31(writer));
+                RenderComponents(writer, (writer, element) => element.SerializeAsV31(writer), OpenApiSpecVersion.OpenApi3_1);                
                 return;
             }
 
@@ -148,7 +149,7 @@ namespace Microsoft.OpenApi.Models
             // however if they have cycles, then we will need a component rendered
             if (writer.GetSettings().InlineLocalReferences)
             {
-                RenderComponents(writer, (writer, element) => element.SerializeAsV3(writer));
+                RenderComponents(writer, (writer, element) => element.SerializeAsV3(writer), OpenApiSpecVersion.OpenApi3_0);
                 return;
             }
 
@@ -315,13 +316,26 @@ namespace Microsoft.OpenApi.Models
             writer.WriteEndObject();
         }
 
-        private void RenderComponents(IOpenApiWriter writer, Action<IOpenApiWriter, IOpenApiSerializable> callback)
+        private void RenderComponents(IOpenApiWriter writer, Action<IOpenApiWriter, IOpenApiSerializable> callback, OpenApiSpecVersion version)
         {
             var loops = writer.GetSettings().LoopDetector.Loops;
             writer.WriteStartObject();
             if (loops.TryGetValue(typeof(OpenApiSchema), out var schemas))
             {
                 writer.WriteOptionalMap(OpenApiConstants.Schemas, Schemas, callback);
+            }
+            // always render security schemes as inlining of security requirement objects is not allowed in the spec
+            if (SecuritySchemes is not null && SecuritySchemes.Any())
+            {
+                writer.WriteOptionalMap(
+                OpenApiConstants.SecuritySchemes,
+                SecuritySchemes,
+                (w, key, component) =>
+                {
+                    if (version is OpenApiSpecVersion.OpenApi3_1)
+                        component.SerializeAsV31(writer);
+                    component.SerializeAsV3(writer);
+                });
             }
             writer.WriteEndObject();
         }

--- a/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
+++ b/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -48,6 +48,10 @@
     </None>
       
     <None Update="Models\Samples\docWithReusableWebhooks.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+      
+    <None Update="Models\Samples\docWithSecurityScheme.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
       

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
@@ -2179,5 +2179,48 @@ components:
             Assert.Equal("version", actual.ParamName);
             Assert.Equal(version, actual.ActualValue);
         }
+
+        [Fact]
+        public async Task SerializeDocWithSecuritySchemeWithInlineRefererencesWorks()
+        {
+            var expected = @"openapi: 3.0.4
+info:
+  title: Repair Service
+  version: 1.0.0
+servers:
+  - url: https://pluginrentu.azurewebsites.net/api
+paths:
+  /repairs:
+    get:
+      summary: List all repairs with oauth
+      description: Returns a list of repairs with their details and images
+      operationId: listRepairs
+      responses:
+        '200':
+          description: A list of repairs
+          content:
+            application/json:
+              schema:
+                type: object
+      security:
+        - oAuth2AuthCode: [ ]
+components:
+  securitySchemes:
+    oAuth2AuthCode:
+      type: oauth2
+      description: OAuth configuration for the repair service
+      flows:
+        authorizationCode:
+          authorizationUrl: https://login.microsoftonline.com/2f13b28c-bd4d-43e2-8ae6-48594aaba125/oauth2/v2.0/authorize
+          tokenUrl: https://login.microsoftonline.com/2f13b28c-bd4d-43e2-8ae6-48594aaba125/oauth2/v2.0/token
+          scopes:
+            api://a2a7226d-e8d1-4ded-8c53-dd4c136ff456/repairs_read: Read repair records";
+
+            var doc = (await OpenApiDocument.LoadAsync("Models/Samples/docWithSecurityScheme.yaml", SettingsFixture.ReaderSettings)).Document;
+            var stringWriter = new StringWriter();
+            doc.SerializeAsV3(new OpenApiYamlWriter(stringWriter, new OpenApiWriterSettings { InlineLocalReferences = true }));
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected.MakeLineBreaksEnvironmentNeutral(), actual.MakeLineBreaksEnvironmentNeutral());
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/Samples/docWithSecurityScheme.yaml
+++ b/test/Microsoft.OpenApi.Tests/Models/Samples/docWithSecurityScheme.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+info:
+  title: Repair Service
+  version: 1.0.0
+servers:
+  - url: https://pluginrentu.azurewebsites.net/api
+components:
+  securitySchemes:
+    oAuth2AuthCode:
+      type: oauth2
+      description: OAuth configuration for the repair service
+      flows:
+        authorizationCode:
+          authorizationUrl: https://login.microsoftonline.com/2f13b28c-bd4d-43e2-8ae6-48594aaba125/oauth2/v2.0/authorize
+          tokenUrl: https://login.microsoftonline.com/2f13b28c-bd4d-43e2-8ae6-48594aaba125/oauth2/v2.0/token
+          scopes:
+            api://a2a7226d-e8d1-4ded-8c53-dd4c136ff456/repairs_read: Read repair records
+paths:
+  /repairs:
+    get:
+      operationId: listRepairs
+      summary: List all repairs with oauth
+      description: Returns a list of repairs with their details and images
+      security:
+        - oAuth2AuthCode: []
+      responses:
+        '200':
+          description: A list of repairs
+          content:
+            application/json:
+              schema:
+                type: object


### PR DESCRIPTION
This PR fixes a bug where the security schemes object within the components wasn't being serialized when `InlineLocalReferences` or `InlineExternlRefeences` is enabled.

Fixes #2267