### PR TITLE
Fix issue Empty tag causes error generating Kiota client #2283

### DIFF
--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
@@ -19,12 +19,26 @@ namespace Microsoft.OpenApi.Reader.V2
     /// </summary>
     internal static partial class OpenApiV2Deserializer
     {
+        /// <summary>
+        /// Have a default empty tag we can use to filter out empty tags.
+        /// </summary>
+        private static OpenApiTagReference emptyTagReference = new("empty");
         private static readonly FixedFieldMap<OpenApiOperation> _operationFixedFields =
             new()
             {
                 {
-                    "tags", (o, n, doc) => { 
-                        if (n.CreateSimpleList((valueNode, doc) => LoadTagByReference(valueNode.GetScalarValue(), doc), doc) is {Count: > 0} tags)
+                    "tags", (o, n, doc) => {
+                        if (n.CreateSimpleList(
+                            (valueNode, doc) =>
+                            {
+                                var val = valueNode.GetScalarValue();
+                                if (string.IsNullOrEmpty(val))
+                                    return emptyTagReference;   // Avoid exception on empty tag, we'll remove these from the list further on
+                                return LoadTagByReference(val , doc);
+                                },
+                            doc)
+                        // Filter out empty tags instead of excepting on them
+                        .Where(n => !object.ReferenceEquals(emptyTagReference, n)).ToList() is {Count: > 0} tags)
                         {
                             o.Tags = new HashSet<OpenApiTagReference>(tags, OpenApiTagComparer.Instance);
                         }

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
@@ -22,7 +22,6 @@ namespace Microsoft.OpenApi.Reader.V2
         /// <summary>
         /// Have a default empty tag we can use to filter out empty tags.
         /// </summary>
-        private static OpenApiTagReference emptyTagReference = new("empty");
         private static readonly FixedFieldMap<OpenApiOperation> _operationFixedFields =
             new()
             {
@@ -33,12 +32,12 @@ namespace Microsoft.OpenApi.Reader.V2
                             {
                                 var val = valueNode.GetScalarValue();
                                 if (string.IsNullOrEmpty(val))
-                                    return emptyTagReference;   // Avoid exception on empty tag, we'll remove these from the list further on
+                                    return null;   // Avoid exception on empty tag, we'll remove these from the list further on
                                 return LoadTagByReference(val , doc);
                                 },
                             doc)
                         // Filter out empty tags instead of excepting on them
-                        .Where(n => !object.ReferenceEquals(emptyTagReference, n)).ToList() is {Count: > 0} tags)
+                        .OfType<OpenApiTagReference>().ToList() is {Count: > 0} tags)
                         {
                             o.Tags = new HashSet<OpenApiTagReference>(tags, OpenApiTagComparer.Instance);
                         }

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
@@ -19,9 +19,6 @@ namespace Microsoft.OpenApi.Reader.V2
     /// </summary>
     internal static partial class OpenApiV2Deserializer
     {
-        /// <summary>
-        /// Have a default empty tag we can use to filter out empty tags.
-        /// </summary>
         private static readonly FixedFieldMap<OpenApiOperation> _operationFixedFields =
             new()
             {

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiOperationDeserializer.cs
@@ -17,9 +17,6 @@ namespace Microsoft.OpenApi.Reader.V3
     /// </summary>
     internal static partial class OpenApiV3Deserializer
     {
-        /// <summary>
-        /// Have a default empty tag we can use to filter out empty tags.
-        /// </summary>
         private static readonly FixedFieldMap<OpenApiOperation> _operationFixedFields =
             new()
             {

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiOperationDeserializer.cs
@@ -20,7 +20,6 @@ namespace Microsoft.OpenApi.Reader.V3
         /// <summary>
         /// Have a default empty tag we can use to filter out empty tags.
         /// </summary>
-        private static OpenApiTagReference emptyTagReference = new("empty");
         private static readonly FixedFieldMap<OpenApiOperation> _operationFixedFields =
             new()
             {
@@ -31,12 +30,12 @@ namespace Microsoft.OpenApi.Reader.V3
                             {
                                 var val = valueNode.GetScalarValue();
                                 if (string.IsNullOrEmpty(val))
-                                    return emptyTagReference;   // Avoid exception on empty tag, we'll remove these from the list further on
+                                    return null;   // Avoid exception on empty tag, we'll remove these from the list further on
                                 return LoadTagByReference(val , doc);
                                 },
                             doc)
                         // Filter out empty tags instead of excepting on them
-                        .Where(n => !object.ReferenceEquals(emptyTagReference, n)).ToList() is {Count: > 0} tags)
+                        .OfType<OpenApiTagReference>().ToList() is {Count: > 0} tags)
                         {
                             o.Tags = new HashSet<OpenApiTagReference>(tags, OpenApiTagComparer.Instance);
                         }

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiOperationDeserializer.cs
@@ -14,9 +14,6 @@ namespace Microsoft.OpenApi.Reader.V31
     /// </summary>
     internal static partial class OpenApiV31Deserializer
     {
-        /// <summary>
-        /// Have a default empty tag we can use to filter out empty tags.
-        /// </summary>
         private static readonly FixedFieldMap<OpenApiOperation> _operationFixedFields =
             new()
             {

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiOperationDeserializer.cs
@@ -17,7 +17,6 @@ namespace Microsoft.OpenApi.Reader.V31
         /// <summary>
         /// Have a default empty tag we can use to filter out empty tags.
         /// </summary>
-        private static OpenApiTagReference emptyTagReference = new("empty");
         private static readonly FixedFieldMap<OpenApiOperation> _operationFixedFields =
             new()
             {
@@ -28,12 +27,12 @@ namespace Microsoft.OpenApi.Reader.V31
                             {
                                 var val = valueNode.GetScalarValue();
                                 if (string.IsNullOrEmpty(val))
-                                    return emptyTagReference;   // Avoid exception on empty tag, we'll remove these from the list further on
+                                    return null;   // Avoid exception on empty tag, we'll remove these from the list further on
                                 return LoadTagByReference(val , doc);
                                 },
                             doc)
                         // Filter out empty tags instead of excepting on them
-                        .Where(n => !object.ReferenceEquals(emptyTagReference, n)).ToList() is {Count: > 0} tags)
+                        .OfType<OpenApiTagReference>().ToList() is {Count: > 0} tags)
                         {
                             o.Tags = new HashSet<OpenApiTagReference>(tags, OpenApiTagComparer.Instance);
                         }

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiOperationDeserializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.References;
@@ -13,12 +14,26 @@ namespace Microsoft.OpenApi.Reader.V31
     /// </summary>
     internal static partial class OpenApiV31Deserializer
     {
+        /// <summary>
+        /// Have a default empty tag we can use to filter out empty tags.
+        /// </summary>
+        private static OpenApiTagReference emptyTagReference = new("empty");
         private static readonly FixedFieldMap<OpenApiOperation> _operationFixedFields =
             new()
             {
                 {
-                    "tags", (o, n, doc) => { 
-                        if (n.CreateSimpleList((valueNode, doc) => LoadTagByReference(valueNode.GetScalarValue(), doc), doc) is {Count: > 0} tags)
+                    "tags", (o, n, doc) => {
+                        if (n.CreateSimpleList(
+                            (valueNode, doc) =>
+                            {
+                                var val = valueNode.GetScalarValue();
+                                if (string.IsNullOrEmpty(val))
+                                    return emptyTagReference;   // Avoid exception on empty tag, we'll remove these from the list further on
+                                return LoadTagByReference(val , doc);
+                                },
+                            doc)
+                        // Filter out empty tags instead of excepting on them
+                        .Where(n => !object.ReferenceEquals(emptyTagReference, n)).ToList() is {Count: > 0} tags)
                         {
                             o.Tags = new HashSet<OpenApiTagReference>(tags, OpenApiTagComparer.Instance);
                         }

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiDocumentTests.cs
@@ -571,6 +571,15 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
         }
 
         [Fact]
+        public async Task ParseDocumentWithEmptyTagsWorks()
+        {
+            var path = Path.Combine(SampleFolderPath, "documentWithEmptyTags.json");
+            var doc = (await OpenApiDocument.LoadAsync(path, SettingsFixture.ReaderSettings)).Document;
+
+            doc.Paths["/groups"].Operations[HttpMethod.Get].Tags.Should().BeNull("Empty tags are ignored, so we should not have any tags");
+        }
+
+        [Fact]
         public void ParseEmptyMemoryStreamThrowsAnArgumentException()
         {
             Assert.Throws<ArgumentException>(() => OpenApiDocument.Load(new MemoryStream()));

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/Samples/OpenApiDocument/documentWithEmptyTags.json
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/Samples/OpenApiDocument/documentWithEmptyTags.json
@@ -1,0 +1,50 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "description": "Groups API",
+    "title": "Groups",
+    "version": "1.0"
+  },
+  "paths": {
+    "/groups": {
+      "get": {
+        "operationId": "getGroups",
+        "parameters": [
+          {
+            "description": "Zero-based page index (0..N)",
+            "example": 0,
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0,
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PaginatedGroup" } } }
+          }
+        },
+        "tags": [ "" ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PaginatedGroup": {
+        "type": "object",
+        "properties": {
+          "number": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of the current page."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
When parsing the list of tags, removed tags that are empty so we don't fail on them.
