### PR TITLE
Use SHA512.HashDataAsync

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -524,9 +524,7 @@ namespace Microsoft.OpenApi.Models
         /// <returns>The hash value.</returns>
         public async Task<string> GetHashCodeAsync(CancellationToken cancellationToken = default)
         {
-            byte[]? hash;
-
-#if NET
+#if NET7_OR_GREATER
             using var memoryStream = new MemoryStream();
             using var streamWriter = new StreamWriter(memoryStream);
 
@@ -534,7 +532,7 @@ namespace Microsoft.OpenApi.Models
 
             memoryStream.Seek(0, SeekOrigin.Begin);
 
-            hash = await SHA512.HashDataAsync(memoryStream, cancellationToken).ConfigureAwait(false);
+            var hash = await SHA512.HashDataAsync(memoryStream, cancellationToken).ConfigureAwait(false);
 #else
             using HashAlgorithm sha = SHA512.Create();
             using var cryptoStream = new CryptoStream(Stream.Null, sha, CryptoStreamMode.Write);
@@ -544,7 +542,7 @@ namespace Microsoft.OpenApi.Models
 
             cryptoStream.FlushFinalBlock();
 
-            hash = sha.Hash;
+            var hash = sha.Hash;
 #endif
 
             return ConvertByteArrayToString(hash ?? []);

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -550,7 +550,7 @@ namespace Microsoft.OpenApi.Models
             async Task WriteDocumentAsync(TextWriter writer, CancellationToken token)
             {
                 var openApiJsonWriter = new OpenApiJsonWriter(writer, new() { Terse = true });
-                SerializeAsV3(openApiJsonWriter);
+                SerializeAsV31(openApiJsonWriter);
                 await openApiJsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -524,20 +524,37 @@ namespace Microsoft.OpenApi.Models
         /// <returns>The hash value.</returns>
         public async Task<string> GetHashCodeAsync(CancellationToken cancellationToken = default)
         {
+            byte[]? hash;
+
+#if NET
+            using var memoryStream = new MemoryStream();
+            using var streamWriter = new StreamWriter(memoryStream);
+
+            await WriteDocumentAsync(streamWriter, cancellationToken).ConfigureAwait(false);
+
+            memoryStream.Seek(0, SeekOrigin.Begin);
+
+            hash = await SHA512.HashDataAsync(memoryStream, cancellationToken).ConfigureAwait(false);
+#else
             using HashAlgorithm sha = SHA512.Create();
             using var cryptoStream = new CryptoStream(Stream.Null, sha, CryptoStreamMode.Write);
             using var streamWriter = new StreamWriter(cryptoStream);
 
-            var openApiJsonWriter = new OpenApiJsonWriter(streamWriter, new() { Terse = true });
-            SerializeAsV3(openApiJsonWriter);
-            await openApiJsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
+            await WriteDocumentAsync(streamWriter, cancellationToken).ConfigureAwait(false);
 
-#if NET5_0_OR_GREATER
-            await cryptoStream.FlushFinalBlockAsync(cancellationToken).ConfigureAwait(false);
-#else
             cryptoStream.FlushFinalBlock();
+
+            hash = sha.Hash;
 #endif
-            return ConvertByteArrayToString(sha.Hash ?? []);
+
+            return ConvertByteArrayToString(hash ?? []);
+
+            async Task WriteDocumentAsync(TextWriter writer, CancellationToken token)
+            {
+                var openApiJsonWriter = new OpenApiJsonWriter(writer, new() { Terse = true });
+                SerializeAsV3(openApiJsonWriter);
+                await openApiJsonWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
         }
 
         private static string ConvertByteArrayToString(byte[] hash)


### PR DESCRIPTION
Use `SHA512.HashDataAsync()` for .NET 8 to reduce allocations.

Complements the change in #2322.

I manually verified the hash before and after was the same by getting the hash from the `TestHashCodesForSimilarOpenApiDocuments` test using the debugger and then verifying it was the same after the change with:

```csharp
Assert.Equal("00BCB7FE78379A07956E06BF3180A8818F6E42E10BC38A7012A342CD6E1033BF03CB7E70E04B285C67BF4D78828D185C1FE438073C2474E40315F2ECE6310B78", doc1HashCode);
```
