### PR TITLE
chore: implement tests for routing issues during serialization

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
@@ -59,7 +59,7 @@ namespace Microsoft.OpenApi.Models
         /// </summary>
         /// <param name="writer"></param>
         /// <exception cref="System.NotImplementedException"></exception>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1, (writer, element) => element.SerializeAsV31(writer));
         }
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiCallback"/> to Open Api v3.0
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (writer, element) => element.SerializeAsV3(writer));
         }
@@ -97,7 +97,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiCallback"/> to Open Api v2.0
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             // Callback object does not exist in V2.
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
@@ -98,7 +98,7 @@ namespace Microsoft.OpenApi.Models
         /// Serialize <see cref="OpenApiComponents"/> to Open API v3.1.
         /// </summary>
         /// <param name="writer"></param>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             Utils.CheckArgumentNull(writer);
 
@@ -136,7 +136,7 @@ namespace Microsoft.OpenApi.Models
         /// Serialize <see cref="OpenApiComponents"/> to v3.0
         /// </summary>
         /// <param name="writer"></param>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             Utils.CheckArgumentNull(writer);
 
@@ -338,7 +338,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiComponents"/> to Open Api v2.0.
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             // Components object does not exist in V2.
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiContact.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiContact.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OpenApi.Models
         /// Serialize <see cref="OpenApiContact"/> to Open Api v3.1
         /// </summary>
         /// <param name="writer"></param>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi3_1);
         }
@@ -62,7 +62,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiContact"/> to Open Api v3.0
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi3_0);
         }
@@ -70,7 +70,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiContact"/> to Open Api v2.0
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi2_0);
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiEncoding.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiEncoding.cs
@@ -76,7 +76,7 @@ namespace Microsoft.OpenApi.Models
         /// Serialize <see cref="OpenApiEncoding"/> to Open Api v3.1
         /// </summary>
         /// <param name="writer"></param>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1, (writer, element) => element.SerializeAsV31(writer));
         }
@@ -85,7 +85,7 @@ namespace Microsoft.OpenApi.Models
         /// Serialize <see cref="OpenApiEncoding"/> to Open Api v3.0
         /// </summary>
         /// <param name="writer"></param>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (writer, element) => element.SerializeAsV3(writer));
         }
@@ -124,7 +124,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v2.0.
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             // nothing here
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiExample.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExample.cs
@@ -50,13 +50,13 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <inheritdoc/>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1);
         }
 
         /// <inheritdoc/>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0);
         }
@@ -86,7 +86,7 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <inheritdoc/>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi2_0);
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiExternalDocs.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExternalDocs.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v3.1.
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi3_1);
         }
@@ -54,7 +54,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v3.0.
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi3_0);
         }
@@ -62,7 +62,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v2.0.
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi2_0);
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
@@ -83,7 +83,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiHeader"/> to Open Api v3.1
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (writer, element) => element.SerializeAsV31(writer));
         }
@@ -91,7 +91,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiHeader"/> to Open Api v3.0
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (writer, element) => element.SerializeAsV3(writer));
         }
@@ -145,7 +145,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize to OpenAPI V2 document without using reference.
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             Utils.CheckArgumentNull(writer);
 

--- a/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiLicense"/> to Open Api v3.1
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi3_1);
             writer.WriteProperty(OpenApiConstants.Identifier, Identifier);
@@ -62,7 +62,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiLicense"/> to Open Api v3.0
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi3_0);
             writer.WriteEndObject();
@@ -71,7 +71,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiLicense"/> to Open Api v2.0
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi2_0);
             writer.WriteEndObject();

--- a/src/Microsoft.OpenApi/Models/OpenApiLink.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiLink.cs
@@ -56,13 +56,13 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <inheritdoc/>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, (writer, element) => element.SerializeAsV31(writer));
         }
 
         /// <inheritdoc/>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, (writer, element) => element.SerializeAsV3(writer));
         }
@@ -98,7 +98,7 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <inheritdoc/>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             // Link object does not exist in V2.
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiMediaType"/> to Open Api v3.1.
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1, (w, element) => element.SerializeAsV31(w));
         }
@@ -75,7 +75,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiMediaType"/> to Open Api v3.0.
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (w, element) => element.SerializeAsV3(w));
         }
@@ -114,7 +114,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiMediaType"/> to Open Api v2.0.
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             // Media type does not exist in V2.
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
@@ -99,7 +99,7 @@ namespace Microsoft.OpenApi.Models
             // examples
             if (Examples != null && Examples.Any())
             {
-                SerializeExamples(writer, Examples);
+                SerializeExamples(writer, Examples, callback);
             }
 
             // encoding
@@ -119,7 +119,7 @@ namespace Microsoft.OpenApi.Models
             // Media type does not exist in V2.
         }
 
-        private static void SerializeExamples(IOpenApiWriter writer, Dictionary<string, IOpenApiExample> examples)
+        private static void SerializeExamples(IOpenApiWriter writer, Dictionary<string, IOpenApiExample> examples, Action<IOpenApiWriter, IOpenApiSerializable> callback)
         {
             /* Special case for writing out empty arrays as valid response examples
             * Check if there is any example with an empty array as its value and set the flag `hasEmptyArray` to true
@@ -143,7 +143,7 @@ namespace Microsoft.OpenApi.Models
             }
             else
             {
-                writer.WriteOptionalMap(OpenApiConstants.Examples, examples, (w, e) => e.SerializeAsV3(w));
+                writer.WriteOptionalMap(OpenApiConstants.Examples, examples, callback);
             }
         }
     }

--- a/src/Microsoft.OpenApi/Models/OpenApiOAuthFlows.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOAuthFlows.cs
@@ -59,7 +59,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiOAuthFlows"/> to Open Api v3.1
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1, (writer, element) => element.SerializeAsV31(writer));
         }
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiOAuthFlows"/> to Open Api v3.0
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (writer, element) => element.SerializeAsV3(writer));
         }
@@ -109,7 +109,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiOAuthFlows"/> to Open Api v2.0
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             // OAuthFlows object does not exist in V2.
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
@@ -158,7 +158,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiOperation"/> to Open Api v3.1.
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1, (writer, element) => element.SerializeAsV31(writer));
         }
@@ -166,7 +166,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiOperation"/> to Open Api v3.0.
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (writer, element) => element.SerializeAsV3(writer));
         }
@@ -228,7 +228,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiOperation"/> to Open Api v2.0.
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             Utils.CheckArgumentNull(writer);
 

--- a/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
@@ -100,13 +100,13 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <inheritdoc/>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1, (writer, element) => element.SerializeAsV31(writer));
         }
 
         /// <inheritdoc/>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (writer, element) => element.SerializeAsV3(writer));
         }
@@ -248,7 +248,7 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <inheritdoc/>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             Utils.CheckArgumentNull(writer);
 

--- a/src/Microsoft.OpenApi/Models/OpenApiPathItem.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiPathItem.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models.Interfaces;
 using Microsoft.OpenApi.Writers;
@@ -67,7 +66,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiPathItem"/> to Open Api v3.1
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1, (writer, element) => element.SerializeAsV31(writer));
         }
@@ -75,7 +74,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiPathItem"/> to Open Api v3.0
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (writer, element) => element.SerializeAsV3(writer));
         }
@@ -84,7 +83,7 @@ namespace Microsoft.OpenApi.Models
         /// Serialize inline PathItem in OpenAPI V2
         /// </summary>
         /// <param name="writer"></param>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             Utils.CheckArgumentNull(writer);
 

--- a/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiRequestBody"/> to Open Api v3.1
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1, (writer, element) => element.SerializeAsV31(writer));
         }
@@ -58,7 +58,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiRequestBody"/> to Open Api v3.0
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (writer, element) => element.SerializeAsV3(writer));
         }
@@ -88,7 +88,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiRequestBody"/> to Open Api v2.0
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             // RequestBody object does not exist in V2.
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiResponse"/> to Open Api v3.1
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1, (writer, element) => element.SerializeAsV31(writer));
         }
@@ -59,7 +59,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiResponse"/> to Open Api v3.0.
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (writer, element) => element.SerializeAsV3(writer));
         }
@@ -92,7 +92,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize to OpenAPI V2 document without using reference.
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             Utils.CheckArgumentNull(writer);
 

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -323,13 +323,13 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <inheritdoc />
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1, (writer, element) => element.SerializeAsV31(writer));
         }
 
         /// <inheritdoc />
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (writer, element) => element.SerializeAsV3(writer));
         }
@@ -514,7 +514,7 @@ namespace Microsoft.OpenApi.Models
         }
 
         /// <inheritdoc />
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             SerializeAsV2(writer: writer, parentRequiredProperties: new HashSet<string>(), propertyName: null);
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -490,7 +490,7 @@ namespace Microsoft.OpenApi.Models
             writer.WriteProperty(OpenApiConstants.WriteOnly, WriteOnly, false);
 
             // xml
-            writer.WriteOptionalObject(OpenApiConstants.Xml, Xml, (w, s) => s.SerializeAsV2(w));
+            writer.WriteOptionalObject(OpenApiConstants.Xml, Xml, callback);
 
             // externalDocs
             writer.WriteOptionalObject(OpenApiConstants.ExternalDocs, ExternalDocs, callback);

--- a/src/Microsoft.OpenApi/Models/OpenApiSecurityRequirement.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSecurityRequirement.cs
@@ -35,7 +35,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiSecurityRequirement"/> to Open Api v3.1
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, (w, s) =>
             {
@@ -49,7 +49,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiSecurityRequirement"/> to Open Api v3.0
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, (w, s) =>
             {
@@ -96,7 +96,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiSecurityRequirement"/> to Open Api v2.0
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             SerializeInternal(writer, (w, s) => s.SerializeAsV2(w));
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiSecurityScheme.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSecurityScheme.cs
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiSecurityScheme"/> to Open Api v3.1
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1, (writer, element) => element.SerializeAsV31(writer));
         }
@@ -75,7 +75,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiSecurityScheme"/> to Open Api v3.0
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (writer, element) => element.SerializeAsV3(writer));
         }
@@ -130,7 +130,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiSecurityScheme"/> to Open Api v2.0
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             Utils.CheckArgumentNull(writer);
 

--- a/src/Microsoft.OpenApi/Models/OpenApiServer.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiServer.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiServer"/> to Open Api v3.1
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1, (writer, element) => element.SerializeAsV31(writer));
         }
@@ -62,7 +62,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiServer"/> to Open Api v3.0
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0, (writer, element) => element.SerializeAsV3(writer));
         }
@@ -95,7 +95,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiServer"/> to Open Api v2.0
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             // Server object does not exist in V2.
         }

--- a/src/Microsoft.OpenApi/Models/OpenApiTag.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiTag.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiTag"/> to Open Api v3.1
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer) 
+        public virtual void SerializeAsV31(IOpenApiWriter writer) 
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_1,
                 (writer, element) => element.SerializeAsV31(writer));
@@ -55,7 +55,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiTag"/> to Open Api v3.0
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer) 
+        public virtual void SerializeAsV3(IOpenApiWriter writer) 
         {
             SerializeInternal(writer, OpenApiSpecVersion.OpenApi3_0,
                 (writer, element) => element.SerializeAsV3(writer));
@@ -84,7 +84,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiTag"/> to Open Api v2.0
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             writer.WriteStartObject();
 

--- a/src/Microsoft.OpenApi/Models/OpenApiXml.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiXml.cs
@@ -66,7 +66,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiXml"/> to Open Api v3.0
         /// </summary>
-        public void SerializeAsV31(IOpenApiWriter writer)
+        public virtual void SerializeAsV31(IOpenApiWriter writer)
         {
             Write(writer, OpenApiSpecVersion.OpenApi3_1);
         }
@@ -74,7 +74,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiXml"/> to Open Api v3.0
         /// </summary>
-        public void SerializeAsV3(IOpenApiWriter writer)
+        public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             Write(writer, OpenApiSpecVersion.OpenApi3_0);
         }
@@ -82,7 +82,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Serialize <see cref="OpenApiXml"/> to Open Api v2.0
         /// </summary>
-        public void SerializeAsV2(IOpenApiWriter writer)
+        public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             Write(writer, OpenApiSpecVersion.OpenApi2_0);
         }

--- a/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
+++ b/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
@@ -26,7 +26,6 @@
     <ProjectReference Include="..\..\src\Microsoft.OpenApi.Hidi\Microsoft.OpenApi.Hidi.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.OpenApi.YamlReader\Microsoft.OpenApi.YamlReader.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.OpenApi\Microsoft.OpenApi.csproj" />
-    <ProjectReference Include="..\Microsoft.OpenApi.Hidi.Tests\Microsoft.OpenApi.Hidi.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
+++ b/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
@@ -26,6 +26,7 @@
     <ProjectReference Include="..\..\src\Microsoft.OpenApi.Hidi\Microsoft.OpenApi.Hidi.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.OpenApi.YamlReader\Microsoft.OpenApi.YamlReader.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.OpenApi\Microsoft.OpenApi.csproj" />
+    <ProjectReference Include="..\Microsoft.OpenApi.Hidi.Tests\Microsoft.OpenApi.Hidi.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiCallbackSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiCallbackSerializationTests.cs
@@ -1,0 +1,51 @@
+﻿using System.IO;
+using System.Net.Http;
+using Microsoft.OpenApi.Expressions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiCallbackSerializationTests
+    {
+        private static readonly OpenApiCallback _callback = (OpenApiCallback)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Callbacks["onData"];
+        private static readonly Mock<OpenApiPathItem> _pathItemMock = new() { CallBase = true };
+
+        public OpenApiCallbackSerializationTests()
+        {
+            _callback.PathItems[RuntimeExpression.Build("{$request.body#/callbackUrl}")] = _pathItemMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _callback.SerializeAsV31(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _pathItemMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _pathItemMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _callback.SerializeAsV3(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _pathItemMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _pathItemMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiCallbackSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiCallbackSerializationTests.cs
@@ -10,11 +10,12 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiCallbackSerializationTests
     {
-        private static readonly OpenApiCallback _callback = (OpenApiCallback)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Callbacks["onData"];
-        private static readonly Mock<OpenApiPathItem> _pathItemMock = new() { CallBase = true };
+        private readonly OpenApiCallback _callback;
+        private readonly Mock<OpenApiPathItem> _pathItemMock = new() { CallBase = true };
 
         public OpenApiCallbackSerializationTests()
         {
+            _callback = (OpenApiCallback)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Callbacks["onData"];
             _callback.PathItems[RuntimeExpression.Build("{$request.body#/callbackUrl}")] = _pathItemMock.Object;
         }
 

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiComponentsSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiComponentsSerializationTests.cs
@@ -8,20 +8,21 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiComponentsSerializationTests
     {
-        private static readonly OpenApiComponents _components = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Components;
-        private static readonly Mock<OpenApiSchema> _schemaMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiRequestBody> _requestBodyMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiResponse> _responseMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiParameter> _parameterMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiHeader> _headerMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiSecurityScheme> _securitySchemeMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiLink> _linkMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiCallback> _callbackMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiExample> _exampleMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiPathItem> _pathItemMock = new() { CallBase = true };
+        private readonly OpenApiComponents _components;
+        private readonly Mock<OpenApiSchema> _schemaMock = new() { CallBase = true };
+        private readonly Mock<OpenApiRequestBody> _requestBodyMock = new() { CallBase = true };
+        private readonly Mock<OpenApiResponse> _responseMock = new() { CallBase = true };
+        private readonly Mock<OpenApiParameter> _parameterMock = new() { CallBase = true };
+        private readonly Mock<OpenApiHeader> _headerMock = new() { CallBase = true };
+        private readonly Mock<OpenApiSecurityScheme> _securitySchemeMock = new() { CallBase = true };
+        private readonly Mock<OpenApiLink> _linkMock = new() { CallBase = true };
+        private readonly Mock<OpenApiCallback> _callbackMock = new() { CallBase = true };
+        private readonly Mock<OpenApiExample> _exampleMock = new() { CallBase = true };
+        private readonly Mock<OpenApiPathItem> _pathItemMock = new() { CallBase = true };
 
         public OpenApiComponentsSerializationTests()
         {
+            _components = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Components;
             _components.Schemas["pet"] = _schemaMock.Object;
             _components.RequestBodies["pet"] = _requestBodyMock.Object;
             _components.Responses["200"] = _responseMock.Object;

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiComponentsSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiComponentsSerializationTests.cs
@@ -1,0 +1,121 @@
+﻿using System.IO;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiComponentsSerializationTests
+    {
+        private static readonly OpenApiComponents _components = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Components;
+        private static readonly Mock<OpenApiSchema> _schemaMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiRequestBody> _requestBodyMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiResponse> _responseMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiParameter> _parameterMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiHeader> _headerMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiSecurityScheme> _securitySchemeMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiLink> _linkMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiCallback> _callbackMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiExample> _exampleMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiPathItem> _pathItemMock = new() { CallBase = true };
+
+        public OpenApiComponentsSerializationTests()
+        {
+            _components.Schemas["pet"] = _schemaMock.Object;
+            _components.RequestBodies["pet"] = _requestBodyMock.Object;
+            _components.Responses["200"] = _responseMock.Object;
+            _components.Parameters["limit"] = _parameterMock.Object;
+            _components.Headers["x-rate-limit"] = _headerMock.Object;
+            _components.SecuritySchemes["api_key"] = _securitySchemeMock.Object;
+            _components.Links["UserRepositories"] = _linkMock.Object;
+            _components.Callbacks["onData"] = _callbackMock.Object;
+            _components.Examples["cat"] = _exampleMock.Object;
+            _components.PathItems["/pets"] = _pathItemMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _components.SerializeAsV31(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _schemaMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _schemaMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _requestBodyMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _requestBodyMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _responseMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _responseMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _parameterMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _parameterMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _headerMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _headerMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _securitySchemeMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _securitySchemeMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _linkMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _linkMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _callbackMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _callbackMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _exampleMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _exampleMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _pathItemMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _pathItemMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _components.SerializeAsV3(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _schemaMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _schemaMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _requestBodyMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _requestBodyMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _responseMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _responseMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _parameterMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _parameterMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _headerMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _headerMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _securitySchemeMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _securitySchemeMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _linkMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _linkMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _callbackMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _callbackMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _exampleMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _exampleMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _pathItemMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _pathItemMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiDocumentMock.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiDocumentMock.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OpenApi.Tests.Mocks
     {
         public static OpenApiDocument CreateCompleteOpenApiDocument()
         {
-            var doc = new OpenApiDocument
+            return new OpenApiDocument
             {
                 Info = new OpenApiInfo
                 {
@@ -92,6 +92,13 @@ namespace Microsoft.OpenApi.Tests.Mocks
                                         Value = JsonValue.Create("Fluffy")
                                     }
                                 },
+                                Content = new Dictionary<string, OpenApiMediaType>
+                                {
+                                    ["application/json"] = new OpenApiMediaType
+                                    {
+                                        Schema = new OpenApiSchemaReference("Pet")
+                                    }
+                                }
                             }
                         ],
                         Operations = new Dictionary<HttpMethod, OpenApiOperation>
@@ -179,6 +186,17 @@ namespace Microsoft.OpenApi.Tests.Mocks
                                                         Summary = "An example cat",
                                                         Value = JsonValue.Create("Fluffy")
                                                     }
+                                                },
+                                                Content = new Dictionary<string, OpenApiMediaType>
+                                                {
+                                                    ["application/json"] = new OpenApiMediaType
+                                                    {
+                                                        Schema = new OpenApiSchema
+                                                        {
+                                                            Type = JsonSchemaType.Array,
+                                                            Items = new OpenApiSchemaReference("Pet")
+                                                        }
+                                                    }
                                                 }
                                             }
                                         },
@@ -233,8 +251,24 @@ namespace Microsoft.OpenApi.Tests.Mocks
                                             }
                                         }
                                     }
-                                }
-                            }
+                                },
+                                Security =
+                                [
+                                    new OpenApiSecurityRequirement
+                                    {
+                                        [new OpenApiSecuritySchemeReference("securitySchemeName1")] = [],
+                                        [new OpenApiSecuritySchemeReference("securitySchemeName2")] =
+                                        [
+                                            "scope1",
+                                            "scope2"
+                                        ]
+                                    }
+                                ],
+                                Tags = new HashSet<OpenApiTagReference>
+                                {
+                                    new OpenApiTagReference("tagId1", new OpenApiDocument{ Tags = new HashSet<OpenApiTag>() { new OpenApiTag{Name = "tagId1"}} })
+                                },
+                                                }
                         }
                     }
                 },
@@ -420,7 +454,6 @@ namespace Microsoft.OpenApi.Tests.Mocks
                     Url = new Uri("https://example.com/docs")
                 }
             };
-            return doc;
         }
     }
 

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiDocumentMock.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiDocumentMock.cs
@@ -1,0 +1,427 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json.Nodes;
+using Microsoft.OpenApi.Expressions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
+using Microsoft.OpenApi.Models.References;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public static class OpenApiDocumentMock
+    {
+        public static OpenApiDocument CreateCompleteOpenApiDocument()
+        {
+            var doc = new OpenApiDocument
+            {
+                Info = new OpenApiInfo
+                {
+                    Title = "Sample API",
+                    Version = "1.0.0"
+                },
+                Servers = new List<OpenApiServer>
+                {
+                    new() 
+                    {
+                        Url = "https://api.example.com",
+                        Description = "Production server"
+                    }
+                },
+                Webhooks = new Dictionary<string, IOpenApiPathItem>
+                {
+                    ["pets"] = new OpenApiPathItem
+                    {
+                        Operations = new()
+                        {
+                            [HttpMethod.Get] = new OpenApiOperation
+                            {
+                                Description = "Returns all pets from the system that the user has access to",
+                                OperationId = "findPets",
+                                Responses = new OpenApiResponses
+                                {
+                                    ["200"] = new OpenApiResponse
+                                    {
+                                        Description = "pet response",
+                                        Content = new()
+                                        {
+                                            ["application/json"] = new OpenApiMediaType
+                                            {
+                                                Schema = new OpenApiSchema()
+                                                {
+                                                    Type = JsonSchemaType.Array,
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                Paths = new OpenApiPaths
+                {
+                    ["/pets"] = new OpenApiPathItem
+                    {
+                        Servers =
+                        [
+                            new()
+                            {
+                                Url = "https://api.example.com",
+                                Description = "Production server"
+                            }
+                        ],
+                        Parameters =
+                        [
+                            new OpenApiParameter
+                            {
+                                Name = "limit",
+                                In = ParameterLocation.Query,
+                                Description = "How many items to return at one time (max 100)",
+                                Required = false,
+                                Schema = new OpenApiSchema
+                                {
+                                    Type = JsonSchemaType.Integer,
+                                    Format = "int32"
+                                },
+                                Examples = new Dictionary<string, IOpenApiExample>
+                                {
+                                    ["cat"] = new OpenApiExample
+                                    {
+                                        Summary = "An example cat",
+                                        Value = JsonValue.Create("Fluffy")
+                                    }
+                                },
+                            }
+                        ],
+                        Operations = new Dictionary<HttpMethod, OpenApiOperation>
+                        {
+                            [HttpMethod.Get] = new OpenApiOperation
+                            {
+                                Summary = "List all pets",
+                                Callbacks = new Dictionary<string, IOpenApiCallback>
+                                {
+                                    ["onData"] = new OpenApiCallback
+                                    {
+                                        PathItems = new Dictionary<RuntimeExpression, IOpenApiPathItem>
+                                        {
+                                            [RuntimeExpression.Build("{$request.body#/callbackUrl}")] = new OpenApiPathItem
+                                            {
+                                                Operations = new Dictionary<HttpMethod, OpenApiOperation>
+                                                {
+                                                    [HttpMethod.Post] = new OpenApiOperation
+                                                    {
+                                                        Responses = new OpenApiResponses
+                                                        {
+                                                            ["200"] = new OpenApiResponse { Description = "ok" }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                Parameters =
+                                [
+                                    new OpenApiParameter
+                                    {
+                                        Name = "limit",
+                                        In = ParameterLocation.Query,
+                                        Description = "How many items to return at one time (max 100)",
+                                        Required = false,
+                                        Schema = new OpenApiSchema
+                                        {
+                                            Type = JsonSchemaType.Integer,
+                                            Format = "int32"
+                                        }
+                                    }
+                                ],
+                                RequestBody =  new OpenApiRequestBody
+                                {
+                                    Content = new Dictionary<string, OpenApiMediaType>
+                                    {
+                                        ["application/json"] = new OpenApiMediaType
+                                        {
+                                            Schema = new OpenApiSchemaReference("Pet")
+                                        },
+                                        ["application/xml"] = new OpenApiMediaType
+                                        {
+                                            Schema = new OpenApiSchema
+                                            {
+                                                Type = JsonSchemaType.String,
+                                                Xml = new OpenApiXml
+                                                {
+                                                    Name = "name1",
+                                                    Namespace = new Uri("http://example.com/schema/namespaceSample"),
+                                                }
+                                            },
+                                        }
+                                    }
+                                },                                
+                                Responses = new OpenApiResponses
+                                {
+                                    ["200"] = new OpenApiResponse
+                                    {
+                                        Description = "A list of pets.",
+                                        Headers = new Dictionary<string, IOpenApiHeader>
+                                        {
+                                            ["x-rate-limit"] = new OpenApiHeader
+                                            {
+                                                Description = "The number of allowed requests in the current period",
+                                                Schema = new OpenApiSchema
+                                                {
+                                                    Type = JsonSchemaType.Integer
+                                                },
+                                                Examples = new Dictionary<string, IOpenApiExample>
+                                                {
+                                                    ["cat"] = new OpenApiExample
+                                                    {
+                                                        Summary = "An example cat",
+                                                        Value = JsonValue.Create("Fluffy")
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        Links = new Dictionary<string, IOpenApiLink>
+                                        {
+                                            ["UserRepositories"] = new OpenApiLink
+                                            {
+                                                OperationId = "getRepositoriesByUsername",
+                                                Parameters = new Dictionary<string, RuntimeExpressionAnyWrapper>
+                                                {
+                                                    ["username"] = new RuntimeExpressionAnyWrapper
+                                                    {
+                                                        Expression = RuntimeExpression.Build("$request.path.id")
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        Content = new Dictionary<string, OpenApiMediaType>
+                                        {
+                                            ["application/json"] = new OpenApiMediaType
+                                            {
+                                                Encoding = new Dictionary<string, OpenApiEncoding>
+                                                {
+                                                    ["x-rate-limit"] = new OpenApiEncoding
+                                                    {
+                                                        Headers = new Dictionary<string, IOpenApiHeader>
+                                                        {
+                                                            ["x-rate-limit"] = new OpenApiHeader
+                                                            {
+                                                                Description = "The number of allowed requests in the current period",
+                                                                Schema = new OpenApiSchema
+                                                                {
+                                                                    Type = JsonSchemaType.Integer
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                Schema = new OpenApiSchema
+                                                {
+                                                    Type = JsonSchemaType.Array,
+                                                    Items = new OpenApiSchemaReference("Pet")
+                                                },
+                                                Examples = new Dictionary<string, IOpenApiExample>
+                                                {
+                                                    ["cat"] = new OpenApiExample
+                                                    {
+                                                        Summary = "An example cat",
+                                                        Value = JsonValue.Create("Fluffy")
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                Components = new OpenApiComponents
+                {
+                    Schemas = new Dictionary<string, IOpenApiSchema>
+                    {
+                        ["pet"] = new OpenApiSchema
+                        {
+                            Type = JsonSchemaType.Object,
+                            Properties = new Dictionary<string, IOpenApiSchema>
+                            {
+                                ["id"] = new OpenApiSchema { Type = JsonSchemaType.Integer, Format = "int64" },
+                                ["name"] = new OpenApiSchema { Type = JsonSchemaType.String },
+                                ["tag"] = new OpenApiSchema { Type = JsonSchemaType.String }
+                            },
+                            Required = ["id", "name"]
+                        }
+                    },
+                    Parameters = new Dictionary<string, IOpenApiParameter>
+                    {
+                        ["limit"] = new OpenApiParameter
+                        {
+                            Name = "limit",
+                            In = ParameterLocation.Query,
+                            Description = "How many items to return at one time (max 100)",
+                            Required = false,
+                            Schema = new OpenApiSchema
+                            {
+                                Type = JsonSchemaType.Integer,
+                                Format = "int32"
+                            }
+                        }
+                    },
+                    Responses = new OpenApiResponses
+                    {
+                        ["200"] = new OpenApiResponse
+                        {
+                            Description = "A list of pets.",                            
+                            Content = new Dictionary<string, OpenApiMediaType>
+                            {
+                                ["application/json"] = new OpenApiMediaType
+                                {
+                                    Schema = new OpenApiSchema
+                                    {
+                                        Type = JsonSchemaType.Array,
+                                        Items = new OpenApiSchemaReference("Pet")
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    RequestBodies = new Dictionary<string, IOpenApiRequestBody>
+                    {
+                        ["pet"] = new OpenApiRequestBody
+                        {
+                            Content = new Dictionary<string, OpenApiMediaType>
+                            {
+                                ["application/json"] = new OpenApiMediaType
+                                {
+                                    Schema = new OpenApiSchemaReference("Pet")
+                                }
+                            }
+                        }
+                    },
+                    Links = new Dictionary<string, IOpenApiLink>
+                    {
+                        ["UserRepositories"] = new OpenApiLink
+                        {
+                            OperationId = "getRepositoriesByUsername",
+                            Parameters = new Dictionary<string, RuntimeExpressionAnyWrapper>
+                            {
+                                ["username"] = new RuntimeExpressionAnyWrapper
+                                {
+                                    Expression = RuntimeExpression.Build("$request.path.id")
+                                }
+                            }
+                        }
+                    },
+                    Headers = new Dictionary<string, IOpenApiHeader>
+                    {
+                        ["x-rate-limit"] = new OpenApiHeader
+                        {
+                            Description = "The number of allowed requests in the current period",
+                            Schema = new OpenApiSchema
+                            {
+                                Type = JsonSchemaType.Integer
+                            }
+                        }
+                    },
+                    Examples = new Dictionary<string, IOpenApiExample>
+                    {
+                        ["cat"] = new OpenApiExample
+                        {
+                            Summary = "An example cat",
+                            Value = JsonValue.Create("Fluffy")
+                        }
+                    },
+                    SecuritySchemes = new Dictionary<string, IOpenApiSecurityScheme>
+                    {
+                        ["api_key"] = new OpenApiSecurityScheme
+                        {
+                            Type = SecuritySchemeType.ApiKey,
+                            Name = "api_key",
+                            In = ParameterLocation.Header
+                        }
+                    },
+                    Callbacks = new Dictionary<string, IOpenApiCallback>
+                    {
+                        ["onData"] = new OpenApiCallback
+                        {
+                            PathItems = new Dictionary<RuntimeExpression, IOpenApiPathItem>
+                            {
+                                [RuntimeExpression.Build("{$request.body#/callbackUrl}")] = new OpenApiPathItem
+                                {
+                                    Operations = new Dictionary<HttpMethod, OpenApiOperation>
+                                    {
+                                        [HttpMethod.Post] = new OpenApiOperation
+                                        {
+                                            Responses = new OpenApiResponses
+                                            {
+                                                ["200"] = new OpenApiResponse { Description = "ok" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    PathItems = new Dictionary<string, IOpenApiPathItem>
+                    {
+                        ["/pets"] = new OpenApiPathItem
+                        {
+                            Operations = new Dictionary<HttpMethod, OpenApiOperation>
+                            {
+                                [HttpMethod.Get] = new OpenApiOperation
+                                {
+                                    Summary = "List all pets",
+                                    Responses = new OpenApiResponses
+                                    {
+                                        ["200"] = new OpenApiResponse
+                                        {
+                                            Description = "A list of pets.",
+                                            Content = new Dictionary<string, OpenApiMediaType>
+                                            {
+                                                ["application/json"] = new OpenApiMediaType
+                                                {
+                                                    Schema = new OpenApiSchema
+                                                    {
+                                                        Type = JsonSchemaType.Array,
+                                                        Items = new OpenApiSchemaReference("Pet")
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                Security =
+                [
+                    new OpenApiSecurityRequirement
+                    {
+                        {
+                            new OpenApiSecuritySchemeReference("api_key"),
+                            new List<string>()
+                        }
+                    }
+                ],
+                Tags =
+                [
+                    new OpenApiTag
+                    {
+                        Name = "pets",
+                        Description = "Operations related to pets"
+                    }
+                ],
+                ExternalDocs = new OpenApiExternalDocs
+                {
+                    Description = "Find out more",
+                    Url = new Uri("https://example.com/docs")
+                }
+            };
+            return doc;
+        }
+    }
+
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiDocumentSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiDocumentSerializationTests.cs
@@ -1,0 +1,91 @@
+﻿using System.IO;
+using System.Linq;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiDocumentSerializationTests
+    {
+        // test for PathItems, servers
+        private static readonly OpenApiDocument _document = OpenApiDocumentMock.CreateCompleteOpenApiDocument();
+        private static readonly Mock<OpenApiPathItem> _pathItemMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiPathItem> _webhookPathItemMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiServer> _serverMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiTag> _tagMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiSecurityRequirement> _securityMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiComponents> _componentsMock = new() { CallBase = true };
+
+        public OpenApiDocumentSerializationTests()
+        {
+            _document.Paths["/pets"] = _pathItemMock.Object;
+            _document.Webhooks["pets"] = _webhookPathItemMock.Object;
+            _document.Servers[0] = _serverMock.Object;
+            _document.Tags.ToList()[0] = _tagMock.Object;
+            _document.Security[0] = _securityMock.Object;
+            _document.Components = _componentsMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _document.SerializeAsV31(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _pathItemMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _pathItemMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _webhookPathItemMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _webhookPathItemMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _tagMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _tagMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _serverMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _serverMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _securityMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _securityMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _componentsMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _componentsMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _document.SerializeAsV3(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _pathItemMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _pathItemMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _serverMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _serverMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _webhookPathItemMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _webhookPathItemMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _tagMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _tagMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _securityMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _securityMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _componentsMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _componentsMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiDocumentSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiDocumentSerializationTests.cs
@@ -9,17 +9,17 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiDocumentSerializationTests
     {
-        // test for PathItems, servers
-        private static readonly OpenApiDocument _document = OpenApiDocumentMock.CreateCompleteOpenApiDocument();
-        private static readonly Mock<OpenApiPathItem> _pathItemMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiPathItem> _webhookPathItemMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiServer> _serverMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiTag> _tagMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiSecurityRequirement> _securityMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiComponents> _componentsMock = new() { CallBase = true };
+        private readonly OpenApiDocument _document;
+        private readonly Mock<OpenApiPathItem> _pathItemMock = new() { CallBase = true };
+        private readonly Mock<OpenApiPathItem> _webhookPathItemMock = new() { CallBase = true };
+        private readonly Mock<OpenApiServer> _serverMock = new() { CallBase = true };
+        private readonly Mock<OpenApiTag> _tagMock = new() { CallBase = true };
+        private readonly Mock<OpenApiSecurityRequirement> _securityMock = new() { CallBase = true };
+        private readonly Mock<OpenApiComponents> _componentsMock = new() { CallBase = true };
 
         public OpenApiDocumentSerializationTests()
         {
+            _document = OpenApiDocumentMock.CreateCompleteOpenApiDocument();
             _document.Paths["/pets"] = _pathItemMock.Object;
             _document.Webhooks["pets"] = _webhookPathItemMock.Object;
             _document.Servers[0] = _serverMock.Object;

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiEncodingSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiEncodingSerializationTests.cs
@@ -1,0 +1,51 @@
+﻿using System.IO;
+using System.Net.Http;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiEncodingSerializationTests
+    {
+        // test for header
+        private static readonly OpenApiEncoding _encoding = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Responses["200"].Content["application/json"].Encoding["x-rate-limit"];
+        private static readonly Mock<OpenApiHeader> _headerMock = new() { CallBase = true };
+
+        public OpenApiEncodingSerializationTests()
+        {
+            _encoding.Headers["x-encoding"] = _headerMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _encoding.SerializeAsV31(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _headerMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _headerMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _encoding.SerializeAsV3(writer);
+
+            // Assert - fail if V2 method is called
+            _headerMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+            _headerMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiEncodingSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiEncodingSerializationTests.cs
@@ -9,12 +9,12 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiEncodingSerializationTests
     {
-        // test for header
-        private static readonly OpenApiEncoding _encoding = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Responses["200"].Content["application/json"].Encoding["x-rate-limit"];
-        private static readonly Mock<OpenApiHeader> _headerMock = new() { CallBase = true };
+        private readonly OpenApiEncoding _encoding;
+        private readonly Mock<OpenApiHeader> _headerMock = new() { CallBase = true };
 
         public OpenApiEncodingSerializationTests()
         {
+            _encoding = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Responses["200"].Content["application/json"].Encoding["x-rate-limit"];
             _encoding.Headers["x-encoding"] = _headerMock.Object;
         }
 

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiHeaderSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiHeaderSerializationTests.cs
@@ -1,0 +1,66 @@
+﻿using System.IO;
+using System.Net.Http;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiHeaderSerializationTests
+    {
+        private static readonly OpenApiHeader _header = (OpenApiHeader)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Responses["200"].Headers["x-rate-limit"];
+        private static readonly Mock<OpenApiSchema> _schemaMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiExample> _exampleMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiMediaType> _mediaTypeMock = new() { CallBase = true };
+
+        public OpenApiHeaderSerializationTests()
+        {
+            _header.Schema = _schemaMock.Object;
+            _header.Examples["cat"] = _exampleMock.Object;
+            _header.Content["application/json"] = _mediaTypeMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _header.SerializeAsV31(writer);
+
+            // Assert
+            _schemaMock.Verify(h => h.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never);
+            _schemaMock.Verify(h => h.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never);
+
+            _exampleMock.Verify(h => h.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never);
+            _exampleMock.Verify(h => h.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never);
+
+            _mediaTypeMock.Verify(h => h.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never);
+            _mediaTypeMock.Verify(h => h.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never);
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _header.SerializeAsV3(writer);
+
+            // Assert
+            _schemaMock.Verify(h => h.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never);
+            _schemaMock.Verify(h => h.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never);
+
+            _exampleMock.Verify(h => h.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never);
+            _exampleMock.Verify(h => h.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never);
+
+            _mediaTypeMock.Verify(h => h.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never);
+            _mediaTypeMock.Verify(h => h.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never);
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiHeaderSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiHeaderSerializationTests.cs
@@ -9,13 +9,14 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiHeaderSerializationTests
     {
-        private static readonly OpenApiHeader _header = (OpenApiHeader)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Responses["200"].Headers["x-rate-limit"];
-        private static readonly Mock<OpenApiSchema> _schemaMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiExample> _exampleMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiMediaType> _mediaTypeMock = new() { CallBase = true };
+        private readonly OpenApiHeader _header;
+        private readonly Mock<OpenApiSchema> _schemaMock = new() { CallBase = true };
+        private readonly Mock<OpenApiExample> _exampleMock = new() { CallBase = true };
+        private readonly Mock<OpenApiMediaType> _mediaTypeMock = new() { CallBase = true };
 
         public OpenApiHeaderSerializationTests()
         {
+            _header = (OpenApiHeader)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Responses["200"].Headers["x-rate-limit"];
             _header.Schema = _schemaMock.Object;
             _header.Examples["cat"] = _exampleMock.Object;
             _header.Content["application/json"] = _mediaTypeMock.Object;

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiInfoSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiInfoSerializationTests.cs
@@ -8,12 +8,13 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiInfoSerializationTests
     {
-        private static readonly OpenApiInfo _info = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Info;
-        private static readonly Mock<OpenApiContact> _contactMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiLicense> _licenseMock = new() { CallBase = true };
+        private readonly OpenApiInfo _info;
+        private readonly Mock<OpenApiContact> _contactMock = new() { CallBase = true };
+        private readonly Mock<OpenApiLicense> _licenseMock = new() { CallBase = true };
 
         public OpenApiInfoSerializationTests()
         {
+            _info = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Info;
             _info.Contact = _contactMock.Object;
             _info.License = _licenseMock.Object;
         }

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiInfoSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiInfoSerializationTests.cs
@@ -1,0 +1,57 @@
+﻿using System.IO;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiInfoSerializationTests
+    {
+        private static readonly OpenApiInfo _info = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Info;
+        private static readonly Mock<OpenApiContact> _contactMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiLicense> _licenseMock = new() { CallBase = true };
+
+        public OpenApiInfoSerializationTests()
+        {
+            _info.Contact = _contactMock.Object;
+            _info.License = _licenseMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _info.SerializeAsV31(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _contactMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _contactMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _licenseMock.Verify(l => l.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _licenseMock.Verify(l => l.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _info.SerializeAsV3(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _contactMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _contactMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _licenseMock.Verify(l => l.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _licenseMock.Verify(l => l.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiMediaTypeSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiMediaTypeSerializationTests.cs
@@ -9,13 +9,14 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiMediaTypeSerializationTests
     {
-        private static readonly OpenApiMediaType _mediaType = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Responses["200"].Content["application/json"];
-        private static readonly Mock<OpenApiSchema> _schemaMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiEncoding> _encodingMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiExample> _exampleMock = new() { CallBase = true };
+        private readonly OpenApiMediaType _mediaType;
+        private readonly Mock<OpenApiSchema> _schemaMock = new() { CallBase = true };
+        private readonly Mock<OpenApiEncoding> _encodingMock = new() { CallBase = true };
+        private readonly Mock<OpenApiExample> _exampleMock = new() { CallBase = true };
 
         public OpenApiMediaTypeSerializationTests()
         {
+            _mediaType = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Responses["200"].Content["application/json"];
             _mediaType.Schema = _schemaMock.Object;
             _mediaType.Examples["cat"] = _exampleMock.Object;
             _mediaType.Examples["example"] = _exampleMock.Object;

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiMediaTypeSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiMediaTypeSerializationTests.cs
@@ -1,0 +1,67 @@
+﻿using System.IO;
+using System.Net.Http;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiMediaTypeSerializationTests
+    {
+        private static readonly OpenApiMediaType _mediaType = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Responses["200"].Content["application/json"];
+        private static readonly Mock<OpenApiSchema> _schemaMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiEncoding> _encodingMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiExample> _exampleMock = new() { CallBase = true };
+
+        public OpenApiMediaTypeSerializationTests()
+        {
+            _mediaType.Schema = _schemaMock.Object;
+            _mediaType.Examples["cat"] = _exampleMock.Object;
+            _mediaType.Examples["example"] = _exampleMock.Object;
+            _mediaType.Encoding["encoding"] = _encodingMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _mediaType.SerializeAsV31(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _schemaMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _schemaMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _encodingMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _encodingMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _exampleMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _exampleMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _mediaType.SerializeAsV3(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _schemaMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _schemaMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _encodingMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _encodingMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _exampleMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _exampleMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiOperationSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiOperationSerializationTests.cs
@@ -11,25 +11,23 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiOperationSerializationTests
     {
-        private static readonly OpenApiOperation _operation = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get];
-
-        private static readonly Mock<OpenApiCallback> _callbackMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiPathItem> _pathItemMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiRequestBody> _requestBodyMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiResponse> _responsesMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiParameter> _parameterMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiSecurityRequirement> _securityRequirementMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiTagReference> _tagMock = new() { CallBase = true };
+        private readonly OpenApiOperation _operation;
+        private readonly Mock<OpenApiCallback> _callbackMock = new() { CallBase = true };
+        private readonly Mock<OpenApiPathItem> _pathItemMock = new() { CallBase = true };
+        private readonly Mock<OpenApiRequestBody> _requestBodyMock = new() { CallBase = true };
+        private readonly Mock<OpenApiResponse> _responsesMock = new() { CallBase = true };
+        private readonly Mock<OpenApiParameter> _parameterMock = new() { CallBase = true };
+        private readonly Mock<OpenApiSecurityRequirement> _securityRequirementMock = new() { CallBase = true };
 
 
         public OpenApiOperationSerializationTests()
         {
+            _operation = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get];
             _operation.Callbacks["onData"] = _callbackMock.Object;
             _operation.Responses["200"] = _responsesMock.Object;
             _operation.RequestBody = _requestBodyMock.Object;
             _operation.Parameters[0] = _parameterMock.Object;
             _operation.Security[0] = _securityRequirementMock.Object;
-            _operation.Tags.ToList()[0] = _tagMock.Object;
         }
 
         [Fact]
@@ -60,9 +58,6 @@ namespace Microsoft.OpenApi.Tests.Mocks
 
             _securityRequirementMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
             _securityRequirementMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
-
-            _tagMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
-            _tagMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
         }
 
         [Fact]
@@ -93,9 +88,6 @@ namespace Microsoft.OpenApi.Tests.Mocks
 
             _securityRequirementMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
             _securityRequirementMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
-
-            _tagMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
-            _tagMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiOperationSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiOperationSerializationTests.cs
@@ -1,0 +1,101 @@
+﻿using System.IO;
+using System.Linq;
+using System.Net.Http;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.References;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiOperationSerializationTests
+    {
+        private static readonly OpenApiOperation _operation = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get];
+
+        private static readonly Mock<OpenApiCallback> _callbackMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiPathItem> _pathItemMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiRequestBody> _requestBodyMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiResponse> _responsesMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiParameter> _parameterMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiSecurityRequirement> _securityRequirementMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiTagReference> _tagMock = new() { CallBase = true };
+
+
+        public OpenApiOperationSerializationTests()
+        {
+            _operation.Callbacks["onData"] = _callbackMock.Object;
+            _operation.Responses["200"] = _responsesMock.Object;
+            _operation.RequestBody = _requestBodyMock.Object;
+            _operation.Parameters[0] = _parameterMock.Object;
+            _operation.Security[0] = _securityRequirementMock.Object;
+            _operation.Tags.ToList()[0] = _tagMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _operation.SerializeAsV31(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _callbackMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _callbackMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _pathItemMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _pathItemMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _requestBodyMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _requestBodyMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _responsesMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _responsesMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _parameterMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _parameterMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _securityRequirementMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _securityRequirementMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _tagMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _tagMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+            
+            // Act
+            _operation.SerializeAsV3(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _callbackMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _callbackMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _pathItemMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _pathItemMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _requestBodyMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _requestBodyMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _responsesMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _responsesMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _parameterMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _parameterMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _securityRequirementMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _securityRequirementMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _tagMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _tagMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiParameterSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiParameterSerializationTests.cs
@@ -8,13 +8,14 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiParameterSerializationTests
     {
-        private static readonly OpenApiParameter _parameter = (OpenApiParameter)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Parameters[0];
-        private static readonly Mock<OpenApiSchema> _schemaMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiMediaType> _contentMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiExample> _exampleMock = new() { CallBase = true };
+        private readonly OpenApiParameter _parameter;
+        private readonly Mock<OpenApiSchema> _schemaMock = new() { CallBase = true };
+        private readonly Mock<OpenApiMediaType> _contentMock = new() { CallBase = true };
+        private readonly Mock<OpenApiExample> _exampleMock = new() { CallBase = true };
 
         public OpenApiParameterSerializationTests()
         {
+            _parameter = (OpenApiParameter)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Parameters[0];
             _parameter.Schema = _schemaMock.Object;
             _parameter.Content["application/json"] = _contentMock.Object;
             _parameter.Examples["example"] = _exampleMock.Object;

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiParameterSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiParameterSerializationTests.cs
@@ -1,0 +1,65 @@
+﻿using System.IO;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiParameterSerializationTests
+    {
+        private static readonly OpenApiParameter _parameter = (OpenApiParameter)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Parameters[0];
+        private static readonly Mock<OpenApiSchema> _schemaMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiMediaType> _contentMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiExample> _exampleMock = new() { CallBase = true };
+
+        public OpenApiParameterSerializationTests()
+        {
+            _parameter.Schema = _schemaMock.Object;
+            _parameter.Content["application/json"] = _contentMock.Object;
+            _parameter.Examples["example"] = _exampleMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _parameter.SerializeAsV31(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _schemaMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _schemaMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _contentMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _contentMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _exampleMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _exampleMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _parameter.SerializeAsV3(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _schemaMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _schemaMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _contentMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _contentMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _exampleMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _exampleMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiPathItemSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiPathItemSerializationTests.cs
@@ -10,13 +10,14 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiPathItemSerializationTests
     {
-        private static readonly IOpenApiPathItem _pathItem = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"];
-        private static readonly Mock<OpenApiOperation> _operationMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiServer> _serverMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiParameter> _parameterMock = new() { CallBase = true };
+        private readonly IOpenApiPathItem _pathItem;
+        private readonly Mock<OpenApiOperation> _operationMock = new() { CallBase = true };
+        private readonly Mock<OpenApiServer> _serverMock = new() { CallBase = true };
+        private readonly Mock<OpenApiParameter> _parameterMock = new() { CallBase = true };
 
         public OpenApiPathItemSerializationTests()
         {
+            _pathItem = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"];
             _pathItem.Operations[HttpMethod.Get] = _operationMock.Object;
             _pathItem.Servers[0] = _serverMock.Object ;
             _pathItem.Parameters[0] = _parameterMock.Object;

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiPathItemSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiPathItemSerializationTests.cs
@@ -1,0 +1,67 @@
+﻿using System.IO;
+using System.Net.Http;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiPathItemSerializationTests
+    {
+        private static readonly IOpenApiPathItem _pathItem = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"];
+        private static readonly Mock<OpenApiOperation> _operationMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiServer> _serverMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiParameter> _parameterMock = new() { CallBase = true };
+
+        public OpenApiPathItemSerializationTests()
+        {
+            _pathItem.Operations[HttpMethod.Get] = _operationMock.Object;
+            _pathItem.Servers[0] = _serverMock.Object ;
+            _pathItem.Parameters[0] = _parameterMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _pathItem.SerializeAsV31(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _operationMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _operationMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _serverMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _serverMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _parameterMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _parameterMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _pathItem.SerializeAsV3(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _operationMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _operationMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _serverMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _serverMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+
+            _parameterMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _parameterMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiRequestBodySerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiRequestBodySerializationTests.cs
@@ -10,11 +10,12 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiRequestBodySerializationTests
     {
-        private static readonly IOpenApiRequestBody _requestBody = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].RequestBody;
-        private static readonly Mock<OpenApiMediaType> _mediaTypeMock = new() { CallBase = true };
+        private readonly IOpenApiRequestBody _requestBody;
+        private readonly Mock<OpenApiMediaType> _mediaTypeMock = new() { CallBase = true };
 
         public OpenApiRequestBodySerializationTests()
         {
+            _requestBody = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].RequestBody;
             _requestBody.Content["application/json"] = _mediaTypeMock.Object;
         }
 

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiRequestBodySerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiRequestBodySerializationTests.cs
@@ -1,0 +1,51 @@
+﻿using System.IO;
+using System.Net.Http;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiRequestBodySerializationTests
+    {
+        private static readonly IOpenApiRequestBody _requestBody = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].RequestBody;
+        private static readonly Mock<OpenApiMediaType> _mediaTypeMock = new() { CallBase = true };
+
+        public OpenApiRequestBodySerializationTests()
+        {
+            _requestBody.Content["application/json"] = _mediaTypeMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _requestBody.SerializeAsV31(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _mediaTypeMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _mediaTypeMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _requestBody.SerializeAsV3(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _mediaTypeMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _mediaTypeMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiResponseSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiResponseSerializationTests.cs
@@ -1,0 +1,67 @@
+﻿using System.IO;
+using System.Net.Http;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiResponseSerializationTests
+    {
+        private static readonly IOpenApiResponse _response = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Responses["200"];
+        private static readonly Mock<OpenApiHeader> _headerMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiMediaType> _mediaTypeMock = new() { CallBase = true };
+        private static readonly Mock<OpenApiLink> _linkMock = new() { CallBase = true };
+
+        public OpenApiResponseSerializationTests()
+        {
+            _response.Headers["x-rate-limit"] = _headerMock.Object;
+            _response.Content["application/json"] = _mediaTypeMock.Object;
+            _response.Links["UserRepositories"] = _linkMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _response.SerializeAsV31(writer);
+
+            // Assert
+            _headerMock.Verify(h => h.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never);
+            _headerMock.Verify(h => h.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never);
+
+            _mediaTypeMock.Verify(m => m.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never);
+            _mediaTypeMock.Verify(m => m.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never);
+
+            _linkMock.Verify(l => l.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never);
+            _linkMock.Verify(l => l.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never);
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _response.SerializeAsV3(writer);
+
+            // Assert
+            _headerMock.Verify(h => h.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never);
+            _headerMock.Verify(h => h.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never);
+
+            _mediaTypeMock.Verify(m => m.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never);
+            _mediaTypeMock.Verify(m => m.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never);
+
+            _linkMock.Verify(l => l.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never);
+            _linkMock.Verify(l => l.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never);
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiResponseSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiResponseSerializationTests.cs
@@ -10,13 +10,14 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiResponseSerializationTests
     {
-        private static readonly IOpenApiResponse _response = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Responses["200"];
-        private static readonly Mock<OpenApiHeader> _headerMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiMediaType> _mediaTypeMock = new() { CallBase = true };
-        private static readonly Mock<OpenApiLink> _linkMock = new() { CallBase = true };
+        private readonly IOpenApiResponse _response;
+        private readonly Mock<OpenApiHeader> _headerMock = new() { CallBase = true };
+        private readonly Mock<OpenApiMediaType> _mediaTypeMock = new() { CallBase = true };
+        private readonly Mock<OpenApiLink> _linkMock = new() { CallBase = true };
 
         public OpenApiResponseSerializationTests()
         {
+            _response = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Responses["200"];
             _response.Headers["x-rate-limit"] = _headerMock.Object;
             _response.Content["application/json"] = _mediaTypeMock.Object;
             _response.Links["UserRepositories"] = _linkMock.Object;

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiSchemaSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiSchemaSerializationTests.cs
@@ -9,11 +9,12 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiSchemaSerializationTests
     {
-        private static readonly OpenApiSchema _schema = (OpenApiSchema)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].RequestBody.Content["application/xml"].Schema;
-        private static readonly Mock<OpenApiXml> _xmlMock = new() { CallBase = true };
+        private readonly OpenApiSchema _schema;
+        private readonly Mock<OpenApiXml> _xmlMock = new() { CallBase = true };
 
         public OpenApiSchemaSerializationTests()
         {
+            _schema = (OpenApiSchema)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].Responses["200"].Content["application/json"].Schema;
             _schema.Xml = _xmlMock.Object;
         }
 

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiSchemaSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiSchemaSerializationTests.cs
@@ -1,0 +1,50 @@
+﻿using System.IO;
+using System.Net.Http;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiSchemaSerializationTests
+    {
+        private static readonly OpenApiSchema _schema = (OpenApiSchema)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Paths["/pets"].Operations[HttpMethod.Get].RequestBody.Content["application/xml"].Schema;
+        private static readonly Mock<OpenApiXml> _xmlMock = new() { CallBase = true };
+
+        public OpenApiSchemaSerializationTests()
+        {
+            _schema.Xml = _xmlMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _schema.SerializeAsV31(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _xmlMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _xmlMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _schema.SerializeAsV3(writer);
+
+            // Assert - fail if V2 method is called
+            _xmlMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+            _xmlMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiSecuritySchemeSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiSecuritySchemeSerializationTests.cs
@@ -8,11 +8,12 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiSecuritySchemeSerializationTests
     {
-        private static readonly OpenApiSecurityScheme _securityScheme = (OpenApiSecurityScheme)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Components.SecuritySchemes["api_key"];
-        private static readonly Mock<OpenApiOAuthFlows> _authFlowMock = new() { CallBase = true };
+        private readonly OpenApiSecurityScheme _securityScheme;
+        private readonly Mock<OpenApiOAuthFlows> _authFlowMock = new() { CallBase = true };
 
         public OpenApiSecuritySchemeSerializationTests()
         {
+            _securityScheme = (OpenApiSecurityScheme)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Components.SecuritySchemes["api_key"];
             _securityScheme.Flows = _authFlowMock.Object;
         }
 

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiSecuritySchemeSerializationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiSecuritySchemeSerializationTests.cs
@@ -1,0 +1,49 @@
+﻿using System.IO;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiSecuritySchemeSerializationTests
+    {
+        private static readonly OpenApiSecurityScheme _securityScheme = (OpenApiSecurityScheme)OpenApiDocumentMock.CreateCompleteOpenApiDocument().Components.SecuritySchemes["api_key"];
+        private static readonly Mock<OpenApiOAuthFlows> _authFlowMock = new() { CallBase = true };
+
+        public OpenApiSecuritySchemeSerializationTests()
+        {
+            _securityScheme.Flows = _authFlowMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _securityScheme.SerializeAsV31(writer);
+
+            // Assert
+            _authFlowMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _authFlowMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _securityScheme.SerializeAsV3(writer);
+
+            // Assert
+            _authFlowMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+            _authFlowMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiTagsSerialization.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiTagsSerialization.cs
@@ -9,11 +9,12 @@ namespace Microsoft.OpenApi.Tests.Mocks
 {
     public class OpenApiTagsSerialization
     {
-        private static readonly OpenApiTag _tag = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Tags.ToList()[0];
-        private static readonly Mock<OpenApiExternalDocs> _externalDocsMock = new() { CallBase = true };
+        private readonly OpenApiTag _tag;
+        private readonly Mock<OpenApiExternalDocs> _externalDocsMock = new() { CallBase = true };
 
         public OpenApiTagsSerialization()
         {
+            _tag = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Tags.ToList()[0];
             _tag.ExternalDocs = _externalDocsMock.Object;
         }
 

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiTagsSerialization.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiTagsSerialization.cs
@@ -1,0 +1,50 @@
+﻿using System.IO;
+using System.Linq;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Writers;
+using Moq;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Mocks
+{
+    public class OpenApiTagsSerialization
+    {
+        private static readonly OpenApiTag _tag = OpenApiDocumentMock.CreateCompleteOpenApiDocument().Tags.ToList()[0];
+        private static readonly Mock<OpenApiExternalDocs> _externalDocsMock = new() { CallBase = true };
+
+        public OpenApiTagsSerialization()
+        {
+            _tag.ExternalDocs = _externalDocsMock.Object;
+        }
+
+        [Fact]
+        public void SerializeAsV31_DoesNotCallV3OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _tag.SerializeAsV31(writer);
+
+            // Assert - fail if V2 or V3 methods are called
+            _externalDocsMock.Verify(c => c.SerializeAsV3(It.IsAny<IOpenApiWriter>()), Times.Never, "V3 method should not be called");
+            _externalDocsMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+        }
+
+        [Fact]
+        public void SerializeAsV3_DoesNotCallV31OrV2Serialization()
+        {
+            // Arrange
+            using var stringWriter = new StringWriter();
+            var writer = new OpenApiJsonWriter(stringWriter);
+
+            // Act
+            _tag.SerializeAsV3(writer);
+
+            // Assert - fail if V2 method is called
+            _externalDocsMock.Verify(c => c.SerializeAsV2(It.IsAny<IOpenApiWriter>()), Times.Never, "V2 method should not be called");
+            _externalDocsMock.Verify(c => c.SerializeAsV31(It.IsAny<IOpenApiWriter>()), Times.Never, "V31 method should not be called");
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -495,9 +495,9 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.Dictionary<Microsoft.OpenApi.Expressions.RuntimeExpression, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>? PathItems { get; set; }
         public void AddPathItem(Microsoft.OpenApi.Expressions.RuntimeExpression expression, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem pathItem) { }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback CreateShallowCopy() { }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiComponents : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
@@ -514,9 +514,9 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>? Responses { get; set; }
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Schemas { get; set; }
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme>? SecuritySchemes { get; set; }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public static class OpenApiConstants
     {
@@ -684,9 +684,9 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public string? Name { get; set; }
         public System.Uri? Url { get; set; }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiDiscriminator : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
@@ -739,9 +739,9 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>? Headers { get; set; }
         public Microsoft.OpenApi.Models.ParameterStyle? Style { get; set; }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiError
     {
@@ -761,9 +761,9 @@ namespace Microsoft.OpenApi.Models
         public string? Summary { get; set; }
         public System.Text.Json.Nodes.JsonNode? Value { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiExample CreateShallowCopy() { }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public abstract class OpenApiExtensibleDictionary<T> : System.Collections.Generic.Dictionary<string, T>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
         where T : Microsoft.OpenApi.Interfaces.IOpenApiSerializable
@@ -782,9 +782,9 @@ namespace Microsoft.OpenApi.Models
         public string? Description { get; set; }
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public System.Uri? Url { get; set; }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiHeader : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader
     {
@@ -802,9 +802,9 @@ namespace Microsoft.OpenApi.Models
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema? Schema { get; set; }
         public Microsoft.OpenApi.Models.ParameterStyle? Style { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader CreateShallowCopy() { }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiInfo : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
@@ -830,9 +830,9 @@ namespace Microsoft.OpenApi.Models
         public string? Identifier { get; set; }
         public string? Name { get; set; }
         public System.Uri? Url { get; set; }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiLink : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink
     {
@@ -845,9 +845,9 @@ namespace Microsoft.OpenApi.Models
         public Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper? RequestBody { get; set; }
         public Microsoft.OpenApi.Models.OpenApiServer? Server { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiLink CreateShallowCopy() { }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiMediaType : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
@@ -858,9 +858,9 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; set; }
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema? Schema { get; set; }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiOAuthFlow : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
@@ -884,9 +884,9 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public Microsoft.OpenApi.Models.OpenApiOAuthFlow? Implicit { get; set; }
         public Microsoft.OpenApi.Models.OpenApiOAuthFlow? Password { get; set; }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiOperation : Microsoft.OpenApi.Interfaces.IMetadataContainer, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
@@ -907,9 +907,9 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.List<Microsoft.OpenApi.Models.OpenApiServer>? Servers { get; set; }
         public string? Summary { get; set; }
         public System.Collections.Generic.HashSet<Microsoft.OpenApi.Models.References.OpenApiTagReference>? Tags { get; set; }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiParameter : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter
     {
@@ -929,9 +929,9 @@ namespace Microsoft.OpenApi.Models
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema? Schema { get; set; }
         public Microsoft.OpenApi.Models.ParameterStyle? Style { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter CreateShallowCopy() { }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiPathItem : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem, Microsoft.OpenApi.Models.Interfaces.IOpenApiSummarizedElement
     {
@@ -944,9 +944,9 @@ namespace Microsoft.OpenApi.Models
         public string? Summary { get; set; }
         public void AddOperation(System.Net.Http.HttpMethod operationType, Microsoft.OpenApi.Models.OpenApiOperation operation) { }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem CreateShallowCopy() { }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiPaths : Microsoft.OpenApi.Models.OpenApiExtensibleDictionary<Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>
     {
@@ -982,9 +982,9 @@ namespace Microsoft.OpenApi.Models
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter ConvertToBodyParameter(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter> ConvertToFormDataParameters(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody CreateShallowCopy() { }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiResponse : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse
     {
@@ -995,9 +995,9 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>? Headers { get; set; }
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>? Links { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse CreateShallowCopy() { }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiResponses : Microsoft.OpenApi.Models.OpenApiExtensibleDictionary<Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>
     {
@@ -1058,16 +1058,16 @@ namespace Microsoft.OpenApi.Models
         public bool WriteOnly { get; set; }
         public Microsoft.OpenApi.Models.OpenApiXml? Xml { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema CreateShallowCopy() { }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiSecurityRequirement : System.Collections.Generic.Dictionary<Microsoft.OpenApi.Models.References.OpenApiSecuritySchemeReference, System.Collections.Generic.List<string>>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
         public OpenApiSecurityRequirement() { }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiSecurityScheme : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme
     {
@@ -1082,9 +1082,9 @@ namespace Microsoft.OpenApi.Models
         public string? Scheme { get; set; }
         public Microsoft.OpenApi.Models.SecuritySchemeType? Type { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme CreateShallowCopy() { }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiServer : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
@@ -1094,9 +1094,9 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public string? Url { get; set; }
         public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiServerVariable>? Variables { get; set; }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiServerVariable : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
@@ -1118,9 +1118,9 @@ namespace Microsoft.OpenApi.Models
         public Microsoft.OpenApi.Models.OpenApiExternalDocs? ExternalDocs { get; set; }
         public string? Name { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiTag CreateShallowCopy() { }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public class OpenApiXml : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiSerializable
     {
@@ -1132,9 +1132,9 @@ namespace Microsoft.OpenApi.Models
         public System.Uri? Namespace { get; set; }
         public string? Prefix { get; set; }
         public bool Wrapped { get; set; }
-        public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
-        public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
+        public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
     }
     public enum ParameterLocation
     {


### PR DESCRIPTION
Uses spies in Moq to inspect and record the sequence in which serialization methods are called in the model classes during routing.

Fixes #2081