### PR TITLE
fix: discriminator mapping references don't get a document when created from DOM

### DIFF
--- a/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
@@ -932,11 +932,34 @@ namespace Microsoft.OpenApi.Services
                 Walk("additionalProperties", () => Walk(schema.AdditionalProperties));
             }
 
+            Walk("discriminator", () => Walk(schema.Discriminator));
+
             Walk(OpenApiConstants.ExternalDocs, () => Walk(schema.ExternalDocs));
 
             Walk(schema as IOpenApiExtensible);
 
             _schemaLoop.Pop();
+        }
+
+        internal void Walk(OpenApiDiscriminator? openApiDiscriminator)
+        {
+            if (openApiDiscriminator == null)
+            {
+                return;
+            }
+
+            _visitor.Visit(openApiDiscriminator);
+
+            if (openApiDiscriminator.Mapping != null)
+            {
+                Walk("mapping", () =>
+                {
+                    foreach (var item in openApiDiscriminator.Mapping)
+                    {
+                        Walk(item.Key, () => Walk((IOpenApiSchema)item.Value));
+                    }
+                });
+            }
         }
 
 
@@ -1215,6 +1238,7 @@ namespace Microsoft.OpenApi.Services
                 case OpenApiRequestBody e: Walk(e); break;
                 case OpenApiResponse e: Walk(e); break;
                 case OpenApiSchema e: Walk(e); break;
+                case OpenApiDiscriminator e: Walk(e); break;
                 case OpenApiSecurityRequirement e: Walk(e); break;
                 case OpenApiSecurityScheme e: Walk(e); break;
                 case OpenApiServer e: Walk(e); break;

--- a/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
@@ -158,7 +158,23 @@ namespace Microsoft.OpenApi.Tests.Walkers
         [Fact]
         public void LocateReferences()
         {
-            var baseSchema = new OpenApiSchema();
+            var baseSchema = new OpenApiSchema
+            {
+                Type = JsonSchemaType.Object,
+                Properties = new()
+                {
+                    ["type"] = new OpenApiSchema() { Type = JsonSchemaType.String }
+                },
+                Required = new HashSet<string> { "type" },
+                Discriminator = new OpenApiDiscriminator
+                {
+                    PropertyName = "type",
+                    Mapping = new Dictionary<string, OpenApiSchemaReference>
+                    {
+                        ["derived"] = new OpenApiSchemaReference("derived")
+                    }
+                }
+            };
 
             var derivedSchema = new OpenApiSchema
             {
@@ -229,7 +245,8 @@ namespace Microsoft.OpenApi.Tests.Walkers
                 "referenceAt: #/paths/~1/get/responses/200/headers/test-header",
                 "referenceAt: #/components/schemas/derived/anyOf/0",
                 "referenceAt: #/components/securitySchemes/test-secScheme",
-                "referenceAt: #/components/headers/test-header/schema"
+                "referenceAt: #/components/headers/test-header/schema",
+                "referenceAt: #/components/schemas/base/discriminator/mapping/derived",
             }, locator.Locations.Where(l => l.StartsWith("referenceAt:", StringComparison.OrdinalIgnoreCase)));
         }
     }


### PR DESCRIPTION
Signed-off-by: Vincent Biret <vibiret@microsoft.com>
