### PR TITLE
fix: tree node has the wrong structure because of trailing slashes

### DIFF
--- a/src/Microsoft.OpenApi/Services/OpenApiUrlTreeNode.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiUrlTreeNode.cs
@@ -59,7 +59,7 @@ namespace Microsoft.OpenApi.Services
         {
             Utils.CheckArgumentNullOrEmpty(label);
 
-            return PathItems is not null && PathItems.TryGetValue(label, out var item) && item.Operations is not null && item.Operations.Any();
+            return PathItems is not null && PathItems.TryGetValue(label, out var item) && item.Operations is { Count : > 0 };
         }
 
         /// <summary>
@@ -151,13 +151,6 @@ namespace Microsoft.OpenApi.Services
             }
 
             var segments = path.Split('/');
-            if (path.EndsWith("/", StringComparison.OrdinalIgnoreCase))
-            {
-                // Remove the last element, which is empty, and append the trailing slash to the new last element
-                // This is to support URLs with trailing slashes
-                Array.Resize(ref segments, segments.Length - 1);
-                segments[segments.Length - 1] += @"\";
-            }
 
             return Attach(segments: segments,
                           pathItem: pathItem,
@@ -179,13 +172,21 @@ namespace Microsoft.OpenApi.Services
                                           string currentPath)
         {
             var segment = segments.FirstOrDefault();
-            if (string.IsNullOrEmpty(segment))
+            // empty segment is significant
+            if (segment is null)
             {
                 if (PathItems.ContainsKey(label))
                 {
                     throw new ArgumentException($"A duplicate label already exists for this node: {label}", nameof(label));
                 }
 
+                Path = currentPath;
+                PathItems.Add(label, pathItem);
+                return this;
+            }
+            // special casing for '/' (root node)
+            if (segment.Length == 0 && currentPath.Length == 0)
+            {
                 Path = currentPath;
                 PathItems.Add(label, pathItem);
                 return this;

--- a/test/Microsoft.OpenApi.Tests/Services/OpenApiUrlTreeNodeTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Services/OpenApiUrlTreeNodeTests.cs
@@ -231,6 +231,66 @@ namespace Microsoft.OpenApi.Tests.Services
         }
 
         [Fact]
+        public void CreatePathsWithTrailingSlashWorks()
+        {
+            var doc = new OpenApiDocument
+            {
+                Paths = new()
+                {
+                    ["/"] = new OpenApiPathItem(),
+                    ["/cars"] = new OpenApiPathItem(),
+                    ["/cars/"] = new OpenApiPathItem(),
+                    ["/cars/coupes"] = new OpenApiPathItem()
+                }
+            };
+
+            var label = "assets";
+            var rootNode = OpenApiUrlTreeNode.Create(doc, label);
+
+            Assert.NotNull(rootNode);
+            Assert.Single(rootNode.Children);
+            var carsNode = rootNode.Children["cars"];
+            Assert.Equal("cars", carsNode.Segment);
+            Assert.Equal(2, carsNode.Children.Count);
+            var emptyNode = carsNode.Children[""];
+            Assert.Empty(emptyNode.Segment);
+            Assert.Empty(emptyNode.Children);
+            var coupesNode = carsNode.Children["coupes"];
+            Assert.Equal("coupes", coupesNode.Segment);
+            Assert.Empty(coupesNode.Children);
+        }
+
+        [Fact]
+        public void CreatePathsWithTrailingSlashWorksInverted()
+        {
+            var doc = new OpenApiDocument
+            {
+                Paths = new()
+                {
+                    ["/"] = new OpenApiPathItem(),
+                    ["/cars/"] = new OpenApiPathItem(),
+                    ["/cars"] = new OpenApiPathItem(), // only difference from previous test, tests that node mapping is not order specific
+                    ["/cars/coupes"] = new OpenApiPathItem()
+                }
+            };
+
+            var label = "assets";
+            var rootNode = OpenApiUrlTreeNode.Create(doc, label);
+
+            Assert.NotNull(rootNode);
+            Assert.Single(rootNode.Children);
+            var carsNode = rootNode.Children["cars"];
+            Assert.Equal("cars", carsNode.Segment);
+            Assert.Equal(2, carsNode.Children.Count);
+            var emptyNode = carsNode.Children[""];
+            Assert.Empty(emptyNode.Segment);
+            Assert.Empty(emptyNode.Children);
+            var coupesNode = carsNode.Children["coupes"];
+            Assert.Equal("coupes", coupesNode.Segment);
+            Assert.Empty(coupesNode.Children);
+        }
+
+        [Fact]
         public void HasOperationsWorks()
         {
             var doc1 = new OpenApiDocument
@@ -468,16 +528,16 @@ namespace Microsoft.OpenApi.Tests.Services
             await Verifier.Verify(diagram);
         }
 
-        public static TheoryData<string, string[], string, string> SupportsTrailingSlashesInPathData => new TheoryData<string, string[], string, string>
+        public static TheoryData<string, string[], string> SupportsTrailingSlashesInPathData => new TheoryData<string, string[], string>
         {
             // Path, children up to second to leaf, last expected leaf node name, expected leaf node path
-            { "/cars/{car-id}/build/", ["cars", "{car-id}"], @"build\", @"\cars\{car-id}\build\" },
-            { "/cars/", [], @"cars\", @"\cars\" },
+            { "/cars/{car-id}/build/", ["cars", "{car-id}", "build"], @"\cars\{car-id}\build\" },
+            { "/cars/", ["cars"], @"\cars\" },
         };
 
         [Theory]
         [MemberData(nameof(SupportsTrailingSlashesInPathData))]
-        public void SupportsTrailingSlashesInPath(string path, string[] childrenBeforeLastNode, string expectedLeafNodeName, string expectedLeafNodePath)
+        public void SupportsTrailingSlashesInPath(string path, string[] childrenBeforeLastNode, string expectedLeafNodePath)
         {
             var openApiDocument = new OpenApiDocument
             {
@@ -496,7 +556,7 @@ namespace Microsoft.OpenApi.Tests.Services
                 secondToLeafNode = secondToLeafNode.Children[childName];
             }
 
-            Assert.True(secondToLeafNode.Children.TryGetValue(expectedLeafNodeName, out var leafNode));
+            Assert.True(secondToLeafNode.Children.TryGetValue(string.Empty, out var leafNode));
             Assert.Equal(expectedLeafNodePath, leafNode.Path);
             Assert.Empty(leafNode.Children);
         }


### PR DESCRIPTION
Signed-off-by: Vincent Biret <vibiret@microsoft.com>
