### PR TITLE
feat: Add writer settings to enable sorting using a comparer

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Extensions/OpenApiExtensibleExtensions.cs
+++ b/src/Microsoft.OpenApi.Hidi/Extensions/OpenApiExtensibleExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OpenApi.Hidi.Extensions
         /// <param name="extensions">A dictionary of <see cref="IOpenApiExtension"/>.</param>
         /// <param name="extensionKey">The key corresponding to the <see cref="IOpenApiExtension"/>.</param>
         /// <returns>A <see cref="string"/> value matching the provided extensionKey. Return null when extensionKey is not found. </returns>
-        internal static string GetExtension(this Dictionary<string, IOpenApiExtension> extensions, string extensionKey)
+        internal static string GetExtension(this IDictionary<string, IOpenApiExtension> extensions, string extensionKey)
         {
             if (extensions.TryGetValue(extensionKey, out var value) && value is JsonNodeExtension { Node: JsonValue castValue } && castValue.TryGetValue<string>(out var stringValue))
             {

--- a/src/Microsoft.OpenApi.Hidi/StatsVisitor.cs
+++ b/src/Microsoft.OpenApi.Hidi/StatsVisitor.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OpenApi.Hidi
 
         public int HeaderCount { get; set; }
 
-        public override void Visit(Dictionary<string, IOpenApiHeader> headers)
+        public override void Visit(IDictionary<string, IOpenApiHeader> headers)
         {
             HeaderCount++;
         }

--- a/src/Microsoft.OpenApi.Workbench/StatsVisitor.cs
+++ b/src/Microsoft.OpenApi.Workbench/StatsVisitor.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OpenApi.Workbench
 
         public int HeaderCount { get; set; }
 
-        public override void Visit(Dictionary<string, IOpenApiHeader> headers)
+        public override void Visit(IDictionary<string, IOpenApiHeader> headers)
         {
             HeaderCount++;
         }

--- a/src/Microsoft.OpenApi/Extensions/DictionaryExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.OpenApi.Extensions
+{
+    /// <summary>
+    /// Dictionary extension methods
+    /// </summary>
+    public static class DictionaryExtensions
+    {
+        /// <summary>
+        /// Returns a new dictionary with entries sorted by key using the default comparer.
+        /// </summary>
+        public static IDictionary<TKey, TValue> Sort<TKey, TValue>(
+            this IDictionary<TKey, TValue> source)
+            where TKey : notnull
+        {
+#if NET7_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(nameof(source));
+#else
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+#endif
+
+            return source.OrderBy(kvp => kvp.Key)
+                               .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        }
+
+        /// <summary>
+        /// Returns a new dictionary with entries sorted by key using a custom comparer.
+        /// </summary>
+        public static IDictionary<TKey, TValue> Sort<TKey, TValue>(
+            this IDictionary<TKey, TValue> source,
+            IComparer<TKey> comparer)
+            where TKey : notnull
+        {
+#if NET7_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(nameof(source));
+            ArgumentNullException.ThrowIfNull(nameof(comparer));
+#else
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            if (comparer == null)
+                throw new ArgumentNullException(nameof(comparer));
+#endif
+            return source.OrderBy(kvp => kvp.Key, comparer)
+                               .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+        }
+    }
+}

--- a/src/Microsoft.OpenApi/Extensions/OpenApiExtensibleExtensions.cs
+++ b/src/Microsoft.OpenApi/Extensions/OpenApiExtensibleExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.OpenApi.Extensions
                 throw new OpenApiException(string.Format(SRResource.ExtensionFieldNameMustBeginWithXDash, name));
             }
 
-            element.Extensions ??= [];
+            element.Extensions ??= new Dictionary<string, IOpenApiExtension>();
             element.Extensions[name] = Utils.CheckArgumentNull(any);
         }
     }

--- a/src/Microsoft.OpenApi/Interfaces/IMetadataContainer.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IMetadataContainer.cs
@@ -14,5 +14,5 @@ public interface IMetadataContainer
     /// A collection of properties associated with the current OpenAPI element to be used by the application.
     /// Metadata are NOT (de)serialized with the schema and can be used for custom properties.
     /// </summary>
-    Dictionary<string, object>? Metadata { get; set; }
+    IDictionary<string, object>? Metadata { get; set; }
 }

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiExtensible.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiExtensible.cs
@@ -13,6 +13,6 @@ namespace Microsoft.OpenApi.Interfaces
         /// <summary>
         /// Specification extensions.
         /// </summary>
-        Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
     }
 }

--- a/src/Microsoft.OpenApi/Interfaces/IOpenApiReadOnlyExtensible.cs
+++ b/src/Microsoft.OpenApi/Interfaces/IOpenApiReadOnlyExtensible.cs
@@ -10,6 +10,6 @@ public interface IOpenApiReadOnlyExtensible
     /// <summary>
     /// Specification extensions.
     /// </summary>
-    Dictionary<string, IOpenApiExtension>? Extensions { get; }
+    IDictionary<string, IOpenApiExtension>? Extensions { get; }
 
 }

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiHeader.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiHeader.cs
@@ -55,11 +55,11 @@ public interface IOpenApiHeader : IOpenApiDescribedElement, IOpenApiReadOnlyExte
     /// <summary>
     /// Examples of the media type.
     /// </summary>
-    public Dictionary<string, IOpenApiExample>? Examples { get; }
+    public IDictionary<string, IOpenApiExample>? Examples { get; }
 
     /// <summary>
     /// A map containing the representations for the header.
     /// </summary>
-    public Dictionary<string, OpenApiMediaType>? Content { get; }
+    public IDictionary<string, OpenApiMediaType>? Content { get; }
 
 }

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiLink.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiLink.cs
@@ -24,7 +24,7 @@ public interface IOpenApiLink : IOpenApiDescribedElement, IOpenApiReadOnlyExtens
     /// <summary>
     /// A map representing parameters to pass to an operation as specified with operationId or identified via operationRef.
     /// </summary>
-    public Dictionary<string, RuntimeExpressionAnyWrapper>? Parameters { get; }
+    public IDictionary<string, RuntimeExpressionAnyWrapper>? Parameters { get; }
 
     /// <summary>
     /// A literal value or {expression} to use as a request body when calling the target operation.

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiParameter.cs
@@ -81,7 +81,7 @@ public interface IOpenApiParameter : IOpenApiDescribedElement, IOpenApiReadOnlyE
     /// Furthermore, if referencing a schema which contains an example,
     /// the examples value SHALL override the example provided by the schema.
     /// </summary>
-    public Dictionary<string, IOpenApiExample>? Examples { get; }
+    public IDictionary<string, IOpenApiExample>? Examples { get; }
 
     /// <summary>
     /// Example of the media type. The example SHOULD match the specified schema and encoding properties
@@ -102,5 +102,5 @@ public interface IOpenApiParameter : IOpenApiDescribedElement, IOpenApiReadOnlyE
     /// When example or examples are provided in conjunction with the schema object,
     /// the example MUST follow the prescribed serialization strategy for the parameter.
     /// </summary>
-    public Dictionary<string, OpenApiMediaType>? Content { get; }    
+    public IDictionary<string, OpenApiMediaType>? Content { get; }    
 }

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiRequestBody.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiRequestBody.cs
@@ -19,7 +19,7 @@ public interface IOpenApiRequestBody : IOpenApiDescribedElement, IOpenApiReadOnl
     /// REQUIRED. The content of the request body. The key is a media type or media type range and the value describes it.
     /// For requests that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
     /// </summary>
-    public Dictionary<string, OpenApiMediaType>? Content { get; }
+    public IDictionary<string, OpenApiMediaType>? Content { get; }
     /// <summary>
     /// Converts the request body to a body parameter in preparation for a v2 serialization.
     /// </summary>

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiResponse.cs
@@ -12,18 +12,18 @@ public interface IOpenApiResponse : IOpenApiDescribedElement, IOpenApiReadOnlyEx
     /// <summary>
     /// Maps a header name to its definition.
     /// </summary>
-    public Dictionary<string, IOpenApiHeader>? Headers { get; }
+    public IDictionary<string, IOpenApiHeader>? Headers { get; }
 
     /// <summary>
     /// A map containing descriptions of potential response payloads.
     /// The key is a media type or media type range and the value describes it.
     /// </summary>
-    public Dictionary<string, OpenApiMediaType>? Content { get; }
+    public IDictionary<string, OpenApiMediaType>? Content { get; }
 
     /// <summary>
     /// A map of operations links that can be followed from the response.
     /// The key of the map is a short name for the link,
     /// following the naming constraints of the names for Component Objects.
     /// </summary>
-    public Dictionary<string, IOpenApiLink>? Links { get; }
+    public IDictionary<string, IOpenApiLink>? Links { get; }
 }

--- a/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/Interfaces/IOpenApiSchema.cs
@@ -36,7 +36,7 @@ public interface IOpenApiSchema : IOpenApiDescribedElement, IOpenApiReadOnlyExte
     /// <summary>
     /// $vocabulary- used in meta-schemas to identify the vocabularies available for use in schemas described by that meta-schema.
     /// </summary>
-    public Dictionary<string, bool>? Vocabulary { get; }
+    public IDictionary<string, bool>? Vocabulary { get; }
 
     /// <summary>
     /// $dynamicRef - an applicator that allows for deferring the full resolution until runtime, at which point it is resolved each time it is encountered while evaluating an instance
@@ -52,7 +52,7 @@ public interface IOpenApiSchema : IOpenApiDescribedElement, IOpenApiReadOnlyExte
     /// $defs - reserves a location for schema authors to inline re-usable JSON Schemas into a more general schema. 
     /// The keyword does not directly affect the validation result
     /// </summary>
-    public Dictionary<string, IOpenApiSchema>? Definitions { get; }
+    public IDictionary<string, IOpenApiSchema>? Definitions { get; }
 
     /// <summary>
     /// Follow JSON Schema definition: https://tools.ietf.org/html/draft-fge-json-schema-validation-00
@@ -196,7 +196,7 @@ public interface IOpenApiSchema : IOpenApiDescribedElement, IOpenApiReadOnlyExte
     /// Follow JSON Schema definition: https://tools.ietf.org/html/draft-fge-json-schema-validation-00
     /// Property definitions MUST be a Schema Object and not a standard JSON Schema (inline or referenced).
     /// </summary>
-    public Dictionary<string, IOpenApiSchema>? Properties { get; }
+    public IDictionary<string, IOpenApiSchema>? Properties { get; }
 
     /// <summary>
     /// Follow JSON Schema definition: https://tools.ietf.org/html/draft-fge-json-schema-validation-00
@@ -205,7 +205,7 @@ public interface IOpenApiSchema : IOpenApiDescribedElement, IOpenApiReadOnlyExte
     /// egular expression dialect. Each property value of this object MUST be an object, and each object MUST 
     /// be a valid Schema Object not a standard JSON Schema.
     /// </summary>
-    public Dictionary<string, IOpenApiSchema>? PatternProperties { get; }
+    public IDictionary<string, IOpenApiSchema>? PatternProperties { get; }
 
     /// <summary>
     /// Follow JSON Schema definition: https://tools.ietf.org/html/draft-fge-json-schema-validation-00
@@ -279,10 +279,10 @@ public interface IOpenApiSchema : IOpenApiDescribedElement, IOpenApiReadOnlyExte
     /// <summary>
     /// This object stores any unrecognized keywords found in the schema.
     /// </summary>
-    public Dictionary<string, JsonNode>? UnrecognizedKeywords { get; }
+    public IDictionary<string, JsonNode>? UnrecognizedKeywords { get; }
 
     /// <summary>
     /// Follow JSON Schema definition:https://json-schema.org/draft/2020-12/json-schema-validation#section-6.5.4
     /// </summary>
-    public Dictionary<string, HashSet<string>>? DependentRequired { get; }
+    public IDictionary<string, HashSet<string>>? DependentRequired { get; }
 }

--- a/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiCallback.cs
@@ -22,7 +22,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameter-less constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiComponents.cs
@@ -19,57 +19,57 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// An object to hold reusable <see cref="IOpenApiSchema"/> Objects.
         /// </summary>
-        public Dictionary<string, IOpenApiSchema>? Schemas { get; set; }
+        public IDictionary<string, IOpenApiSchema>? Schemas { get; set; }
 
         /// <summary>
         /// An object to hold reusable <see cref="IOpenApiResponse"/> Objects.
         /// </summary>
-        public Dictionary<string, IOpenApiResponse>? Responses { get; set; }
+        public IDictionary<string, IOpenApiResponse>? Responses { get; set; }
 
         /// <summary>
         /// An object to hold reusable <see cref="IOpenApiParameter"/> Objects.
         /// </summary>
-        public Dictionary<string, IOpenApiParameter>? Parameters { get; set; }
+        public IDictionary<string, IOpenApiParameter>? Parameters { get; set; }
 
         /// <summary>
         /// An object to hold reusable <see cref="OpenApiExample"/> Objects.
         /// </summary>
-        public Dictionary<string, IOpenApiExample>? Examples { get; set; }
+        public IDictionary<string, IOpenApiExample>? Examples { get; set; }
 
         /// <summary>
         /// An object to hold reusable <see cref="IOpenApiRequestBody"/> Objects.
         /// </summary>
-        public Dictionary<string, IOpenApiRequestBody>? RequestBodies { get; set; }
+        public IDictionary<string, IOpenApiRequestBody>? RequestBodies { get; set; }
 
         /// <summary>
         /// An object to hold reusable <see cref="IOpenApiHeader"/> Objects.
         /// </summary>
-        public Dictionary<string, IOpenApiHeader>? Headers { get; set; }
+        public IDictionary<string, IOpenApiHeader>? Headers { get; set; }
 
         /// <summary>
         /// An object to hold reusable <see cref="IOpenApiSecurityScheme"/> Objects.
         /// </summary>
-        public Dictionary<string, IOpenApiSecurityScheme>? SecuritySchemes { get; set; }
+        public IDictionary<string, IOpenApiSecurityScheme>? SecuritySchemes { get; set; }
 
         /// <summary>
         /// An object to hold reusable <see cref="IOpenApiLink"/> Objects.
         /// </summary>
-        public Dictionary<string, IOpenApiLink>? Links { get; set; }
+        public IDictionary<string, IOpenApiLink>? Links { get; set; }
 
         /// <summary>
         /// An object to hold reusable <see cref="OpenApiCallback"/> Objects.
         /// </summary>
-        public Dictionary<string, IOpenApiCallback>? Callbacks { get; set; }
+        public IDictionary<string, IOpenApiCallback>? Callbacks { get; set; }
 
         /// <summary>
         /// An object to hold reusable <see cref="IOpenApiPathItem"/> Object.
         /// </summary>
-        public Dictionary<string, IOpenApiPathItem>? PathItems { get; set; }
+        public IDictionary<string, IOpenApiPathItem>? PathItems { get; set; }
 
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameter-less constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiContact.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiContact.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameter-less constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiDiscriminator.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDiscriminator.cs
@@ -21,12 +21,12 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// An object to hold mappings between payload values and schema names or references.
         /// </summary>
-        public Dictionary<string, OpenApiSchemaReference>? Mapping { get; set; }
+        public IDictionary<string, OpenApiSchemaReference>? Mapping { get; set; }
 
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameter-less constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -61,7 +61,7 @@ namespace Microsoft.OpenApi.Models
         /// A map of requests initiated other than by an API call, for example by an out of band registration. 
         /// The key name is a unique string to refer to each webhook, while the (optionally referenced) Path Item Object describes a request that may be initiated by the API provider and the expected responses
         /// </summary>
-        public Dictionary<string, IOpenApiPathItem>? Webhooks { get; set; }
+        public IDictionary<string, IOpenApiPathItem>? Webhooks { get; set; }
 
         /// <summary>
         /// An element to hold various schemas for the specification.
@@ -103,10 +103,10 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, object>? Metadata { get; set; }
+        public IDictionary<string, object>? Metadata { get; set; }
 
         /// <summary>
         /// Absolute location of the document or a generated placeholder if location is not given
@@ -668,43 +668,43 @@ namespace Microsoft.OpenApi.Models
             switch (componentToRegister)
             {
                 case IOpenApiSchema openApiSchema:
-                    Components.Schemas ??= [];
+                    Components.Schemas ??= new Dictionary<string, IOpenApiSchema>();
                     Components.Schemas.Add(id, openApiSchema);
                     break;
                 case IOpenApiParameter openApiParameter:
-                    Components.Parameters ??= [];
+                    Components.Parameters ??= new Dictionary<string, IOpenApiParameter>();
                     Components.Parameters.Add(id, openApiParameter);
                     break;
                 case IOpenApiResponse openApiResponse:
-                    Components.Responses ??= [];
+                    Components.Responses ??= new Dictionary<string, IOpenApiResponse>();
                     Components.Responses.Add(id, openApiResponse);
                     break;
                 case IOpenApiRequestBody openApiRequestBody:
-                    Components.RequestBodies ??= [];
+                    Components.RequestBodies ??= new Dictionary<string, IOpenApiRequestBody>();
                     Components.RequestBodies.Add(id, openApiRequestBody);
                     break;
                 case IOpenApiLink openApiLink:
-                    Components.Links ??= [];
+                    Components.Links ??= new Dictionary<string, IOpenApiLink>();
                     Components.Links.Add(id, openApiLink);
                     break;
                 case IOpenApiCallback openApiCallback:
-                    Components.Callbacks ??= [];
+                    Components.Callbacks ??= new Dictionary<string, IOpenApiCallback>();
                     Components.Callbacks.Add(id, openApiCallback);
                     break;
                 case IOpenApiPathItem openApiPathItem:
-                    Components.PathItems ??= [];
+                    Components.PathItems ??= new Dictionary<string, IOpenApiPathItem>();
                     Components.PathItems.Add(id, openApiPathItem);
                     break;
                 case IOpenApiExample openApiExample:
-                    Components.Examples ??= [];
+                    Components.Examples ??= new Dictionary<string, IOpenApiExample>();
                     Components.Examples.Add(id, openApiExample);
                     break;
                 case IOpenApiHeader openApiHeader:
-                    Components.Headers ??= [];
+                    Components.Headers ??= new Dictionary<string, IOpenApiHeader>();
                     Components.Headers.Add(id, openApiHeader);
                     break;
                 case IOpenApiSecurityScheme openApiSecurityScheme:
-                    Components.SecuritySchemes ??= [];
+                    Components.SecuritySchemes ??= new Dictionary<string, IOpenApiSecurityScheme>();
                     Components.SecuritySchemes.Add(id, openApiSecurityScheme);
                     break;
                 default:

--- a/src/Microsoft.OpenApi/Models/OpenApiEncoding.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiEncoding.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// A map allowing additional information to be provided as headers.
         /// </summary>
-        public Dictionary<string, IOpenApiHeader>? Headers { get; set; }
+        public IDictionary<string, IOpenApiHeader>? Headers { get; set; }
 
         /// <summary>
         /// Describes how a specific property value will be serialized depending on its type.
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameter-less constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiExample.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExample.cs
@@ -28,7 +28,7 @@ namespace Microsoft.OpenApi.Models
         public JsonNode? Value { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameter-less constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExtensibleDictionary.cs
@@ -36,7 +36,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
 
         /// <summary>

--- a/src/Microsoft.OpenApi/Models/OpenApiExternalDocs.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExternalDocs.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameter-less constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiHeader.cs
@@ -47,13 +47,13 @@ namespace Microsoft.OpenApi.Models
         public JsonNode? Example { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExample>? Examples { get; set; }
+        public IDictionary<string, IOpenApiExample>? Examples { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, OpenApiMediaType>? Content { get; set; }
+        public IDictionary<string, OpenApiMediaType>? Content { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameter-less constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiInfo.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiInfo.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameter-less constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameterless constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiLink.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiLink.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenApi.Models
         public string? OperationId { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, RuntimeExpressionAnyWrapper>? Parameters { get; set; }
+        public IDictionary<string, RuntimeExpressionAnyWrapper>? Parameters { get; set; }
 
         /// <inheritdoc/>
         public RuntimeExpressionAnyWrapper? RequestBody { get; set; }
@@ -33,7 +33,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiServer? Server { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameterless constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OpenApi.Models
         /// Examples of the media type.
         /// Each example object SHOULD match the media type and specified schema if present.
         /// </summary>
-        public Dictionary<string, IOpenApiExample>? Examples { get; set; }
+        public IDictionary<string, IOpenApiExample>? Examples { get; set; }
 
         /// <summary>
         /// A map between a property name and its encoding information.
@@ -40,12 +40,12 @@ namespace Microsoft.OpenApi.Models
         /// The encoding object SHALL only apply to requestBody objects
         /// when the media type is multipart or application/x-www-form-urlencoded.
         /// </summary>
-        public Dictionary<string, OpenApiEncoding>? Encoding { get; set; }
+        public IDictionary<string, OpenApiEncoding>? Encoding { get; set; }
 
         /// <summary>
         /// Serialize <see cref="OpenApiExternalDocs"/> to Open Api v3.0.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameterless constructor
@@ -119,7 +119,7 @@ namespace Microsoft.OpenApi.Models
             // Media type does not exist in V2.
         }
 
-        private static void SerializeExamples(IOpenApiWriter writer, Dictionary<string, IOpenApiExample> examples, Action<IOpenApiWriter, IOpenApiSerializable> callback)
+        private static void SerializeExamples(IOpenApiWriter writer, IDictionary<string, IOpenApiExample> examples, Action<IOpenApiWriter, IOpenApiSerializable> callback)
         {
             /* Special case for writing out empty arrays as valid response examples
             * Check if there is any example with an empty array as its value and set the flag `hasEmptyArray` to true

--- a/src/Microsoft.OpenApi/Models/OpenApiOAuthFlow.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOAuthFlow.cs
@@ -33,12 +33,12 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// REQUIRED. A map between the scope name and a short description for it.
         /// </summary>
-        public Dictionary<string, string>? Scopes { get; set; }
+        public IDictionary<string, string>? Scopes { get; set; }
 
         /// <summary>
         /// Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameterless constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiOAuthFlows.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOAuthFlows.cs
@@ -36,7 +36,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameterless constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiOperation.cs
@@ -97,7 +97,7 @@ namespace Microsoft.OpenApi.Models
         /// The key value used to identify the callback object is an expression, evaluated at runtime,
         /// that identifies a URL to use for the callback operation.
         /// </summary>
-        public Dictionary<string, IOpenApiCallback>? Callbacks { get; set; }
+        public IDictionary<string, IOpenApiCallback>? Callbacks { get; set; }
 
         /// <summary>
         /// Declares this operation to be deprecated. Consumers SHOULD refrain from usage of the declared operation.
@@ -123,10 +123,10 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, object>? Metadata { get; set; }
+        public IDictionary<string, object>? Metadata { get; set; }
 
         /// <summary>
         /// Parameterless constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiParameter.cs
@@ -61,16 +61,16 @@ namespace Microsoft.OpenApi.Models
         public IOpenApiSchema? Schema { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExample>? Examples { get; set; }
+        public IDictionary<string, IOpenApiExample>? Examples { get; set; }
 
         /// <inheritdoc/>
         public JsonNode? Example { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, OpenApiMediaType>? Content { get; set; }
+        public IDictionary<string, OpenApiMediaType>? Content { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// A parameterless constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiPathItem.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiPathItem.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OpenApi.Models
         public List<IOpenApiParameter>? Parameters { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Add one operation into this path item.

--- a/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiRequestBody.cs
@@ -24,10 +24,10 @@ namespace Microsoft.OpenApi.Models
         public bool Required { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, OpenApiMediaType>? Content { get; set; }
+        public IDictionary<string, OpenApiMediaType>? Content { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameter-less constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiResponse.cs
@@ -19,16 +19,16 @@ namespace Microsoft.OpenApi.Models
         public string? Description { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiHeader>? Headers { get; set; }
+        public IDictionary<string, IOpenApiHeader>? Headers { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, OpenApiMediaType>? Content { get; set; }
+        public IDictionary<string, OpenApiMediaType>? Content { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiLink>? Links { get; set; }
+        public IDictionary<string, IOpenApiLink>? Links { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameterless constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OpenApi.Models
         public string? Comment { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, bool>? Vocabulary { get; set; }
+        public IDictionary<string, bool>? Vocabulary { get; set; }
 
         /// <inheritdoc />
         public string? DynamicRef { get; set; }
@@ -41,7 +41,7 @@ namespace Microsoft.OpenApi.Models
         public string? DynamicAnchor { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, IOpenApiSchema>? Definitions { get; set; }
+        public IDictionary<string, IOpenApiSchema>? Definitions { get; set; }
 
         private string? _exclusiveMaximum;
         /// <inheritdoc />
@@ -207,10 +207,10 @@ namespace Microsoft.OpenApi.Models
         public bool? UniqueItems { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, IOpenApiSchema>? Properties { get; set; }
+        public IDictionary<string, IOpenApiSchema>? Properties { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, IOpenApiSchema>? PatternProperties { get; set; }
+        public IDictionary<string, IOpenApiSchema>? PatternProperties { get; set; }
 
         /// <inheritdoc />
         public int? MaxProperties { get; set; }
@@ -249,16 +249,16 @@ namespace Microsoft.OpenApi.Models
         public OpenApiXml? Xml { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, JsonNode>? UnrecognizedKeywords { get; set; }
+        public IDictionary<string, JsonNode>? UnrecognizedKeywords { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, object>? Metadata { get; set; }
+        public IDictionary<string, object>? Metadata { get; set; }
 
         /// <inheritdoc />
-        public Dictionary<string, HashSet<string>>? DependentRequired { get; set; }
+        public IDictionary<string, HashSet<string>>? DependentRequired { get; set; }
 
         /// <summary>
         /// Parameterless constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiSecurityScheme.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSecurityScheme.cs
@@ -40,7 +40,7 @@ namespace Microsoft.OpenApi.Models
         public Uri? OpenIdConnectUrl { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameterless constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiServer.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiServer.cs
@@ -28,12 +28,12 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// A map between a variable name and its value. The value is used for substitution in the server's URL template.
         /// </summary>
-        public Dictionary<string, OpenApiServerVariable>? Variables { get; set; }
+        public IDictionary<string, OpenApiServerVariable>? Variables { get; set; }
 
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameterless constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiServerVariable.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiServerVariable.cs
@@ -34,7 +34,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// This object MAY be extended with Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameterless constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiTag.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiTag.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiExternalDocs? ExternalDocs { get; set; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameterless constructor

--- a/src/Microsoft.OpenApi/Models/OpenApiXml.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiXml.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.Models
         /// <summary>
         /// Specification Extensions.
         /// </summary>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get; set; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get; set; }
 
         /// <summary>
         /// Parameterless constructor

--- a/src/Microsoft.OpenApi/Models/References/OpenApiCallbackReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiCallbackReference.cs
@@ -41,7 +41,7 @@ namespace Microsoft.OpenApi.Models.References
         public Dictionary<RuntimeExpression, IOpenApiPathItem>? PathItems { get => Target?.PathItems; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
 
         /// <inheritdoc/>
         public override IOpenApiCallback CopyReferenceAsTargetElementWithOverrides(IOpenApiCallback source)

--- a/src/Microsoft.OpenApi/Models/References/OpenApiExampleReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiExampleReference.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OpenApi.Models.References
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
 
         /// <inheritdoc/>
         public string? ExternalValue { get => Target?.ExternalValue; }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiHeaderReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiHeaderReference.cs
@@ -68,13 +68,13 @@ namespace Microsoft.OpenApi.Models.References
         public JsonNode? Example { get => Target?.Example; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExample>? Examples { get => Target?.Examples; }
+        public IDictionary<string, IOpenApiExample>? Examples { get => Target?.Examples; }
 
         /// <inheritdoc/>
-        public Dictionary<string, OpenApiMediaType>? Content { get => Target?.Content; }
+        public IDictionary<string, OpenApiMediaType>? Content { get => Target?.Content; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
 
         /// <inheritdoc/>
         public override IOpenApiHeader CopyReferenceAsTargetElementWithOverrides(IOpenApiHeader source)

--- a/src/Microsoft.OpenApi/Models/References/OpenApiLinkReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiLinkReference.cs
@@ -52,13 +52,13 @@ namespace Microsoft.OpenApi.Models.References
         public OpenApiServer? Server { get => Target?.Server; }
 
         /// <inheritdoc/>
-        public Dictionary<string, RuntimeExpressionAnyWrapper>? Parameters { get => Target?.Parameters; }
+        public IDictionary<string, RuntimeExpressionAnyWrapper>? Parameters { get => Target?.Parameters; }
 
         /// <inheritdoc/>
         public RuntimeExpressionAnyWrapper? RequestBody { get => Target?.RequestBody; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
 
         /// <inheritdoc/>
         public override void SerializeAsV2(IOpenApiWriter writer)

--- a/src/Microsoft.OpenApi/Models/References/OpenApiParameterReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiParameterReference.cs
@@ -61,7 +61,7 @@ namespace Microsoft.OpenApi.Models.References
         public IOpenApiSchema? Schema { get => Target?.Schema; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExample>? Examples { get => Target?.Examples; }
+        public IDictionary<string, IOpenApiExample>? Examples { get => Target?.Examples; }
 
         /// <inheritdoc/>
         public JsonNode? Example { get => Target?.Example; }
@@ -76,10 +76,10 @@ namespace Microsoft.OpenApi.Models.References
         public bool Explode { get => Target?.Explode ?? default; }
 
         /// <inheritdoc/>
-        public Dictionary<string, OpenApiMediaType>? Content { get => Target?.Content; }
+        public IDictionary<string, OpenApiMediaType>? Content { get => Target?.Content; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
         
         /// <inheritdoc/>
         public override IOpenApiParameter CopyReferenceAsTargetElementWithOverrides(IOpenApiParameter  source)

--- a/src/Microsoft.OpenApi/Models/References/OpenApiPathItemReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiPathItemReference.cs
@@ -62,7 +62,7 @@ namespace Microsoft.OpenApi.Models.References
         public List<IOpenApiParameter>? Parameters { get => Target?.Parameters; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
 
         /// <inheritdoc/>
         public override IOpenApiPathItem CopyReferenceAsTargetElementWithOverrides(IOpenApiPathItem source)

--- a/src/Microsoft.OpenApi/Models/References/OpenApiRequestBodyReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiRequestBodyReference.cs
@@ -45,13 +45,13 @@ namespace Microsoft.OpenApi.Models.References
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, OpenApiMediaType>? Content { get => Target?.Content; }
+        public IDictionary<string, OpenApiMediaType>? Content { get => Target?.Content; }
 
         /// <inheritdoc/>
         public bool Required { get => Target?.Required ?? false; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
 
         /// <inheritdoc/>
         public override IOpenApiRequestBody CopyReferenceAsTargetElementWithOverrides(IOpenApiRequestBody source)

--- a/src/Microsoft.OpenApi/Models/References/OpenApiResponseReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiResponseReference.cs
@@ -43,16 +43,16 @@ namespace Microsoft.OpenApi.Models.References
         }
 
         /// <inheritdoc/>
-        public Dictionary<string, OpenApiMediaType>? Content { get => Target?.Content; }
+        public IDictionary<string, OpenApiMediaType>? Content { get => Target?.Content; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiHeader>? Headers { get => Target?.Headers; }
+        public IDictionary<string, IOpenApiHeader>? Headers { get => Target?.Headers; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiLink>? Links { get => Target?.Links; }
+        public IDictionary<string, IOpenApiLink>? Links { get => Target?.Links; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
 
         /// <inheritdoc/>
         public override IOpenApiResponse CopyReferenceAsTargetElementWithOverrides(IOpenApiResponse source)

--- a/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
@@ -52,13 +52,13 @@ namespace Microsoft.OpenApi.Models.References
         /// <inheritdoc/>
         public string? Comment { get => Target?.Comment; }
         /// <inheritdoc/>
-        public Dictionary<string, bool>? Vocabulary { get => Target?.Vocabulary; }
+        public IDictionary<string, bool>? Vocabulary { get => Target?.Vocabulary; }
         /// <inheritdoc/>
         public string? DynamicRef { get => Target?.DynamicRef; }
         /// <inheritdoc/>
         public string? DynamicAnchor { get => Target?.DynamicAnchor; }
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiSchema>? Definitions { get => Target?.Definitions; }
+        public IDictionary<string, IOpenApiSchema>? Definitions { get => Target?.Definitions; }
         /// <inheritdoc/>
         public string? ExclusiveMaximum { get => Target?.ExclusiveMaximum; }
         /// <inheritdoc/>
@@ -106,9 +106,9 @@ namespace Microsoft.OpenApi.Models.References
         /// <inheritdoc/>
         public bool? UniqueItems { get => Target?.UniqueItems; }
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiSchema>? Properties { get => Target?.Properties; }
+        public IDictionary<string, IOpenApiSchema>? Properties { get => Target?.Properties; }
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiSchema>? PatternProperties { get => Target?.PatternProperties; }
+        public IDictionary<string, IOpenApiSchema>? PatternProperties { get => Target?.PatternProperties; }
         /// <inheritdoc/>
         public int? MaxProperties { get => Target?.MaxProperties; }
         /// <inheritdoc/>
@@ -134,13 +134,13 @@ namespace Microsoft.OpenApi.Models.References
         /// <inheritdoc/>
         public OpenApiXml? Xml { get => Target?.Xml; }
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
 
         /// <inheritdoc/>
-        public Dictionary<string, JsonNode>? UnrecognizedKeywords { get => Target?.UnrecognizedKeywords; }
+        public IDictionary<string, JsonNode>? UnrecognizedKeywords { get => Target?.UnrecognizedKeywords; }
 
         /// <inheritdoc/>
-        public Dictionary<string, HashSet<string>>? DependentRequired { get => Target?.DependentRequired; }
+        public IDictionary<string, HashSet<string>>? DependentRequired { get => Target?.DependentRequired; }
 
         /// <inheritdoc/>
         public override void SerializeAsV31(IOpenApiWriter writer)

--- a/src/Microsoft.OpenApi/Models/References/OpenApiSecuritySchemeReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiSecuritySchemeReference.cs
@@ -57,7 +57,7 @@ namespace Microsoft.OpenApi.Models.References
         public Uri? OpenIdConnectUrl { get => Target?.OpenIdConnectUrl; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
 
         /// <inheritdoc/>
         public SecuritySchemeType? Type { get => Target?.Type; }

--- a/src/Microsoft.OpenApi/Models/References/OpenApiTagReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiTagReference.cs
@@ -56,7 +56,7 @@ namespace Microsoft.OpenApi.Models.References
         public OpenApiExternalDocs? ExternalDocs { get => Target?.ExternalDocs; }
 
         /// <inheritdoc/>
-        public Dictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
+        public IDictionary<string, IOpenApiExtension>? Extensions { get => Target?.Extensions; }
 
         /// <inheritdoc/>
         public string? Name { get => Target?.Name; }

--- a/src/Microsoft.OpenApi/Reader/ParseNodes/AnyMapFieldMapParameter.cs
+++ b/src/Microsoft.OpenApi/Reader/ParseNodes/AnyMapFieldMapParameter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OpenApi.Reader.ParseNodes
         /// Constructor
         /// </summary>
         public AnyMapFieldMapParameter(
-            Func<T, Dictionary<string, U>?> propertyMapGetter,
+            Func<T, IDictionary<string, U>?> propertyMapGetter,
             Func<U, JsonNode?> propertyGetter,
             Action<U, JsonNode> propertySetter,
             Func<T, IOpenApiSchema?> schemaGetter)
@@ -29,7 +29,7 @@ namespace Microsoft.OpenApi.Reader.ParseNodes
         /// <summary>
         /// Function to retrieve the property that is a map from string to an inner element.
         /// </summary>
-        public Func<T, Dictionary<string, U>?> PropertyMapGetter { get; }
+        public Func<T, IDictionary<string, U>?> PropertyMapGetter { get; }
 
         /// <summary>
         /// Function to retrieve the value of the property from an inner element.

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiDocumentDeserializer.cs
@@ -313,8 +313,8 @@ namespace Microsoft.OpenApi.Reader.V2
 
     internal class RequestBodyReferenceFixer : OpenApiVisitorBase
     {
-        private readonly Dictionary<string, IOpenApiRequestBody> _requestBodies;
-        public RequestBodyReferenceFixer(Dictionary<string, IOpenApiRequestBody> requestBodies)
+        private readonly IDictionary<string, IOpenApiRequestBody> _requestBodies;
+        public RequestBodyReferenceFixer(IDictionary<string, IOpenApiRequestBody> requestBodies)
         {
             _requestBodies = requestBodies;
         }

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
@@ -10,6 +10,7 @@ using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Models.Interfaces;
 using System;
 using System.Text.Json.Nodes;
+using Microsoft.OpenApi.Interfaces;
 
 namespace Microsoft.OpenApi.Reader.V2
 {
@@ -243,7 +244,7 @@ namespace Microsoft.OpenApi.Reader.V2
 
             if (bodyParameter.Name is not null)
             {
-                requestBody.Extensions ??= [];
+                requestBody.Extensions ??= new Dictionary<string, IOpenApiExtension>();
                 requestBody.Extensions[OpenApiConstants.BodyName] = new JsonNodeExtension(bodyParameter.Name);
             }            
             return requestBody;

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiResponseDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiResponseDeserializer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.OpenApi.Reader.V2
         {
             if (response.Content == null)
             {
-                response.Content = [];
+                response.Content = new Dictionary<string, OpenApiMediaType>();
             }
             else if (context.GetFromTempStorage<bool>(TempStorageKeys.ResponseProducesSet, response))
             {

--- a/src/Microsoft.OpenApi/Services/CopyReferences.cs
+++ b/src/Microsoft.OpenApi/Services/CopyReferences.cs
@@ -91,7 +91,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
         EnsureSchemasExist();
         if (referenceId is not null && schema is not null && !(Components.Schemas?.ContainsKey(referenceId) ?? false))
         {
-            Components.Schemas ??= [];
+            Components.Schemas ??= new Dictionary<string, IOpenApiSchema>();
             Components.Schemas.Add(referenceId, schema);
         }
     }
@@ -102,7 +102,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
         EnsureParametersExist();
         if (parameter is not null && referenceId is not null && !(Components.Parameters?.ContainsKey(referenceId) ?? false))
         {
-            Components.Parameters ??= [];
+            Components.Parameters ??= new Dictionary<string, IOpenApiParameter>();
             Components.Parameters.Add(referenceId, parameter);
         }
     }
@@ -113,7 +113,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
         EnsureResponsesExist();
         if (referenceId is not null && response is not null && !(Components.Responses?.ContainsKey(referenceId) ?? false))
         {
-            Components.Responses ??= [];
+            Components.Responses ??= new Dictionary<string, IOpenApiResponse>();
             Components.Responses.Add(referenceId, response);
         }
     }
@@ -123,7 +123,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
         EnsureRequestBodiesExist();
         if (requestBody is not null && referenceId is not null && !(Components.RequestBodies?.ContainsKey(referenceId) ?? false))
         {
-            Components.RequestBodies ??= [];
+            Components.RequestBodies ??= new Dictionary<string, IOpenApiRequestBody>();
             Components.RequestBodies.Add(referenceId, requestBody);
         }
     }
@@ -133,7 +133,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
         EnsureLinksExist();
         if (link is not null && referenceId is not null && !(Components.Links?.ContainsKey(referenceId) ?? false))
         {
-            Components.Links ??= [];
+            Components.Links ??= new Dictionary<string, IOpenApiLink>();
             Components.Links.Add(referenceId, link);
         }
     }
@@ -143,7 +143,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
         EnsureCallbacksExist();
         if (callback is not null && referenceId is not null && !(Components.Callbacks?.ContainsKey(referenceId) ?? false))
         {
-            Components.Callbacks ??= [];
+            Components.Callbacks ??= new Dictionary<string, IOpenApiCallback>();
             Components.Callbacks.Add(referenceId, callback);
         }
     }
@@ -153,7 +153,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
         EnsureHeadersExist();
         if (header is not null && referenceId is not null && !(Components.Headers?.ContainsKey(referenceId) ?? false))
         {
-            Components.Headers ??= [];
+            Components.Headers ??= new Dictionary<string, IOpenApiHeader>();
             Components.Headers.Add(referenceId, header);
         }
     }
@@ -163,7 +163,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
         EnsureExamplesExist();
         if (example is not null && referenceId is not null && !(Components.Examples?.ContainsKey(referenceId) ?? false))
         {
-            Components.Examples ??= [];
+            Components.Examples ??= new Dictionary<string, IOpenApiExample>();
             Components.Examples.Add(referenceId, example);
         }
     }
@@ -173,7 +173,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
         EnsurePathItemsExist();
         if (pathItem is not null && referenceId is not null && !(Components.PathItems?.ContainsKey(referenceId) ?? false))
         {
-            Components.PathItems ??= [];
+            Components.PathItems ??= new Dictionary<string, IOpenApiPathItem>();
             Components.PathItems.Add(referenceId, pathItem);
         }
     }
@@ -183,7 +183,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
         EnsureSecuritySchemesExist();
         if (securityScheme is not null && referenceId is not null && !(Components.SecuritySchemes?.ContainsKey(referenceId) ?? false))
         {
-            Components.SecuritySchemes ??= [];
+            Components.SecuritySchemes ??= new Dictionary<string, IOpenApiSecurityScheme>();
             Components.SecuritySchemes.Add(referenceId, securityScheme);
         }
     }
@@ -208,7 +208,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
     {
         if (_target.Components is not null)
         {
-            _target.Components.Schemas ??= [];
+            _target.Components.Schemas ??= new Dictionary<string, IOpenApiSchema>();
         }
     }
 
@@ -216,7 +216,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
     {
         if (_target.Components is not null)
         {
-            _target.Components.Parameters ??= [];
+            _target.Components.Parameters ??= new Dictionary<string, IOpenApiParameter>();
         }
     }
 
@@ -224,7 +224,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
     {
         if (_target.Components is not null)
         {
-            _target.Components.Responses ??= [];
+            _target.Components.Responses ??= new Dictionary<string, IOpenApiResponse>();
         }
     }
 
@@ -232,7 +232,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
     {
         if (_target.Components is not null)
         {
-            _target.Components.RequestBodies ??= [];
+            _target.Components.RequestBodies ??= new Dictionary<string, IOpenApiRequestBody>();
         }
     }
 
@@ -240,7 +240,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
     {
         if (_target.Components is not null)
         {
-            _target.Components.Examples ??= [];
+            _target.Components.Examples ??= new Dictionary<string, IOpenApiExample>();
         }
     }
 
@@ -248,7 +248,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
     {
         if (_target.Components is not null)
         {
-            _target.Components.Headers ??= [];
+            _target.Components.Headers ??= new Dictionary<string, IOpenApiHeader>();
         }
     }
 
@@ -256,7 +256,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
     {
         if (_target.Components is not null)
         {
-            _target.Components.Callbacks ??= [];
+            _target.Components.Callbacks ??= new Dictionary<string, IOpenApiCallback>();
         }
     }
 
@@ -264,7 +264,7 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
     {
         if (_target.Components is not null)
         {
-            _target.Components.Links ??= [];
+            _target.Components.Links ??= new Dictionary<string, IOpenApiLink>();
         }
     }
 
@@ -272,14 +272,14 @@ internal class CopyReferences(OpenApiDocument target) : OpenApiVisitorBase
     {
         if (_target.Components is not null)
         {
-            _target.Components.SecuritySchemes ??= [];
+            _target.Components.SecuritySchemes ??= new Dictionary<string, IOpenApiSecurityScheme>();
         }
     }
     private void EnsurePathItemsExist()
     {
         if (_target.Components is not null)
         {
-            _target.Components.PathItems = [];
+            _target.Components.PathItems = new Dictionary<string, IOpenApiPathItem>();
         }
     }
 }

--- a/src/Microsoft.OpenApi/Services/OpenApiUrlTreeNode.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiUrlTreeNode.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// All the subdirectories of a node.
         /// </summary>
-        public Dictionary<string, OpenApiUrlTreeNode> Children { get; } = new Dictionary<string, OpenApiUrlTreeNode>();
+        public IDictionary<string, OpenApiUrlTreeNode> Children { get; } = new Dictionary<string, OpenApiUrlTreeNode>();
 
         /// <summary>
         /// The relative directory path of the current node from the root node.
@@ -31,12 +31,12 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Dictionary of labels and Path Item objects that describe the operations available on a node.
         /// </summary>
-        public Dictionary<string, IOpenApiPathItem> PathItems { get; } = new Dictionary<string, IOpenApiPathItem>();
+        public IDictionary<string, IOpenApiPathItem> PathItems { get; } = new Dictionary<string, IOpenApiPathItem>();
 
         /// <summary>
         /// A dictionary of key value pairs that contain information about a node.
         /// </summary>
-        public Dictionary<string, List<string>> AdditionalData { get; set; } = new Dictionary<string, List<string>>();
+        public IDictionary<string, List<string>> AdditionalData { get; set; } = new Dictionary<string, List<string>>();
 
         /// <summary>
         /// Flag indicating whether a node segment is a path parameter.

--- a/src/Microsoft.OpenApi/Services/OpenApiVisitorBase.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiVisitorBase.cs
@@ -107,7 +107,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits Webhooks>
         /// </summary>
-        public virtual void Visit(Dictionary<string, IOpenApiPathItem> webhooks)
+        public virtual void Visit(IDictionary<string, IOpenApiPathItem> webhooks)
         {
         }
 
@@ -128,7 +128,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits the operations.
         /// </summary>
-        public virtual void Visit(Dictionary<HttpMethod, OpenApiOperation> operations)
+        public virtual void Visit(IDictionary<HttpMethod, OpenApiOperation> operations)
         {
         }
 
@@ -163,14 +163,14 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits headers.
         /// </summary>
-        public virtual void Visit(Dictionary<string, IOpenApiHeader> headers)
+        public virtual void Visit(IDictionary<string, IOpenApiHeader> headers)
         {
         }
 
         /// <summary>
         /// Visits callbacks.
         /// </summary>
-        public virtual void Visit(Dictionary<string, IOpenApiCallback> callbacks)
+        public virtual void Visit(IDictionary<string, IOpenApiCallback> callbacks)
         {
         }
 
@@ -191,7 +191,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits media type content.
         /// </summary>
-        public virtual void Visit(Dictionary<string, OpenApiMediaType> content)
+        public virtual void Visit(IDictionary<string, OpenApiMediaType> content)
         {
         }
 
@@ -212,7 +212,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits the examples.
         /// </summary>
-        public virtual void Visit(Dictionary<string, IOpenApiExample> examples)
+        public virtual void Visit(IDictionary<string, IOpenApiExample> examples)
         {
         }
 
@@ -240,7 +240,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits the links.
         /// </summary>
-        public virtual void Visit(Dictionary<string, IOpenApiLink> links)
+        public virtual void Visit(IDictionary<string, IOpenApiLink> links)
         {
         }
 
@@ -352,7 +352,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits a dictionary of server variables
         /// </summary>
-        public virtual void Visit(Dictionary<string, OpenApiServerVariable> serverVariables)
+        public virtual void Visit(IDictionary<string, OpenApiServerVariable> serverVariables)
         {
         }
 
@@ -360,7 +360,7 @@ namespace Microsoft.OpenApi.Services
         /// Visits a dictionary of encodings
         /// </summary>
         /// <param name="encodings"></param>
-        public virtual void Visit(Dictionary<string, OpenApiEncoding> encodings)
+        public virtual void Visit(IDictionary<string, OpenApiEncoding> encodings)
         {
         }
 

--- a/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWalker.cs
@@ -282,7 +282,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits Webhooks and child objects
         /// </summary>
-        internal void Walk(Dictionary<string, IOpenApiPathItem>? webhooks)
+        internal void Walk(IDictionary<string, IOpenApiPathItem>? webhooks)
         {
             if (webhooks == null)
             {
@@ -488,7 +488,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits dictionary of <see cref="OpenApiServerVariable"/>
         /// </summary>
-        internal void Walk(Dictionary<string, OpenApiServerVariable>? serverVariables)
+        internal void Walk(IDictionary<string, OpenApiServerVariable>? serverVariables)
         {
             if (serverVariables == null)
             {
@@ -565,7 +565,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits dictionary of <see cref="OpenApiOperation"/>
         /// </summary>
-        internal void Walk(Dictionary<HttpMethod, OpenApiOperation>? operations)
+        internal void Walk(IDictionary<HttpMethod, OpenApiOperation>? operations)
         {
             if (operations == null)
             {
@@ -747,7 +747,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits dictionary of <see cref="OpenApiHeader"/>
         /// </summary>
-        internal void Walk(Dictionary<string, IOpenApiHeader>? headers)
+        internal void Walk(IDictionary<string, IOpenApiHeader>? headers)
         {
             if (headers == null)
             {
@@ -769,7 +769,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits dictionary of <see cref="IOpenApiCallback"/>
         /// </summary>
-        internal void Walk(Dictionary<string, IOpenApiCallback>? callbacks)
+        internal void Walk(IDictionary<string, IOpenApiCallback>? callbacks)
         {
             if (callbacks == null)
             {
@@ -791,7 +791,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits dictionary of <see cref="OpenApiMediaType"/>
         /// </summary>
-        internal void Walk(Dictionary<string, OpenApiMediaType>? content)
+        internal void Walk(IDictionary<string, OpenApiMediaType>? content)
         {
             if (content == null)
             {
@@ -831,7 +831,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits dictionary of <see cref="OpenApiEncoding"/>
         /// </summary>
-        internal void Walk(Dictionary<string, OpenApiEncoding>? encodings)
+        internal void Walk(IDictionary<string, OpenApiEncoding>? encodings)
         {
             if (encodings == null)
             {
@@ -966,7 +966,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits dictionary of <see cref="IOpenApiExample"/>
         /// </summary>
-        internal void Walk(Dictionary<string, IOpenApiExample>? examples)
+        internal void Walk(IDictionary<string, IOpenApiExample>? examples)
         {
             if (examples == null)
             {
@@ -1091,7 +1091,7 @@ namespace Microsoft.OpenApi.Services
         /// <summary>
         /// Visits dictionary of <see cref="IOpenApiLink"/> and child objects
         /// </summary>
-        internal void Walk(Dictionary<string, IOpenApiLink>? links)
+        internal void Walk(IDictionary<string, IOpenApiLink>? links)
         {
             if (links == null)
             {

--- a/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
+++ b/src/Microsoft.OpenApi/Validations/OpenApiValidator.cs
@@ -149,21 +149,21 @@ namespace Microsoft.OpenApi.Validations
         /// <inheritdoc/>
         public override void Visit(OpenApiOperation operation) => Validate(operation);
         /// <inheritdoc/>
-        public override void Visit(Dictionary<HttpMethod, OpenApiOperation> operations) => Validate(operations, operations.GetType());
+        public override void Visit(IDictionary<HttpMethod, OpenApiOperation> operations) => Validate(operations, operations.GetType());
         /// <inheritdoc/>
-        public override void Visit(Dictionary<string, IOpenApiHeader> headers) => Validate(headers, headers.GetType());
+        public override void Visit(IDictionary<string, IOpenApiHeader> headers) => Validate(headers, headers.GetType());
         /// <inheritdoc/>
-        public override void Visit(Dictionary<string, IOpenApiCallback> callbacks) => Validate(callbacks, callbacks.GetType());
+        public override void Visit(IDictionary<string, IOpenApiCallback> callbacks) => Validate(callbacks, callbacks.GetType());
         /// <inheritdoc/>
-        public override void Visit(Dictionary<string, OpenApiMediaType> content) => Validate(content, content.GetType());
+        public override void Visit(IDictionary<string, OpenApiMediaType> content) => Validate(content, content.GetType());
         /// <inheritdoc/>
-        public override void Visit(Dictionary<string, IOpenApiExample> examples) => Validate(examples, examples.GetType());
+        public override void Visit(IDictionary<string, IOpenApiExample> examples) => Validate(examples, examples.GetType());
         /// <inheritdoc/>
-        public override void Visit(Dictionary<string, IOpenApiLink> links) => Validate(links, links.GetType());
+        public override void Visit(IDictionary<string, IOpenApiLink> links) => Validate(links, links.GetType());
         /// <inheritdoc/>
-        public override void Visit(Dictionary<string, OpenApiServerVariable> serverVariables) => Validate(serverVariables, serverVariables.GetType());
+        public override void Visit(IDictionary<string, OpenApiServerVariable> serverVariables) => Validate(serverVariables, serverVariables.GetType());
         /// <inheritdoc/>
-        public override void Visit(Dictionary<string, OpenApiEncoding> encodings) => Validate(encodings, encodings.GetType());
+        public override void Visit(IDictionary<string, OpenApiEncoding> encodings) => Validate(encodings, encodings.GetType());
 
         private void Validate<T>(T item)
         {

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiNonDefaultRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiNonDefaultRules.cs
@@ -90,7 +90,7 @@ namespace Microsoft.OpenApi.Validations.Rules
         private static void ValidateMismatchedDataType(IValidationContext context,
                                                       string ruleName,
                                                       JsonNode? example,
-                                                      Dictionary<string, IOpenApiExample>? examples,
+                                                      IDictionary<string, IOpenApiExample>? examples,
                                                       IOpenApiSchema? schema)
         {
             // example

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterAnyExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterAnyExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.OpenApi.Writers
         /// <param name="writer">The Open API writer.</param>
         /// <param name="extensions">The specification extensions.</param>
         /// <param name="specVersion">Version of the OpenAPI specification that that will be output.</param>
-        public static void WriteExtensions(this IOpenApiWriter writer, Dictionary<string, IOpenApiExtension>? extensions, OpenApiSpecVersion specVersion)
+        public static void WriteExtensions(this IOpenApiWriter writer, IDictionary<string, IOpenApiExtension>? extensions, OpenApiSpecVersion specVersion)
         {
             Utils.CheckArgumentNull(writer);
 

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterExtensions.cs
@@ -266,7 +266,7 @@ namespace Microsoft.OpenApi.Writers
         public static void WriteRequiredMap(
             this IOpenApiWriter writer,
             string name,
-            Dictionary<string, string>? elements,
+            IDictionary<string, string>? elements,
             Action<IOpenApiWriter, string> action)
         {
             writer.WriteMapInternal(name, elements, action);
@@ -282,7 +282,7 @@ namespace Microsoft.OpenApi.Writers
         public static void WriteOptionalMap(
             this IOpenApiWriter writer,
             string name,
-            Dictionary<string, JsonNode>? elements,
+            IDictionary<string, JsonNode>? elements,
             Action<IOpenApiWriter, JsonNode> action)
         {
             if (elements != null && elements.Any())
@@ -301,7 +301,7 @@ namespace Microsoft.OpenApi.Writers
         public static void WriteOptionalMap(
             this IOpenApiWriter writer,
             string name,
-            Dictionary<string, string>? elements,
+            IDictionary<string, string>? elements,
             Action<IOpenApiWriter, string> action)
         {
             if (elements != null && elements.Any())
@@ -320,7 +320,7 @@ namespace Microsoft.OpenApi.Writers
         public static void WriteOptionalMap(
             this IOpenApiWriter writer,
             string name,
-            Dictionary<string, bool>? elements,
+            IDictionary<string, bool>? elements,
             Action<IOpenApiWriter, bool> action)
         {
             if (elements != null && elements.Any())
@@ -339,7 +339,7 @@ namespace Microsoft.OpenApi.Writers
         public static void WriteOptionalMap(
             this IOpenApiWriter writer,
             string name,
-            Dictionary<string, HashSet<string>>? elements,
+            IDictionary<string, HashSet<string>>? elements,
             Action<IOpenApiWriter, HashSet<string>> action)
         {
             if (elements != null && elements.Any())
@@ -359,7 +359,7 @@ namespace Microsoft.OpenApi.Writers
         public static void WriteOptionalMap<T>(
             this IOpenApiWriter writer,
             string name,
-            Dictionary<string, T>? elements,
+            IDictionary<string, T>? elements,
             Action<IOpenApiWriter, T> action)
             where T : IOpenApiElement
         {
@@ -380,7 +380,7 @@ namespace Microsoft.OpenApi.Writers
         public static void WriteOptionalMap<T>(
             this IOpenApiWriter writer,
             string name,
-            Dictionary<string, T>? elements,
+            IDictionary<string, T>? elements,
             Action<IOpenApiWriter, string, T> action)
             where T : IOpenApiElement
         {
@@ -401,7 +401,7 @@ namespace Microsoft.OpenApi.Writers
         public static void WriteRequiredMap<T>(
             this IOpenApiWriter writer,
             string name,
-            Dictionary<string, T>? elements,
+            IDictionary<string, T>? elements,
             Action<IOpenApiWriter, T> action)
             where T : IOpenApiElement
         {
@@ -439,7 +439,7 @@ namespace Microsoft.OpenApi.Writers
         private static void WriteMapInternal<T>(
             this IOpenApiWriter writer,
             string name,
-            Dictionary<string, T>? elements,
+            IDictionary<string, T>? elements,
             Action<IOpenApiWriter, T> action)
         {
             WriteMapInternal(writer, name, elements, (w, _, s) => action(w, s));
@@ -448,7 +448,7 @@ namespace Microsoft.OpenApi.Writers
         private static void WriteMapInternal<T>(
             this IOpenApiWriter writer,
             string name,
-            Dictionary<string, T>? elements,
+            IDictionary<string, T>? elements,
             Action<IOpenApiWriter, string, T> action)
         {
             Utils.CheckArgumentNull(action);

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
+using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Interfaces;
 
 namespace Microsoft.OpenApi.Writers
@@ -458,6 +459,17 @@ namespace Microsoft.OpenApi.Writers
 
             if (elements != null)
             {
+                var settings = writer.GetSettings();
+
+                if (settings?.EnableSorting == true)
+                {
+                    elements = elements.Sort(); // sort with default comparer
+                }
+                else if (settings?.KeyComparer != null)
+                {
+                    elements = elements.Sort(settings.KeyComparer); // sort using custom comparer
+                }
+
                 foreach (var item in elements)
                 {
                     writer.WritePropertyName(item.Key);

--- a/src/Microsoft.OpenApi/Writers/OpenApiWriterSettings.cs
+++ b/src/Microsoft.OpenApi/Writers/OpenApiWriterSettings.cs
@@ -1,3 +1,4 @@
+﻿using System.Collections.Generic;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
 
@@ -24,5 +25,15 @@ namespace Microsoft.OpenApi.Writers
             return (reference.IsLocal && InlineLocalReferences)
                              || (reference.IsExternal && InlineExternalReferences);
         }
+
+        /// <summary>  
+        /// Enables sorting of collections using the default comparer  
+        /// </summary>  
+        public bool EnableSorting { get; set; }
+
+        /// <summary>  
+        /// Custom comparer for sorting collections.  
+        /// </summary>  
+        public IComparer<string>? KeyComparer { get; set; }
     }
 }

--- a/test/Microsoft.OpenApi.Hidi.Tests/Formatters/PowerShellFormatterTests.cs
+++ b/test/Microsoft.OpenApi.Hidi.Tests/Formatters/PowerShellFormatterTests.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Hidi.Formatters;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
 using Microsoft.OpenApi.Services;
 using Xunit;
 
@@ -123,7 +125,7 @@ namespace Microsoft.OpenApi.Hidi.Tests.Formatters
                                             {
                                                 Name = "ids",
                                                 In = ParameterLocation.Query,
-                                                Content = new()
+                                                Content = new Dictionary<string, OpenApiMediaType>()
                                                 {
                                                     {
                                                         "application/json",
@@ -142,7 +144,7 @@ namespace Microsoft.OpenApi.Hidi.Tests.Formatters
                                                 }
                                             }
                                         ],
-                                        Extensions = new()
+                                        Extensions = new Dictionary<string, IOpenApiExtension>()
                                         {
                                             {
                                                 "x-ms-docs-operation-type", new JsonNodeExtension("function")
@@ -156,12 +158,12 @@ namespace Microsoft.OpenApi.Hidi.Tests.Formatters
                 },
                 Components = new()
                 {
-                    Schemas = new()
+                    Schemas = new Dictionary<string, IOpenApiSchema>()
                     {
                         { "TestSchema",  new OpenApiSchema
                             {
                                 Type = JsonSchemaType.Object,
-                                Properties = new()
+                                Properties = new Dictionary<string, IOpenApiSchema>()
                                 {
                                     {
                                         "averageAudioDegradation", new OpenApiSchema

--- a/test/Microsoft.OpenApi.Hidi.Tests/UtilityFiles/OpenApiDocumentMock.cs
+++ b/test/Microsoft.OpenApi.Hidi.Tests/UtilityFiles/OpenApiDocumentMock.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.Interfaces;
 using Microsoft.OpenApi.Models.References;
@@ -97,7 +98,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                             "200", new OpenApiResponse()
                                             {
                                                 Description = "Success",
-                                                Content = new()
+                                                Content = new Dictionary<string, OpenApiMediaType>()
                                                 {
                                                     {
                                                         applicationJsonMediaType,
@@ -158,7 +159,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                             "200", new OpenApiResponse()
                                             {
                                                 Description = "Success",
-                                                Content = new()
+                                                Content = new Dictionary<string, OpenApiMediaType>()
                                                 {
                                                     {
                                                         applicationJsonMediaType,
@@ -206,7 +207,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                             "200", new OpenApiResponse()
                                             {
                                                 Description = "Retrieved entities",
-                                                Content = new()
+                                                Content = new Dictionary<string, OpenApiMediaType>()
                                                 {
                                                     {
                                                         applicationJsonMediaType,
@@ -216,7 +217,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                                             {
                                                                 Title = "Collection of user",
                                                                 Type = JsonSchemaType.Object,
-                                                                Properties = new()
+                                                                Properties = new Dictionary<string, IOpenApiSchema>()
                                                                 {
                                                                     {
                                                                         "value",
@@ -252,7 +253,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                             "200", new OpenApiResponse()
                                             {
                                                 Description = "Retrieved entity",
-                                                Content = new()
+                                                Content = new Dictionary<string, OpenApiMediaType>()
                                                 {
                                                     {
                                                         applicationJsonMediaType,
@@ -315,7 +316,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                             "200", new OpenApiResponse()
                                             {
                                                 Description = "Retrieved navigation property",
-                                                Content = new()
+                                                Content = new Dictionary<string, OpenApiMediaType>()
                                                 {
                                                     {
                                                         applicationJsonMediaType,
@@ -362,7 +363,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                             "200", new OpenApiResponse()
                                             {
                                                 Description = "Success",
-                                                Content = new()
+                                                Content = new Dictionary<string, OpenApiMediaType>()
                                                 {
                                                     {
                                                         applicationJsonMediaType,
@@ -419,7 +420,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                             "200", new OpenApiResponse()
                                             {
                                                 Description = "Retrieved navigation property",
-                                                Content = new()
+                                                Content = new Dictionary<string, OpenApiMediaType>()
                                                 {
                                                     {
                                                         applicationJsonMediaType,
@@ -429,7 +430,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                                             {
                                                                 Title = "Collection of hostSecurityProfile",
                                                                 Type = JsonSchemaType.Object,
-                                                                Properties = new()
+                                                                Properties = new Dictionary<string, IOpenApiSchema>()
                                                                 {
                                                                     {
                                                                         "value",
@@ -471,7 +472,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                             {
                                                 Type = JsonSchemaType.String
                                             },
-                                            Extensions = new()
+                                            Extensions = new Dictionary<string, IOpenApiExtension>()
                                             {
                                                 {
                                                     "x-ms-docs-key-type", new JsonNodeExtension("call")
@@ -488,7 +489,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                             }
                                         }
                                     },
-                                    Extensions = new()
+                                    Extensions = new Dictionary<string, IOpenApiExtension>()
                                     {
                                         {
                                             "x-ms-docs-operation-type", new JsonNodeExtension("action")
@@ -519,7 +520,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                             {
                                                 Type = JsonSchemaType.String
                                             },
-                                            Extensions = new()
+                                            Extensions = new Dictionary<string, IOpenApiExtension>()
                                             {
                                                 {
                                                     "x-ms-docs-key-type", new JsonNodeExtension("group")
@@ -536,7 +537,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                             {
                                                 Type = JsonSchemaType.String
                                             },
-                                            Extensions = new()
+                                            Extensions = new Dictionary<string, IOpenApiExtension>()
                                             {
                                                 {
                                                     "x-ms-docs-key-type", new JsonNodeExtension("event")
@@ -550,7 +551,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                             "200", new OpenApiResponse()
                                             {
                                                 Description = "Success",
-                                                Content = new()
+                                                Content = new Dictionary<string, OpenApiMediaType>()
                                                 {
                                                     {
                                                         applicationJsonMediaType,
@@ -558,7 +559,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                                         {
                                                             Schema = new OpenApiSchema()
                                                             {
-                                                                Properties = new()
+                                                                Properties = new Dictionary<string, IOpenApiSchema>()
                                                                 {
                                                                     {
                                                                         "value",
@@ -575,7 +576,7 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                                             }
                                         }
                                     },
-                                    Extensions = new()
+                                    Extensions = new Dictionary<string, IOpenApiExtension>()
                                     {
                                         {
                                             "x-ms-docs-operation-type", new JsonNodeExtension("function")
@@ -601,14 +602,14 @@ namespace Microsoft.OpenApi.Tests.UtilityFiles
                 },
                 Components = new()
                 {
-                    Schemas = new()
+                    Schemas = new Dictionary<string, IOpenApiSchema>()
                     {
                         {
                             "microsoft.graph.networkInterface", new OpenApiSchema
                             {
                                 Title = "networkInterface",
                                 Type = JsonSchemaType.Object,
-                                Properties = new()
+                                Properties = new Dictionary<string, IOpenApiSchema>()
                                 {
                                     {
                                         "description", new OpenApiSchema

--- a/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/TryLoadReferenceV2Tests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ReferenceService/TryLoadReferenceV2Tests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.OpenApi.Readers.Tests.ReferenceService
                 new OpenApiResponse
                 {
                     Description = "Entity not found.",
-                    Content = new()
+                    Content = new Dictionary<string, OpenApiMediaType>()
                     {
                         ["application/json"] = new()
                     }
@@ -89,7 +89,7 @@ namespace Microsoft.OpenApi.Readers.Tests.ReferenceService
             var expected = new OpenApiResponse
                 {
                     Description = "General Error",
-                    Content = new()
+                    Content = new Dictionary<string, OpenApiMediaType>()
                     {
                         ["application/json"] = new()
                         {

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
 
             var okSchema = new OpenApiSchema
             {
-                Properties = new()
+                Properties = new Dictionary<string, IOpenApiSchema>()
                 {
                     { "id", new OpenApiSchema
                         {
@@ -89,7 +89,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
 
             var errorSchema = new OpenApiSchema
             {
-                Properties = new()
+                Properties = new Dictionary<string, IOpenApiSchema>()
                 {
                     { "code", new OpenApiSchema
                         {
@@ -151,7 +151,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                                     ["200"] = new OpenApiResponse()
                                     {
                                         Description = "An OK response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = okMediaType,
                                             ["application/xml"] = okMediaType,
@@ -160,7 +160,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                                     ["default"] = new OpenApiResponse()
                                     {
                                         Description = "An error response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = errorMediaType,
                                             ["application/xml"] = errorMediaType
@@ -175,7 +175,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                                     ["200"] = new OpenApiResponse()
                                     {
                                         Description = "An OK response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["html/text"] = okMediaType
                                         }
@@ -183,7 +183,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                                     ["default"] = new OpenApiResponse()
                                     {
                                         Description = "An error response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["html/text"] = errorMediaType
                                         }
@@ -197,7 +197,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                                     ["200"] = new OpenApiResponse()
                                     {
                                         Description = "An OK response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = okMediaType,
                                             ["application/xml"] = okMediaType,
@@ -206,7 +206,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                                     ["default"] = new OpenApiResponse()
                                     {
                                         Description = "An error response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = errorMediaType,
                                             ["application/xml"] = errorMediaType
@@ -219,7 +219,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 },
                 Components = new()
                 {
-                    Schemas = new()
+                    Schemas = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["Item"] = okSchema,
                         ["Error"] = errorSchema

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiOperationTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.Interfaces;
 using Microsoft.OpenApi.Models.References;
@@ -50,7 +51,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 ["200"] = new OpenApiResponse
                 {
                     Description = "Pet updated.",
-                    Content = new()
+                    Content = new Dictionary<string, OpenApiMediaType>()
                     {
                         ["application/json"] = new OpenApiMediaType(),
                         ["application/xml"] = new OpenApiMediaType()
@@ -82,7 +83,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             {
                 Description = "Pet to update with",
                 Required = true,
-                Content = new()
+                Content = new Dictionary<string, OpenApiMediaType>()
                 {
                     ["application/json"] = new OpenApiMediaType
                     {
@@ -92,7 +93,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                         }
                     }
                 },
-                Extensions = new()
+                Extensions = new Dictionary<string, IOpenApiExtension>()
                 {
                     [OpenApiConstants.BodyName] = new JsonNodeExtension("petObject")
                 }
@@ -102,7 +103,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 ["200"] = new OpenApiResponse
                 {
                     Description = "Pet updated.",
-                    Content = new()
+                    Content = new Dictionary<string, OpenApiMediaType>()
                     {
                         ["application/json"] = new OpenApiMediaType(),
                         ["application/xml"] = new OpenApiMediaType()
@@ -111,7 +112,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                 ["405"] = new OpenApiResponse
                 {
                     Description = "Invalid input",
-                    Content = new()
+                    Content = new Dictionary<string, OpenApiMediaType>()
                     {
                         ["application/json"] = new OpenApiMediaType(),
                         ["application/xml"] = new OpenApiMediaType()
@@ -213,7 +214,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                         { "200", new OpenApiResponse()
                         {
                             Description = "An array of float response",
-                            Content = new()
+                            Content = new Dictionary<string, OpenApiMediaType>()
                             {
                                 ["application/json"] = new OpenApiMediaType()
                                 {
@@ -532,7 +533,7 @@ responses: { }";
             openApiDocument.AddComponent("UserRequest", new OpenApiRequestBody
             {
                 Description = "User creation request body",
-                Content = new()
+                Content = new Dictionary<string, OpenApiMediaType>()
                 {
                     ["application/json"] = new OpenApiMediaType
                     {

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiPathItemTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiPathItemTests.cs
@@ -64,14 +64,14 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                     ],
                     RequestBody = new OpenApiRequestBody()
                     {
-                        Content = new()
+                        Content = new Dictionary<string, OpenApiMediaType>()
                         {
                             ["application/x-www-form-urlencoded"] = new()
                             {
                                 Schema = new OpenApiSchema()
                                 {
                                     Type = JsonSchemaType.Object,
-                                    Properties = new()
+                                    Properties = new Dictionary<string, IOpenApiSchema>()
                                     {
                                         ["name"] = new OpenApiSchema()
                                         {
@@ -95,7 +95,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                                Schema = new OpenApiSchema()
                                 {
                                     Type = JsonSchemaType.Object,
-                                    Properties = new()
+                                    Properties = new Dictionary<string, IOpenApiSchema>()
                                     {
                                         ["name"] = new OpenApiSchema()
                                         {
@@ -121,7 +121,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                         ["200"] = new OpenApiResponse()
                         {
                             Description = "Pet updated.",
-                            Content = new()
+                            Content = new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/json"] = new(),
                                     ["application/xml"] = new()
@@ -130,7 +130,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                         ["405"] = new OpenApiResponse()
                         {
                             Description = "Invalid input",
-                            Content = new()
+                            Content = new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/json"] = new(),
                                     ["application/xml"] = new()
@@ -170,14 +170,14 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                     ],
                     RequestBody = new OpenApiRequestBody()
                     {
-                        Content = new()
+                        Content = new Dictionary<string, OpenApiMediaType>()
                         {
                             ["application/x-www-form-urlencoded"] = new()
                             {
                                 Schema = new OpenApiSchema()
                                 {
                                     Type = JsonSchemaType.Object,
-                                    Properties = new()
+                                    Properties = new Dictionary<string, IOpenApiSchema>()
                                     {
                                         ["name"] = new OpenApiSchema()
                                         {
@@ -206,7 +206,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                                 Schema = new OpenApiSchema()
                                 {
                                     Type = JsonSchemaType.Object,
-                                    Properties = new()
+                                    Properties = new Dictionary<string, IOpenApiSchema>()
                                     {
                                         ["name"] = new OpenApiSchema()
                                         {
@@ -237,7 +237,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                         ["200"] = new OpenApiResponse()
                         {
                             Description = "Pet updated.",
-                            Content = new()
+                            Content = new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/json"] = new(),
                                     ["application/xml"] = new()

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiSchemaTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
@@ -8,6 +9,7 @@ using FluentAssertions;
 using FluentAssertions.Equivalency;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
 using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Reader.ParseNodes;
@@ -111,7 +113,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             var targetSchema = new OpenApiSchema()
             {
                 Type = JsonSchemaType.Object,
-                Properties = new()
+                Properties = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["prop1"] = new OpenApiSchema()
                     {
@@ -119,7 +121,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                     }
                 }
             };
-            workingDocument.Components.Schemas = new()
+            workingDocument.Components.Schemas = new Dictionary<string, IOpenApiSchema>()
             {
                 [referenceId] = targetSchema
             };
@@ -127,7 +129,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             var referenceSchema = new OpenApiSchema()
             {
                 Type = JsonSchemaType.Object,
-                Properties = new()
+                Properties = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["propA"] = new OpenApiSchemaReference(referenceId, workingDocument),
                 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiDocumentTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
 
             var components = new OpenApiComponents
             {
-                Schemas = new()
+                Schemas = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["petSchema"] =  new OpenApiSchema()
                     {
@@ -46,7 +46,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                         {
                             { "tag", new HashSet<string> { "category" } }
                         },
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["id"] = new OpenApiSchema()
                             {
@@ -78,7 +78,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                         {
                             { "tag", new HashSet<string> { "category" } }
                         },
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["id"] = new OpenApiSchema()
                             {
@@ -154,7 +154,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                                     ["200"] = new OpenApiResponse
                                     {
                                         Description = "pet response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = new OpenApiMediaType
                                             {
@@ -182,7 +182,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                                 {
                                     Description = "Information about a new pet in the system",
                                     Required = true,
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -195,7 +195,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                                     ["200"] = new OpenApiResponse
                                     {
                                         Description = "Return a 200 status to indicate that the data was received successfully",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = new OpenApiMediaType
                                             {
@@ -224,7 +224,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
 
             var components = new OpenApiComponents
             {
-                Schemas = new()
+                Schemas = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["petSchema"] = new OpenApiSchema()
                     {
@@ -238,7 +238,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                         {
                             { "tag", new HashSet<string> { "category" } }
                         },
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["id"] = new OpenApiSchema()
                             {
@@ -270,7 +270,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                         {
                             { "tag", new HashSet<string> { "category" } }
                         },
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["id"] = new OpenApiSchema()
                             {
@@ -344,7 +344,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "pet response",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -372,7 +372,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                             {
                                 Description = "Information about a new pet in the system",
                                 Required = true,
-                                Content = new()
+                                Content = new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -385,7 +385,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "Return a 200 status to indicate that the data was received successfully",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -447,7 +447,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             var expectedSchema = new OpenApiSchema
             {
                 Type = JsonSchemaType.Object,
-                Properties = new()
+                Properties = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["prop1"] = new OpenApiSchema
                     {
@@ -462,7 +462,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                         Type = JsonSchemaType.String
                     }
                 },
-                PatternProperties = new()
+                PatternProperties = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["^x-.*$"] = new OpenApiSchema
                     {

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiSchemaTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                 Schema = new Uri("https://json-schema.org/draft/2020-12/schema"),
                 Description = "A representation of a person, company, organization, or place",
                 Type = JsonSchemaType.Object,
-                Properties = new()
+                Properties = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["fruits"] = new OpenApiSchema
                     {
@@ -70,7 +70,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
                         {
                             { "veggieType", new HashSet<string> { "veggieColor", "veggieSize" } }
                         },
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["veggieName"] = new OpenApiSchema
                             {
@@ -181,7 +181,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             var expectedSchema = new OpenApiSchema
             {
                 Type = JsonSchemaType.Object,
-                Properties = new()
+                Properties = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["one"] = new OpenApiSchema()
                     {
@@ -205,7 +205,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             var expectedSchema = new OpenApiSchema
             {
                 Type = JsonSchemaType.Object,
-                Properties = new()
+                Properties = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["one"] = new OpenApiSchema()
                     {

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -190,7 +190,7 @@ paths: {}
 
             var components = new OpenApiComponents
             {
-                Schemas = new()
+                Schemas = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["pet1"] = new OpenApiSchema()
                     {
@@ -200,7 +200,7 @@ paths: {}
                                 "id",
                                 "name"
                             },
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["id"] = new OpenApiSchema()
                             {
@@ -224,7 +224,7 @@ paths: {}
                             {
                                 "name"
                             },
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["id"] = new OpenApiSchema()
                             {
@@ -249,7 +249,7 @@ paths: {}
                                 "code",
                                 "message"
                             },
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["code"] = new OpenApiSchema()
                             {
@@ -343,7 +343,7 @@ paths: {}
                                     ["200"] = new OpenApiResponse
                                     {
                                         Description = "pet response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = new OpenApiMediaType
                                             {
@@ -366,7 +366,7 @@ paths: {}
                                     ["4XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected client error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -377,7 +377,7 @@ paths: {}
                                     ["5XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected server error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -395,7 +395,7 @@ paths: {}
                                 {
                                     Description = "Pet to add to the store",
                                     Required = true,
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -408,7 +408,7 @@ paths: {}
                                     ["200"] = new OpenApiResponse
                                     {
                                         Description = "pet response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = new OpenApiMediaType
                                             {
@@ -419,7 +419,7 @@ paths: {}
                                     ["4XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected client error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -430,7 +430,7 @@ paths: {}
                                     ["5XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected server error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -471,7 +471,7 @@ paths: {}
                                     ["200"] = new OpenApiResponse
                                     {
                                         Description = "pet response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = new OpenApiMediaType
                                             {
@@ -486,7 +486,7 @@ paths: {}
                                     ["4XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected client error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -497,7 +497,7 @@ paths: {}
                                     ["5XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected server error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -535,7 +535,7 @@ paths: {}
                                     ["4XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected client error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -546,7 +546,7 @@ paths: {}
                                     ["5XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected server error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -576,7 +576,7 @@ paths: {}
 
             var components = new OpenApiComponents
             {
-                Schemas = new()
+                Schemas = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["pet1"] = new OpenApiSchema()
                     {
@@ -586,7 +586,7 @@ paths: {}
                                 "id",
                                 "name"
                             },
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["id"] = new OpenApiSchema()
                             {
@@ -610,7 +610,7 @@ paths: {}
                             {
                                 "name"
                             },
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["id"] = new OpenApiSchema()
                             {
@@ -635,7 +635,7 @@ paths: {}
                                 "code",
                                 "message"
                             },
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["code"] = new OpenApiSchema()
                             {
@@ -767,7 +767,7 @@ paths: {}
                                     ["200"] = new OpenApiResponse
                                     {
                                         Description = "pet response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = new OpenApiMediaType
                                             {
@@ -790,7 +790,7 @@ paths: {}
                                     ["4XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected client error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -801,7 +801,7 @@ paths: {}
                                     ["5XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected server error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -824,7 +824,7 @@ paths: {}
                                 {
                                     Description = "Pet to add to the store",
                                     Required = true,
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -837,7 +837,7 @@ paths: {}
                                     ["200"] = new OpenApiResponse
                                     {
                                         Description = "pet response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = new OpenApiMediaType
                                             {
@@ -848,7 +848,7 @@ paths: {}
                                     ["4XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected client error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -859,7 +859,7 @@ paths: {}
                                     ["5XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected server error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -912,7 +912,7 @@ paths: {}
                                     ["200"] = new OpenApiResponse
                                     {
                                         Description = "pet response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = new OpenApiMediaType
                                             {
@@ -927,7 +927,7 @@ paths: {}
                                     ["4XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected client error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -938,7 +938,7 @@ paths: {}
                                     ["5XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected server error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -976,7 +976,7 @@ paths: {}
                                     ["4XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected client error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -987,7 +987,7 @@ paths: {}
                                     ["5XX"] = new OpenApiResponse
                                     {
                                         Description = "unexpected server error",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/html"] = new OpenApiMediaType
                                             {
@@ -1247,7 +1247,7 @@ paths: {}
             {
                 Type = JsonSchemaType.Object,
                 Description = "A pet",
-                Properties = new()
+                Properties = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["id"] = new OpenApiSchema
                     {
@@ -1282,7 +1282,7 @@ paths: {}
                             ["200"] = new OpenApiResponse
                             {
                                 Description = "A list of pets",
-                                Content = new()
+                                Content = new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiParameterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiParameterTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                 {
                     In = ParameterLocation.Query,
                     Name = "coordinates",
-                    Content = new()
+                    Content = new Dictionary<string, OpenApiMediaType>()
                     {
                         ["application/json"] = new()
                         {
@@ -122,7 +122,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
                                     "lat",
                                     "long"
                                 },
-                                Properties = new()
+                                Properties = new Dictionary<string, IOpenApiSchema>()
                                 {
                                     ["lat"] = new OpenApiSchema()
                                     {

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
@@ -10,6 +10,7 @@ using FluentAssertions;
 using FluentAssertions.Equivalency;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
 using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Reader;
 using Microsoft.OpenApi.Reader.ParseNodes;
@@ -195,7 +196,7 @@ get:
             new OpenApiSchema
             {
                 Type = JsonSchemaType.Object,
-                Properties = new()
+                Properties = new Dictionary<string, IOpenApiSchema>()
                 {
                         ["id"] = new OpenApiSchema()
                         {
@@ -241,12 +242,12 @@ get:
 
             var expectedComponents = new OpenApiComponents
             {
-                Schemas = new()
+                Schemas = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["ErrorModel"] = new OpenApiSchema()
                     {
                         Type = JsonSchemaType.Object,
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["code"] = new OpenApiSchema()
                             {
@@ -274,7 +275,7 @@ get:
                             {
                                 Type = JsonSchemaType.Object,
                                 Required = new HashSet<string> {"rootCause"},
-                                Properties = new()
+                                Properties = new Dictionary<string, IOpenApiSchema>()
                                 {
                                     ["rootCause"] = new OpenApiSchema()
                                     {
@@ -298,7 +299,7 @@ get:
 
             var expectedComponents = new OpenApiComponents
             {
-                Schemas = new()
+                Schemas = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["Pet"] = new OpenApiSchema()
                     {
@@ -307,7 +308,7 @@ get:
                         {
                             PropertyName = "petType"
                         },
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["name"] = new OpenApiSchema()
                             {
@@ -334,7 +335,7 @@ get:
                             {
                                 Type = JsonSchemaType.Object,
                                 Required = new HashSet<string>{"huntingSkill"},
-                                Properties = new()
+                                Properties = new Dictionary<string, IOpenApiSchema>()
                                 {
                                     ["huntingSkill"] = new OpenApiSchema()
                                     {
@@ -362,7 +363,7 @@ get:
                             {
                                 Type = JsonSchemaType.Object,
                                 Required = new HashSet<string>{"packSize"},
-                                Properties = new()
+                                Properties = new Dictionary<string, IOpenApiSchema>()
                                 {
                                     ["packSize"] = new OpenApiSchema()
                                     {
@@ -404,7 +405,7 @@ get:
 
             var expectedComponents = new OpenApiComponents
             {
-                Schemas = new()
+                Schemas = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["RelativePathModel"] = new OpenApiSchema()
                     {

--- a/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.SortOpenApiDocumentSucceeds_version=OpenApi2_0.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.SortOpenApiDocumentSucceeds_version=OpenApi2_0.verified.txt
@@ -1,0 +1,57 @@
+﻿swagger: '2.0'
+info:
+  title: Test API
+  version: '1.0'
+paths:
+  pet:
+    get:
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  newPet:
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Information about a new pet in the system
+          schema:
+            $ref: '#/definitions/Pet'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+definitions:
+  errorModel:
+    type: object
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+  newPet:
+    type: object
+    required:
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+  Pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string

--- a/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.SortOpenApiDocumentSucceeds_version=OpenApi3_0.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.SortOpenApiDocumentSucceeds_version=OpenApi3_0.verified.txt
@@ -1,0 +1,56 @@
+﻿openapi: 3.0.4
+info:
+  title: Test API
+  version: '1.0'
+paths:
+  pet:
+    get:
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  newPet:
+    post:
+      requestBody:
+        description: Information about a new pet in the system
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+components:
+  schemas:
+    errorModel:
+      required:
+        - code
+        - message
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    newPet:
+      required:
+        - name
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string

--- a/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.SortOpenApiDocumentSucceeds_version=OpenApi3_1.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.SortOpenApiDocumentSucceeds_version=OpenApi3_1.verified.txt
@@ -1,0 +1,56 @@
+﻿openapi: '3.1.1'
+info:
+  title: Test API
+  version: '1.0'
+paths:
+  pet:
+    get:
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  newPet:
+    post:
+      requestBody:
+        description: Information about a new pet in the system
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+components:
+  schemas:
+    errorModel:
+      required:
+        - code
+        - message
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    newPet:
+      required:
+        - name
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string

--- a/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.SortOpenApiDocumentUsingCustomComparerSucceeds_version=OpenApi2_0.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.SortOpenApiDocumentUsingCustomComparerSucceeds_version=OpenApi2_0.verified.txt
@@ -1,0 +1,57 @@
+﻿swagger: '2.0'
+info:
+  title: Test API
+  version: '1.0'
+paths:
+  pet:
+    get:
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  newPet:
+    post:
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          description: Information about a new pet in the system
+          schema:
+            $ref: '#/definitions/Pet'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+definitions:
+  errorModel:
+    type: object
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+  newPet:
+    type: object
+    required:
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+  pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string

--- a/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.SortOpenApiDocumentUsingCustomComparerSucceeds_version=OpenApi3_0.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.SortOpenApiDocumentUsingCustomComparerSucceeds_version=OpenApi3_0.verified.txt
@@ -1,0 +1,56 @@
+﻿openapi: 3.0.4
+info:
+  title: Test API
+  version: '1.0'
+paths:
+  pet:
+    get:
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  newPet:
+    post:
+      requestBody:
+        description: Information about a new pet in the system
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+components:
+  schemas:
+    errorModel:
+      required:
+        - code
+        - message
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    newPet:
+      required:
+        - name
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string

--- a/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.SortOpenApiDocumentUsingCustomComparerSucceeds_version=OpenApi3_1.verified.txt
+++ b/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.SortOpenApiDocumentUsingCustomComparerSucceeds_version=OpenApi3_1.verified.txt
@@ -1,0 +1,56 @@
+﻿openapi: '3.1.1'
+info:
+  title: Test API
+  version: '1.0'
+paths:
+  pet:
+    get:
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+  newPet:
+    post:
+      requestBody:
+        description: Information about a new pet in the system
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '200':
+          description: Return a 200 status to indicate that the data was received successfully
+components:
+  schemas:
+    errorModel:
+      required:
+        - code
+        - message
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    newPet:
+      required:
+        - name
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string

--- a/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Extensions/DictionaryExtensionsTests.cs
@@ -1,0 +1,217 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models.Interfaces;
+using Microsoft.OpenApi.Models.References;
+using Microsoft.OpenApi.Writers;
+using VerifyXunit;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Extensions
+{
+    public class DictionaryExtensionsTests
+    {
+        public static readonly OpenApiDocument Document = new OpenApiDocument
+        {
+            Info = new OpenApiInfo { Title = "Test API", Version = "1.0" },
+            Paths = new OpenApiPaths
+            {
+                ["pet"] = new OpenApiPathItem
+                {
+                    Operations = new ()
+                    {
+                        [HttpMethod.Get] = new OpenApiOperation
+                        {
+                            Responses = new OpenApiResponses
+                            {
+                                ["200"] = new OpenApiResponse
+                                {
+                                    Description = "Return a 200 status to indicate that the data was received successfully"
+                                }
+                            }
+                        }
+                    }
+                },
+                ["newPet"] = new OpenApiPathItem
+                {
+                    Operations = new()
+                    {
+                        [HttpMethod.Post] = new OpenApiOperation
+                        {
+                            RequestBody = new OpenApiRequestBody
+                            {
+                                Description = "Information about a new pet in the system",
+                                Content = new Dictionary<string, OpenApiMediaType>()
+                                {
+                                    ["application/json"] = new OpenApiMediaType
+                                    {
+                                        Schema = new OpenApiSchemaReference("Pet", null)
+                                    }
+                                }
+                            },
+                            Responses = new OpenApiResponses
+                            {
+                                ["200"] = new OpenApiResponse
+                                {
+                                    Description = "Return a 200 status to indicate that the data was received successfully"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            Components = new OpenApiComponents
+            {
+                Schemas = new Dictionary<string, IOpenApiSchema>()
+                {
+                    ["pet"] = new OpenApiSchema()
+                    {
+                        Required = new HashSet<string>
+                        {
+                            "id", "name"
+                        },
+                        Properties = new Dictionary<string, IOpenApiSchema>()
+                        {
+                            ["name"] = new OpenApiSchema()
+                            {
+                                Type = JsonSchemaType.String
+                            },
+                            ["id"] = new OpenApiSchema()
+                            {
+                                Type = JsonSchemaType.Integer,
+                                Format = "int64"
+                            },
+                            ["tag"] = new OpenApiSchema()
+                            {
+                                Type = JsonSchemaType.String
+                            }
+                        },
+                    },
+                    ["newPet"] = new OpenApiSchema()
+                    {
+                        Type = JsonSchemaType.Object,
+                        Required = new HashSet<string>
+                        {
+                            "name"
+                        },
+                        Properties = new Dictionary<string, IOpenApiSchema>()
+                        {
+                            ["name"] = new OpenApiSchema()
+                            {
+                                Type = JsonSchemaType.String
+                            },
+                            ["id"] = new OpenApiSchema()
+                            {
+                                Type = JsonSchemaType.Integer,
+                                Format = "int64"
+                            }
+                        }
+                    },
+                    ["errorModel"] = new OpenApiSchema()
+                    {
+                        Type = JsonSchemaType.Object,
+                        Required = new HashSet<string>
+                        {
+                            "code",
+                            "message"
+                        },
+                        Properties = new Dictionary<string, IOpenApiSchema>()
+                        {
+                            ["message"] = new OpenApiSchema()
+                            {
+                                Type = JsonSchemaType.String
+                            },
+                            ["code"] = new OpenApiSchema()
+                            {
+                                Type = JsonSchemaType.Integer,
+                                Format = "int32"
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        [Fact]
+        public void SortEmptyDictionaryReturnsEmptyDictionary()
+        {
+            // Arrange
+            Document.Components.Headers = new Dictionary<string, IOpenApiHeader>();
+
+            // Act
+            var sortedDictionary = Document.Components.Headers.Sort();
+
+            // Assert
+            Assert.Empty(sortedDictionary);
+        }
+
+        [Fact]
+        public async Task SortOpenApiDocumentLexicographicallySucceeds()
+        {
+            // Arrange
+            var expected = @"required:
+  - id
+  - name
+properties:
+  id:
+    type: integer
+    format: int64
+  name:
+    type: string
+  tag:
+    type: string";
+
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var settings = new OpenApiWriterSettings
+            {
+                EnableSorting = true
+            };
+            var writer = new OpenApiYamlWriter(outputStringWriter, settings);
+
+            // Act
+            var schema = Document.Components.Schemas["pet"];
+
+            schema.SerializeAsV3(writer);
+            await writer.FlushAsync();
+            var actual = outputStringWriter.ToString();
+
+            // Assert
+            Assert.Equal(expected.MakeLineBreaksEnvironmentNeutral(), actual.MakeLineBreaksEnvironmentNeutral());
+        }
+
+        [Theory]
+        [MemberData(nameof(OpenApiSpecVersions))]
+        public async Task SortOpenApiDocumentUsingCustomComparerSucceeds(OpenApiSpecVersion version)
+        {
+            // Arrange
+            var outputStringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            var settings = new OpenApiWriterSettings
+            {
+                KeyComparer = StringComparer.OrdinalIgnoreCase
+            };
+            var writer = new OpenApiYamlWriter(outputStringWriter, settings);
+
+            // Act
+            Document.SerializeAs(version, writer);
+            await writer.FlushAsync();
+
+            // Assert
+            await Verifier.Verify(outputStringWriter).UseParameters(version);
+        }        
+
+        public static TheoryData<OpenApiSpecVersion> OpenApiSpecVersions()
+        {
+            var values = new TheoryData<OpenApiSpecVersion>();
+            foreach (var value in Enum.GetValues<OpenApiSpecVersion>())
+            {
+                values.Add(value);
+            }
+            return values;
+        }
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Extensions/Samples/petStore.yaml
+++ b/test/Microsoft.OpenApi.Tests/Extensions/Samples/petStore.yaml
@@ -1,0 +1,190 @@
+openapi: '3.0.0'
+info:
+  version: '1.0.0'
+  title: Swagger Petstore (Simple)
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  termsOfService: http://helloreverb.com/terms/
+  contact:
+    name: Swagger API team
+    email: foo@example.com
+    url: http://swagger.io
+  license:
+    name: MIT
+    url: http://opensource.org/licenses/MIT
+servers:
+    - url: http://petstore.swagger.io/api
+paths:
+  /pets:
+    get:
+      description: Returns all pets from the system that the user has access to
+      operationId: findPets
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          schema:
+            type: array
+            items:
+                type: string
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+                schema:
+                    type: array
+                    items:
+                      "$ref": '#/components/schemas/pet1'
+            application/xml:
+                schema:
+                    type: array
+                    items:
+                      "$ref": '#/components/schemas/pet1'
+
+        '4XX':
+          description: unexpected client error
+          content:
+            text/html:
+                schema:
+                    "$ref": '#/components/schemas/errorModel'
+        '5XX':
+          description: unexpected server error
+          content:
+            text/html:
+                schema:
+                    "$ref": '#/components/schemas/errorModel'
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      requestBody:
+          description: Pet to add to the store
+          required: true
+          content:
+            'application/json':
+              schema:
+                "$ref": '#/components/schemas/newPet'
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+                schema:
+                    "$ref": '#/components/schemas/pet1'
+        '4XX':
+          description: unexpected client error
+          content:
+            text/html:
+                schema:
+                    "$ref": '#/components/schemas/errorModel'
+        '5XX':
+          description: unexpected server error
+          content:
+            text/html:
+                schema:
+                    "$ref": '#/components/schemas/errorModel'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: findPetById
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: pet response
+          content:
+            application/json:
+                schema:
+                    "$ref": '#/components/schemas/pet1'
+            application/xml:
+                schema:
+                    "$ref": '#/components/schemas/pet1'
+        '4XX':
+          description: unexpected client error
+          content:
+            text/html:
+                schema:
+                    "$ref": '#/components/schemas/errorModel'
+        '5XX':
+          description: unexpected server error
+          content:
+            text/html:
+                schema:
+                    "$ref": '#/components/schemas/errorModel'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: pet deleted
+        '4XX':
+          description: unexpected client error
+          content:
+            text/html:
+                schema:
+                    "$ref": '#/components/schemas/errorModel'
+        '5XX':
+          description: unexpected server error
+          content:
+            text/html:
+                schema:
+                    "$ref": '#/components/schemas/errorModel'
+components:
+    schemas:
+        pet1:
+            type: object
+            required:
+            - id
+            - name
+            properties:
+              id:
+                type: integer
+                format: int64
+              name:
+                type: string
+              tag:
+                type: string
+        newPet:
+            type: object
+            required:
+            - name
+            properties:
+              id:
+                type: integer
+                format: int64
+              name:
+                type: string
+              tag:
+                type: string
+        errorModel:
+            type: object
+            required:
+            - code
+            - message
+            properties:
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string

--- a/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
+++ b/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
@@ -65,4 +65,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Extensions\Samples\" />
+  </ItemGroup>
 </Project>

--- a/test/Microsoft.OpenApi.Tests/Mocks/OpenApiDocumentMock.cs
+++ b/test/Microsoft.OpenApi.Tests/Mocks/OpenApiDocumentMock.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OpenApi.Tests.Mocks
                                     ["200"] = new OpenApiResponse
                                     {
                                         Description = "pet response",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = new OpenApiMediaType
                                             {

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiCallbackTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiCallbackTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.OpenApi.Tests.Models
                         {
                             RequestBody = new OpenApiRequestBody()
                             {
-                                Content = new()
+                                Content = new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/json"] = new()
                                     {
@@ -73,7 +73,7 @@ namespace Microsoft.OpenApi.Tests.Models
                         {
                             RequestBody = new OpenApiRequestBody()
                             {
-                                Content = new()
+                                Content = new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/json"] = new()
                                     {

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiComponentsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiComponentsTests.cs
@@ -17,11 +17,11 @@ namespace Microsoft.OpenApi.Tests.Models
     {
         public static OpenApiComponents AdvancedComponents = new()
         {
-            Schemas = new()
+            Schemas = new Dictionary<string, IOpenApiSchema>()
             {
                 ["schema1"] = new OpenApiSchema()
                 {
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property2"] = new OpenApiSchema()
                         {
@@ -66,11 +66,11 @@ namespace Microsoft.OpenApi.Tests.Models
 
         public static OpenApiComponents AdvancedComponentsWithReference = new()
         {
-            Schemas = new()
+            Schemas = new Dictionary<string, IOpenApiSchema>()
             {
                 ["schema1"] = new OpenApiSchema()
                 {
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property2"] = new OpenApiSchema()
                         {
@@ -81,7 +81,7 @@ namespace Microsoft.OpenApi.Tests.Models
                 },
                 ["schema2"] = new OpenApiSchema()
                 {
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property2"] = new OpenApiSchema()
                         {
@@ -123,7 +123,7 @@ namespace Microsoft.OpenApi.Tests.Models
 
         public static OpenApiComponents BrokenComponents = new()
         {
-            Schemas = new()
+            Schemas = new Dictionary<string, IOpenApiSchema>()
             {
                 ["schema1"] = new OpenApiSchema()
                 {
@@ -151,13 +151,13 @@ namespace Microsoft.OpenApi.Tests.Models
 
         public static OpenApiComponents TopLevelReferencingComponents = new()
         {
-            Schemas = new()
+            Schemas = new Dictionary<string, IOpenApiSchema>()
             {
                 ["schema1"] = new OpenApiSchemaReference("schema2", null),
                 ["schema2"] = new OpenApiSchema()
                 {
                     Type = JsonSchemaType.Object,
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property1"] = new OpenApiSchema()
                         {
@@ -170,12 +170,12 @@ namespace Microsoft.OpenApi.Tests.Models
 
         public static OpenApiComponents TopLevelSelfReferencingComponentsWithOtherProperties = new()
         {
-            Schemas = new()
+            Schemas = new Dictionary<string, IOpenApiSchema>()
             {
                 ["schema1"] = new OpenApiSchema()
                 {
                     Type = JsonSchemaType.Object,
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property1"] = new OpenApiSchema()
                         {
@@ -186,7 +186,7 @@ namespace Microsoft.OpenApi.Tests.Models
                 ["schema2"] = new OpenApiSchema()
                 {
                     Type = JsonSchemaType.Object,
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property1"] = new OpenApiSchema()
                         {
@@ -199,7 +199,7 @@ namespace Microsoft.OpenApi.Tests.Models
 
         public static OpenApiComponents TopLevelSelfReferencingComponents = new()
         {
-            Schemas = new()
+            Schemas = new Dictionary<string, IOpenApiSchema>()
             {
                 ["schema1"] = new OpenApiSchemaReference("schema1", null)
             }
@@ -207,11 +207,11 @@ namespace Microsoft.OpenApi.Tests.Models
 
         public static OpenApiComponents ComponentsWithPathItem = new OpenApiComponents
         {
-            Schemas = new()
+            Schemas = new Dictionary<string, IOpenApiSchema>()
             {
                 ["schema1"] = new OpenApiSchema()
                 {
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property2"] = new OpenApiSchema()
                         {
@@ -223,7 +223,7 @@ namespace Microsoft.OpenApi.Tests.Models
 
                 ["schema2"] = new OpenApiSchema()
                 {
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property2"] = new OpenApiSchema()
                         {
@@ -243,7 +243,7 @@ namespace Microsoft.OpenApi.Tests.Models
                             RequestBody = new OpenApiRequestBody
                             {
                                 Description = "Information about a new pet in the system",
-                                Content = new()
+                                Content = new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiContactTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiContactTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Xunit;
 
@@ -18,7 +20,7 @@ namespace Microsoft.OpenApi.Tests.Models
             Name = "API Support",
             Url = new("http://www.example.com/support"),
             Email = "support@example.com",
-            Extensions = new()
+            Extensions = new Dictionary<string, IOpenApiExtension>()
             {
                 {"x-internal-id", new JsonNodeExtension(42)}
             }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.Interfaces;
 using Microsoft.OpenApi.Models.References;
@@ -22,13 +23,13 @@ namespace Microsoft.OpenApi.Tests.Models
     {
         public static readonly OpenApiComponents TopLevelReferencingComponents = new OpenApiComponents()
         {
-            Schemas = new()
+            Schemas = new Dictionary<string, IOpenApiSchema>()
             {
                 ["schema1"] = new OpenApiSchemaReference("schema2", null),
                 ["schema2"] = new OpenApiSchema()
                 {
                     Type = JsonSchemaType.Object,
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property1"] = new OpenApiSchema()
                         {
@@ -42,12 +43,12 @@ namespace Microsoft.OpenApi.Tests.Models
 
         public static readonly OpenApiComponents TopLevelSelfReferencingComponentsWithOtherProperties = new OpenApiComponents()
         {
-            Schemas = new()
+            Schemas = new Dictionary<string, IOpenApiSchema>()
             {
                 ["schema1"] = new OpenApiSchema()
                 {
                     Type = JsonSchemaType.Object,
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property1"] = new OpenApiSchema()
                         {
@@ -60,7 +61,7 @@ namespace Microsoft.OpenApi.Tests.Models
                 ["schema2"] = new OpenApiSchema()
                 {
                     Type = JsonSchemaType.Object,
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property1"] = new OpenApiSchema()
                         {
@@ -74,7 +75,7 @@ namespace Microsoft.OpenApi.Tests.Models
 
         public static readonly OpenApiComponents TopLevelSelfReferencingComponents = new OpenApiComponents()
         {
-            Schemas = new()
+            Schemas = new Dictionary<string, IOpenApiSchema>()
             {
                 ["schema1"] = new OpenApiSchema()
                 {
@@ -114,7 +115,7 @@ namespace Microsoft.OpenApi.Tests.Models
 
         public static readonly OpenApiComponents AdvancedComponentsWithReference = new OpenApiComponents
         {
-            Schemas = new()
+            Schemas = new Dictionary<string, IOpenApiSchema>()
             {
                 ["pet"] = new OpenApiSchema()
                 {
@@ -124,7 +125,7 @@ namespace Microsoft.OpenApi.Tests.Models
                         "id",
                         "name"
                     },
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["id"] = new OpenApiSchema()
                         {
@@ -148,7 +149,7 @@ namespace Microsoft.OpenApi.Tests.Models
                     {
                         "name"
                     },
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["id"] = new OpenApiSchema()
                         {
@@ -173,7 +174,7 @@ namespace Microsoft.OpenApi.Tests.Models
                         "code",
                         "message"
                     },
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["code"] = new OpenApiSchema()
                         {
@@ -269,7 +270,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "pet response",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -292,7 +293,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["4XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected client error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -303,7 +304,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["5XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected server error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -321,7 +322,7 @@ namespace Microsoft.OpenApi.Tests.Models
                             {
                                 Description = "Pet to add to the store",
                                 Required = true,
-                                Content = new()
+                                Content = new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -334,7 +335,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "pet response",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -345,7 +346,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["4XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected client error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -356,7 +357,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["5XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected server error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -397,7 +398,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "pet response",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -412,7 +413,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["4XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected client error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -423,7 +424,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["5XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected server error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -461,7 +462,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["4XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected client error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -472,7 +473,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["5XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected server error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -491,7 +492,7 @@ namespace Microsoft.OpenApi.Tests.Models
 
         public static readonly OpenApiComponents AdvancedComponents = new OpenApiComponents
         {
-            Schemas = new()
+            Schemas = new Dictionary<string, IOpenApiSchema>()
             {
                 ["pet"] = new OpenApiSchema()
                 {
@@ -501,7 +502,7 @@ namespace Microsoft.OpenApi.Tests.Models
                         "id",
                         "name"
                     },
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["id"] = new OpenApiSchema()
                         {
@@ -525,7 +526,7 @@ namespace Microsoft.OpenApi.Tests.Models
                     {
                         "name"
                     },
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["id"] = new OpenApiSchema()
                         {
@@ -550,7 +551,7 @@ namespace Microsoft.OpenApi.Tests.Models
                         "code",
                         "message"
                     },
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["code"] = new OpenApiSchema()
                         {
@@ -645,7 +646,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "pet response",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -668,7 +669,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["4XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected client error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -679,7 +680,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["5XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected server error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -697,7 +698,7 @@ namespace Microsoft.OpenApi.Tests.Models
                             {
                                 Description = "Pet to add to the store",
                                 Required = true,
-                                Content = new()
+                                Content = new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -710,7 +711,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "pet response",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -721,7 +722,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["4XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected client error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -732,7 +733,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["5XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected server error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -773,7 +774,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "pet response",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -788,7 +789,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["4XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected client error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -799,7 +800,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["5XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected server error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -837,7 +838,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["4XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected client error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -848,7 +849,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["5XX"] = new OpenApiResponse
                                 {
                                     Description = "unexpected server error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new OpenApiMediaType
                                         {
@@ -883,7 +884,7 @@ namespace Microsoft.OpenApi.Tests.Models
                             RequestBody = new OpenApiRequestBody
                             {
                                 Description = "Information about a new pet in the system",
-                                Content = new()
+                                Content = new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/json"] = new OpenApiMediaType
                                     {
@@ -904,7 +905,7 @@ namespace Microsoft.OpenApi.Tests.Models
             },
             Components = new OpenApiComponents
             {
-                Schemas = new()
+                Schemas = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["Pet"] = new OpenApiSchema()
                     {
@@ -912,7 +913,7 @@ namespace Microsoft.OpenApi.Tests.Models
                         {
                            "id", "name"
                         },
-                        Properties = new()
+                        Properties = new Dictionary<string, IOpenApiSchema>()
                         {
                             ["id"] = new OpenApiSchema()
                             {
@@ -968,12 +969,12 @@ namespace Microsoft.OpenApi.Tests.Models
                                     Schema = new OpenApiSchema()
                                     {
                                         Type = JsonSchemaType.Integer,
-                                        Extensions = new()
+                                        Extensions = new Dictionary<string, IOpenApiExtension>()
                                         {
                                             ["my-extension"] = new JsonNodeExtension(4)
                                         }
                                     },
-                                    Extensions = new()
+                                    Extensions = new Dictionary<string, IOpenApiExtension>()
                                     {
                                         ["my-extension"] = new JsonNodeExtension(4),
                                     }
@@ -987,12 +988,12 @@ namespace Microsoft.OpenApi.Tests.Models
                                     Schema = new OpenApiSchema()
                                     {
                                         Type = JsonSchemaType.Integer,
-                                        Extensions = new()
+                                        Extensions = new Dictionary<string, IOpenApiExtension>()
                                         {
                                             ["my-extension"] = new JsonNodeExtension(4)
                                         }
                                     },
-                                    Extensions = new()
+                                    Extensions = new Dictionary<string, IOpenApiExtension>()
                                     {
                                         ["my-extension"] = new JsonNodeExtension(4),
                                     }
@@ -1003,7 +1004,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["200"] = new OpenApiResponse
                                 {
                                     Description = "pet response",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new OpenApiMediaType
                                         {
@@ -1104,7 +1105,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["200"] = new OpenApiResponse()
                                 {
                                     Description = "pet response",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new()
                                         {
@@ -1127,7 +1128,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["4XX"] = new OpenApiResponse()
                                 {
                                     Description = "unexpected client error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new()
                                         {
@@ -1138,7 +1139,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["5XX"] = new OpenApiResponse()
                                 {
                                     Description = "unexpected server error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new()
                                         {
@@ -1156,7 +1157,7 @@ namespace Microsoft.OpenApi.Tests.Models
                             {
                                 Description = "Pet to add to the store",
                                 Required = true,
-                                Content = new()
+                                Content = new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/json"] = new()
                                     {
@@ -1169,7 +1170,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["200"] = new OpenApiResponse()
                                 {
                                     Description = "pet response",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new()
                                         {
@@ -1180,7 +1181,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["4XX"] = new OpenApiResponse()
                                 {
                                     Description = "unexpected client error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new()
                                         {
@@ -1191,7 +1192,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["5XX"] = new OpenApiResponse()
                                 {
                                     Description = "unexpected server error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new()
                                         {
@@ -1232,7 +1233,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["200"] = new OpenApiResponse()
                                 {
                                     Description = "pet response",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new()
                                         {
@@ -1247,7 +1248,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["4XX"] = new OpenApiResponse()
                                 {
                                     Description = "unexpected client error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new()
                                         {
@@ -1258,7 +1259,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["5XX"] = new OpenApiResponse()
                                 {
                                     Description = "unexpected server error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new()
                                         {
@@ -1296,7 +1297,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["4XX"] = new OpenApiResponse()
                                 {
                                     Description = "unexpected client error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new()
                                         {
@@ -1307,7 +1308,7 @@ namespace Microsoft.OpenApi.Tests.Models
                                 ["5XX"] = new OpenApiResponse()
                                 {
                                     Description = "unexpected server error",
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["text/html"] = new()
                                         {
@@ -1538,7 +1539,7 @@ definitions:
                                 {
                                     ["200"] = new OpenApiResponse
                                     {
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = new OpenApiMediaType
                                             {
@@ -1795,7 +1796,7 @@ paths:
                                     ["200"] = new OpenApiResponse
                                     {
                                         Description = "foo",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["text/plain"] = new OpenApiMediaType
                                             {
@@ -1826,7 +1827,7 @@ paths:
         {
             var baseDocument = new OpenApiDocument
             {
-                Metadata = new()
+                Metadata = new Dictionary<string, object> 
                 {
                     ["key1"] = "value1",
                     ["key2"] = 2
@@ -1857,7 +1858,7 @@ paths:
                             {
                                 RequestBody = new OpenApiRequestBody()
                                 {
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new OpenApiMediaType()
                                         {
@@ -2074,7 +2075,7 @@ components:
                     new OpenApiTag
                     {
                         Name = "tag1",
-                        Extensions = new()
+                        Extensions = new Dictionary<string, IOpenApiExtension>()
                         {
                             ["x-tag1"] = new JsonNodeExtension("tag1")
                         }
@@ -2082,7 +2083,7 @@ components:
                     new OpenApiTag
                     {
                         Name = "tag2",
-                        Extensions = new()
+                        Extensions = new Dictionary<string, IOpenApiExtension>()
                         {
                             ["x-tag2"] = new JsonNodeExtension("tag2")
                         }
@@ -2103,7 +2104,7 @@ components:
                     new OpenApiTag
                     {
                         Name = "tag1",
-                        Extensions = new()
+                        Extensions = new Dictionary<string, IOpenApiExtension>()
                         {
                             ["x-tag1"] = new JsonNodeExtension("tag1")
                         }
@@ -2111,7 +2112,7 @@ components:
                     new OpenApiTag
                     {
                         Name = "tag2",
-                        Extensions = new()
+                        Extensions = new Dictionary<string, IOpenApiExtension>()
                         {
                             ["x-tag2"] = new JsonNodeExtension("tag2")
                         }
@@ -2119,7 +2120,7 @@ components:
                     new OpenApiTag
                     {
                         Name = "tag1",
-                        Extensions = new()
+                        Extensions = new Dictionary<string, IOpenApiExtension>()
                         {
                             ["x-tag1"] = new JsonNodeExtension("tag1")
                         }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiInfoTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiInfoTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Xunit;
 
@@ -20,7 +21,7 @@ namespace Microsoft.OpenApi.Tests.Models
             Contact = OpenApiContactTests.AdvanceContact,
             License = OpenApiLicenseTests.AdvanceLicense,
             Version = "1.1.1",
-            Extensions = new()
+            Extensions = new Dictionary<string, IOpenApiExtension>()
             {
                 {"x-updated", new JsonNodeExtension("metadata")}
             }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiLicenseTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiLicenseTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Xunit;
 
@@ -20,7 +22,7 @@ namespace Microsoft.OpenApi.Tests.Models
         {
             Name = "Apache 2.0",
             Url = new("http://www.apache.org/licenses/LICENSE-2.0.html"),
-            Extensions = new()
+            Extensions = new Dictionary<string, IOpenApiExtension>()
             {
                 {"x-copyright", new JsonNodeExtension("Abc")}
             }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiLinkTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiLinkTests.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Expressions;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.References;
 using Microsoft.OpenApi.Writers;
@@ -125,7 +126,7 @@ namespace Microsoft.OpenApi.Tests.Models
             // Arrange
             var link = new OpenApiLink()
             {
-                Extensions = new()
+                Extensions = new Dictionary<string, IOpenApiExtension>()
                 {
                     { "x-display", new JsonNodeExtension("Abc") 
                 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiMediaTypeTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiMediaTypeTests.cs
@@ -437,7 +437,7 @@ namespace Microsoft.OpenApi.Tests.Models
                 Example = 42,
                 Examples = new Dictionary<string, IOpenApiExample>(),
                 Encoding = new Dictionary<string, OpenApiEncoding>(),
-                Extensions = new()
+                Extensions = new Dictionary<string, IOpenApiExtension>()
             };
 
             // Assert

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiOperationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiOperationTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.OpenApi.Tests.Models
             {
                 Description = "description2",
                 Required = true,
-                Content = new()
+                Content = new Dictionary<string, OpenApiMediaType>()
                 {
                     ["application/json"] = new()
                     {
@@ -63,7 +63,7 @@ namespace Microsoft.OpenApi.Tests.Models
                 ["200"] = new OpenApiResponseReference("response1"),
                 ["400"] = new OpenApiResponse()
                 {
-                    Content = new()
+                    Content = new Dictionary<string, OpenApiMediaType>()
                     {
                         ["application/json"] = new()
                         {
@@ -119,7 +119,7 @@ namespace Microsoft.OpenApi.Tests.Models
             {
                 Description = "description2",
                 Required = true,
-                Content = new()
+                Content = new Dictionary<string, OpenApiMediaType>()
                 {
                     ["application/json"] = new()
                     {
@@ -137,7 +137,7 @@ namespace Microsoft.OpenApi.Tests.Models
                 ["200"] = new OpenApiResponseReference("response1"),
                 ["400"] = new OpenApiResponse()
                 {
-                    Content = new()
+                    Content = new Dictionary<string, OpenApiMediaType>()
                     {
                         ["application/json"] = new()
                         {
@@ -223,13 +223,13 @@ namespace Microsoft.OpenApi.Tests.Models
                 ],
                 RequestBody = new OpenApiRequestBody()
                 {
-                    Content = new()
+                    Content = new Dictionary<string, OpenApiMediaType>()
                     {
                         ["application/x-www-form-urlencoded"] = new()
                         {
                             Schema = new OpenApiSchema()
                             {
-                                Properties = new()
+                                Properties = new Dictionary<string, IOpenApiSchema>()
                                 {
                                     ["name"] = new OpenApiSchema()
                                     {
@@ -252,7 +252,7 @@ namespace Microsoft.OpenApi.Tests.Models
                         {
                             Schema = new OpenApiSchema()
                             {
-                                Properties = new()
+                                Properties = new Dictionary<string, IOpenApiSchema>()
                                 {
                                     ["name"] = new OpenApiSchema()
                                     {

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiRequestBodyTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiRequestBodyTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OpenApi.Tests.Models
         {
             Description = "description",
             Required = true,
-            Content = new()
+            Content = new Dictionary<string, OpenApiMediaType>()
             {
                 ["application/json"] = new()
                 {
@@ -37,7 +37,7 @@ namespace Microsoft.OpenApi.Tests.Models
         {
             Description = "description",
             Required = true,
-            Content = new()
+            Content = new Dictionary<string, OpenApiMediaType>()
             {
                 ["application/json"] = new()
                 {

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiResponseTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiResponseTests.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.Interfaces;
 using Microsoft.OpenApi.Models.References;
@@ -33,7 +34,7 @@ namespace Microsoft.OpenApi.Tests.Models
                         Items = new OpenApiSchemaReference("customType", null)
                     },
                     Example = "Blabla",
-                    Extensions = new()
+                    Extensions = new Dictionary<string, IOpenApiExtension>()
                     {
                         ["myextension"] = new JsonNodeExtension("myextensionvalue"),
                     }, 
@@ -72,7 +73,7 @@ namespace Microsoft.OpenApi.Tests.Models
                         Items = new OpenApiSchemaReference("customType", null)
                     },
                     Example = "Blabla",
-                    Extensions = new()
+                    Extensions = new Dictionary<string, IOpenApiExtension>()
                     {
                         ["myextension"] = new JsonNodeExtension("myextensionvalue"),
                     },

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Models.Interfaces;
 using Microsoft.OpenApi.Services;
@@ -42,11 +43,11 @@ namespace Microsoft.OpenApi.Tests.Models
         public static readonly OpenApiSchema AdvancedSchemaObject = new()
         {
             Title = "title1",
-            Properties = new()
+            Properties = new Dictionary<string, IOpenApiSchema>()
             {
                 ["property1"] = new OpenApiSchema()
                 {
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property2"] = new OpenApiSchema()
                         {
@@ -61,11 +62,11 @@ namespace Microsoft.OpenApi.Tests.Models
                 },
                 ["property4"] = new OpenApiSchema()
                 {
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property5"] = new OpenApiSchema()
                         {
-                            Properties = new()
+                            Properties = new Dictionary<string, IOpenApiSchema>()
                             {
                                 ["property6"] = new OpenApiSchema()
                                 {
@@ -96,7 +97,7 @@ namespace Microsoft.OpenApi.Tests.Models
                 new OpenApiSchema()
                 {
                     Title = "title2",
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property1"] = new OpenApiSchema()
                         {
@@ -112,11 +113,11 @@ namespace Microsoft.OpenApi.Tests.Models
                 new OpenApiSchema()
                 {
                     Title = "title3",
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property3"] = new OpenApiSchema()
                         {
-                            Properties = new()
+                            Properties = new Dictionary<string, IOpenApiSchema>()
                             {
                                 ["property4"] = new OpenApiSchema()
                                 {
@@ -159,12 +160,12 @@ namespace Microsoft.OpenApi.Tests.Models
         {
             Title = "title1",
             Required = new HashSet<string> { "property1" },
-            Properties = new()
+            Properties = new Dictionary<string, IOpenApiSchema>()
             {
                 ["property1"] = new OpenApiSchema()
                 {
                     Required = new HashSet<string> { "property3" },
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property2"] = new OpenApiSchema()
                         {
@@ -181,11 +182,11 @@ namespace Microsoft.OpenApi.Tests.Models
                 },
                 ["property4"] = new OpenApiSchema()
                 {
-                    Properties = new()
+                    Properties = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["property5"] = new OpenApiSchema()
                         {
-                            Properties = new()
+                            Properties = new Dictionary<string, IOpenApiSchema>()
                             {
                                 ["property6"] = new OpenApiSchema()
                                 {
@@ -534,7 +535,7 @@ namespace Microsoft.OpenApi.Tests.Models
             // Arrange
             var schema = new OpenApiSchema
             {
-                Extensions = new()
+                Extensions = new Dictionary<string, IOpenApiExtension>()
                 {
                     { "x-myextension", new JsonNodeExtension(42) }
                 }
@@ -545,7 +546,7 @@ namespace Microsoft.OpenApi.Tests.Models
             Assert.Single(schemaCopy.Extensions);
 
             // Act && Assert
-            schemaCopy.Extensions = new()
+            schemaCopy.Extensions = new Dictionary<string, IOpenApiExtension>()
             {
                 { "x-myextension" , new JsonNodeExtension(40) }
             };

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiTagTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiTagTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OpenApi.Tests.Models
             Name = "pet",
             Description = "Pets operations",
             ExternalDocs = OpenApiExternalDocsTests.AdvanceExDocs,
-            Extensions = new()
+            Extensions = new Dictionary<string, IOpenApiExtension>()
             {
                 {"x-tag-extension", null}
             }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiXmlTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiXmlTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.Extensions;
+using Microsoft.OpenApi.Interfaces;
 using Microsoft.OpenApi.Models;
 using Xunit;
 
@@ -18,7 +20,7 @@ namespace Microsoft.OpenApi.Tests.Models
             Prefix = "sample",
             Wrapped = true,
             Attribute = true,
-            Extensions = new()
+            Extensions = new Dictionary<string, IOpenApiExtension>()
             {
                 {"x-xml-extension", new JsonNodeExtension(7)}
             }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -197,12 +197,12 @@ namespace Microsoft.OpenApi.Interfaces
     public interface IDiagnostic { }
     public interface IMetadataContainer
     {
-        System.Collections.Generic.Dictionary<string, object>? Metadata { get; set; }
+        System.Collections.Generic.IDictionary<string, object>? Metadata { get; set; }
     }
     public interface IOpenApiElement { }
     public interface IOpenApiExtensible : Microsoft.OpenApi.Interfaces.IOpenApiElement
     {
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
     }
     public interface IOpenApiExtension
     {
@@ -210,7 +210,7 @@ namespace Microsoft.OpenApi.Interfaces
     }
     public interface IOpenApiReadOnlyExtensible
     {
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
     }
     public interface IOpenApiReader
     {
@@ -347,10 +347,10 @@ namespace Microsoft.OpenApi.Models.Interfaces
     {
         bool AllowEmptyValue { get; }
         bool AllowReserved { get; }
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
         bool Deprecated { get; }
         System.Text.Json.Nodes.JsonNode? Example { get; }
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; }
         bool Explode { get; }
         bool Required { get; }
         Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema? Schema { get; }
@@ -360,7 +360,7 @@ namespace Microsoft.OpenApi.Models.Interfaces
     {
         string? OperationId { get; }
         string? OperationRef { get; }
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper>? Parameters { get; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper>? Parameters { get; }
         Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper? RequestBody { get; }
         Microsoft.OpenApi.Models.OpenApiServer? Server { get; }
     }
@@ -368,10 +368,10 @@ namespace Microsoft.OpenApi.Models.Interfaces
     {
         bool AllowEmptyValue { get; }
         bool AllowReserved { get; }
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
         bool Deprecated { get; }
         System.Text.Json.Nodes.JsonNode? Example { get; }
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; }
         bool Explode { get; }
         Microsoft.OpenApi.Models.ParameterLocation? In { get; }
         string? Name { get; }
@@ -391,16 +391,16 @@ namespace Microsoft.OpenApi.Models.Interfaces
     }
     public interface IOpenApiRequestBody : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
     {
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
         bool Required { get; }
         Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter? ConvertToBodyParameter(Microsoft.OpenApi.Writers.IOpenApiWriter writer);
         System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>? ConvertToFormDataParameters(Microsoft.OpenApi.Writers.IOpenApiWriter writer);
     }
     public interface IOpenApiResponse : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
     {
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>? Headers { get; }
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>? Links { get; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>? Headers { get; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>? Links { get; }
     }
     public interface IOpenApiSchema : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement
     {
@@ -411,8 +411,8 @@ namespace Microsoft.OpenApi.Models.Interfaces
         string? Comment { get; }
         string? Const { get; }
         System.Text.Json.Nodes.JsonNode? Default { get; }
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Definitions { get; }
-        System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>>? DependentRequired { get; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Definitions { get; }
+        System.Collections.Generic.IDictionary<string, System.Collections.Generic.HashSet<string>>? DependentRequired { get; }
         bool Deprecated { get; }
         Microsoft.OpenApi.Models.OpenApiDiscriminator? Discriminator { get; }
         string? DynamicAnchor { get; }
@@ -438,8 +438,8 @@ namespace Microsoft.OpenApi.Models.Interfaces
         Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema? Not { get; }
         System.Collections.Generic.List<Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? OneOf { get; }
         string? Pattern { get; }
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? PatternProperties { get; }
-        System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Properties { get; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? PatternProperties { get; }
+        System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Properties { get; }
         bool ReadOnly { get; }
         System.Collections.Generic.HashSet<string>? Required { get; }
         System.Uri? Schema { get; }
@@ -447,8 +447,8 @@ namespace Microsoft.OpenApi.Models.Interfaces
         Microsoft.OpenApi.Models.JsonSchemaType? Type { get; }
         bool UnevaluatedProperties { get; }
         bool? UniqueItems { get; }
-        System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>? UnrecognizedKeywords { get; }
-        System.Collections.Generic.Dictionary<string, bool>? Vocabulary { get; }
+        System.Collections.Generic.IDictionary<string, System.Text.Json.Nodes.JsonNode>? UnrecognizedKeywords { get; }
+        System.Collections.Generic.IDictionary<string, bool>? Vocabulary { get; }
         bool WriteOnly { get; }
         Microsoft.OpenApi.Models.OpenApiXml? Xml { get; }
     }
@@ -488,7 +488,7 @@ namespace Microsoft.OpenApi.Models
     public class OpenApiCallback : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback
     {
         public OpenApiCallback() { }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public System.Collections.Generic.Dictionary<Microsoft.OpenApi.Expressions.RuntimeExpression, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>? PathItems { get; set; }
         public void AddPathItem(Microsoft.OpenApi.Expressions.RuntimeExpression expression, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem pathItem) { }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback CreateShallowCopy() { }
@@ -500,17 +500,17 @@ namespace Microsoft.OpenApi.Models
     {
         public OpenApiComponents() { }
         public OpenApiComponents(Microsoft.OpenApi.Models.OpenApiComponents? components) { }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>? Callbacks { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>? Headers { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>? Links { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>? Parameters { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>? PathItems { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody>? RequestBodies { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>? Responses { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Schemas { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme>? SecuritySchemes { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>? Callbacks { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>? Headers { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>? Links { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>? Parameters { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>? PathItems { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody>? RequestBodies { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>? Responses { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Schemas { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSecurityScheme>? SecuritySchemes { get; set; }
         public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -678,7 +678,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiContact() { }
         public OpenApiContact(Microsoft.OpenApi.Models.OpenApiContact contact) { }
         public string? Email { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public string? Name { get; set; }
         public System.Uri? Url { get; set; }
         public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -689,8 +689,8 @@ namespace Microsoft.OpenApi.Models
     {
         public OpenApiDiscriminator() { }
         public OpenApiDiscriminator(Microsoft.OpenApi.Models.OpenApiDiscriminator discriminator) { }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.References.OpenApiSchemaReference>? Mapping { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.References.OpenApiSchemaReference>? Mapping { get; set; }
         public string? PropertyName { get; set; }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -702,16 +702,16 @@ namespace Microsoft.OpenApi.Models
         public OpenApiDocument(Microsoft.OpenApi.Models.OpenApiDocument? document) { }
         public System.Uri BaseUri { get; }
         public Microsoft.OpenApi.Models.OpenApiComponents? Components { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public Microsoft.OpenApi.Models.OpenApiExternalDocs? ExternalDocs { get; set; }
         public Microsoft.OpenApi.Models.OpenApiInfo Info { get; set; }
         public System.Uri? JsonSchemaDialect { get; set; }
-        public System.Collections.Generic.Dictionary<string, object>? Metadata { get; set; }
+        public System.Collections.Generic.IDictionary<string, object>? Metadata { get; set; }
         public Microsoft.OpenApi.Models.OpenApiPaths Paths { get; set; }
         public System.Collections.Generic.List<Microsoft.OpenApi.Models.OpenApiSecurityRequirement>? Security { get; set; }
         public System.Collections.Generic.List<Microsoft.OpenApi.Models.OpenApiServer>? Servers { get; set; }
         public System.Collections.Generic.HashSet<Microsoft.OpenApi.Models.OpenApiTag>? Tags { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>? Webhooks { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>? Webhooks { get; set; }
         public Microsoft.OpenApi.Services.OpenApiWorkspace? Workspace { get; set; }
         public bool AddComponent<T>(string id, T componentToRegister) { }
         public System.Threading.Tasks.Task<string> GetHashCodeAsync(System.Threading.CancellationToken cancellationToken = default) { }
@@ -733,8 +733,8 @@ namespace Microsoft.OpenApi.Models
         public bool? AllowReserved { get; set; }
         public string? ContentType { get; set; }
         public bool? Explode { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>? Headers { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>? Headers { get; set; }
         public Microsoft.OpenApi.Models.ParameterStyle? Style { get; set; }
         public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -753,7 +753,7 @@ namespace Microsoft.OpenApi.Models
     {
         public OpenApiExample() { }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public string? ExternalValue { get; set; }
         public string? Summary { get; set; }
         public System.Text.Json.Nodes.JsonNode? Value { get; set; }
@@ -767,7 +767,7 @@ namespace Microsoft.OpenApi.Models
     {
         protected OpenApiExtensibleDictionary() { }
         protected OpenApiExtensibleDictionary(System.Collections.Generic.Dictionary<string, T> dictionary, System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? extensions = null) { }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -777,7 +777,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiExternalDocs() { }
         public OpenApiExternalDocs(Microsoft.OpenApi.Models.OpenApiExternalDocs externalDocs) { }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public System.Uri? Url { get; set; }
         public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -788,13 +788,13 @@ namespace Microsoft.OpenApi.Models
         public OpenApiHeader() { }
         public bool AllowEmptyValue { get; set; }
         public bool AllowReserved { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; set; }
         public bool Deprecated { get; set; }
         public string? Description { get; set; }
         public System.Text.Json.Nodes.JsonNode? Example { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; set; }
         public bool Explode { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public bool Required { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema? Schema { get; set; }
         public Microsoft.OpenApi.Models.ParameterStyle? Style { get; set; }
@@ -809,7 +809,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiInfo(Microsoft.OpenApi.Models.OpenApiInfo info) { }
         public Microsoft.OpenApi.Models.OpenApiContact? Contact { get; set; }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public Microsoft.OpenApi.Models.OpenApiLicense? License { get; set; }
         public string? Summary { get; set; }
         public System.Uri? TermsOfService { get; set; }
@@ -823,7 +823,7 @@ namespace Microsoft.OpenApi.Models
     {
         public OpenApiLicense() { }
         public OpenApiLicense(Microsoft.OpenApi.Models.OpenApiLicense license) { }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public string? Identifier { get; set; }
         public string? Name { get; set; }
         public System.Uri? Url { get; set; }
@@ -835,10 +835,10 @@ namespace Microsoft.OpenApi.Models
     {
         public OpenApiLink() { }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public string? OperationId { get; set; }
         public string? OperationRef { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper>? Parameters { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper>? Parameters { get; set; }
         public Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper? RequestBody { get; set; }
         public Microsoft.OpenApi.Models.OpenApiServer? Server { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiLink CreateShallowCopy() { }
@@ -850,10 +850,10 @@ namespace Microsoft.OpenApi.Models
     {
         public OpenApiMediaType() { }
         public OpenApiMediaType(Microsoft.OpenApi.Models.OpenApiMediaType? mediaType) { }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiEncoding>? Encoding { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiEncoding>? Encoding { get; set; }
         public System.Text.Json.Nodes.JsonNode? Example { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema? Schema { get; set; }
         public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -864,9 +864,9 @@ namespace Microsoft.OpenApi.Models
         public OpenApiOAuthFlow() { }
         public OpenApiOAuthFlow(Microsoft.OpenApi.Models.OpenApiOAuthFlow oAuthFlow) { }
         public System.Uri? AuthorizationUrl { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public System.Uri? RefreshUrl { get; set; }
-        public System.Collections.Generic.Dictionary<string, string>? Scopes { get; set; }
+        public System.Collections.Generic.IDictionary<string, string>? Scopes { get; set; }
         public System.Uri? TokenUrl { get; set; }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -878,7 +878,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiOAuthFlows(Microsoft.OpenApi.Models.OpenApiOAuthFlows oAuthFlows) { }
         public Microsoft.OpenApi.Models.OpenApiOAuthFlow? AuthorizationCode { get; set; }
         public Microsoft.OpenApi.Models.OpenApiOAuthFlow? ClientCredentials { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public Microsoft.OpenApi.Models.OpenApiOAuthFlow? Implicit { get; set; }
         public Microsoft.OpenApi.Models.OpenApiOAuthFlow? Password { get; set; }
         public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -890,12 +890,12 @@ namespace Microsoft.OpenApi.Models
         public const bool DeprecatedDefault = false;
         public OpenApiOperation() { }
         public OpenApiOperation(Microsoft.OpenApi.Models.OpenApiOperation operation) { }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>? Callbacks { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>? Callbacks { get; set; }
         public bool Deprecated { get; set; }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public Microsoft.OpenApi.Models.OpenApiExternalDocs? ExternalDocs { get; set; }
-        public System.Collections.Generic.Dictionary<string, object>? Metadata { get; set; }
+        public System.Collections.Generic.IDictionary<string, object>? Metadata { get; set; }
         public string? OperationId { get; set; }
         public System.Collections.Generic.List<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>? Parameters { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody? RequestBody { get; set; }
@@ -913,13 +913,13 @@ namespace Microsoft.OpenApi.Models
         public OpenApiParameter() { }
         public bool AllowEmptyValue { get; set; }
         public bool AllowReserved { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; set; }
         public bool Deprecated { get; set; }
         public string? Description { get; set; }
         public System.Text.Json.Nodes.JsonNode? Example { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; set; }
         public bool Explode { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public Microsoft.OpenApi.Models.ParameterLocation? In { get; set; }
         public string? Name { get; set; }
         public bool Required { get; set; }
@@ -934,7 +934,7 @@ namespace Microsoft.OpenApi.Models
     {
         public OpenApiPathItem() { }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public System.Collections.Generic.Dictionary<System.Net.Http.HttpMethod, Microsoft.OpenApi.Models.OpenApiOperation>? Operations { get; set; }
         public System.Collections.Generic.List<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>? Parameters { get; set; }
         public System.Collections.Generic.List<Microsoft.OpenApi.Models.OpenApiServer>? Servers { get; set; }
@@ -972,9 +972,9 @@ namespace Microsoft.OpenApi.Models
     public class OpenApiRequestBody : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody
     {
         public OpenApiRequestBody() { }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; set; }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public bool Required { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter ConvertToBodyParameter(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter> ConvertToFormDataParameters(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -986,11 +986,11 @@ namespace Microsoft.OpenApi.Models
     public class OpenApiResponse : Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse
     {
         public OpenApiResponse() { }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; set; }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>? Headers { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>? Links { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>? Headers { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>? Links { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse CreateShallowCopy() { }
         public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1011,8 +1011,8 @@ namespace Microsoft.OpenApi.Models
         public string? Comment { get; set; }
         public string? Const { get; set; }
         public System.Text.Json.Nodes.JsonNode? Default { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Definitions { get; set; }
-        public System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>>? DependentRequired { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Definitions { get; set; }
+        public System.Collections.Generic.IDictionary<string, System.Collections.Generic.HashSet<string>>? DependentRequired { get; set; }
         public bool Deprecated { get; set; }
         public string? Description { get; set; }
         public Microsoft.OpenApi.Models.OpenApiDiscriminator? Discriminator { get; set; }
@@ -1023,7 +1023,7 @@ namespace Microsoft.OpenApi.Models
         public System.Collections.Generic.List<System.Text.Json.Nodes.JsonNode>? Examples { get; set; }
         public string? ExclusiveMaximum { get; set; }
         public string? ExclusiveMinimum { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public Microsoft.OpenApi.Models.OpenApiExternalDocs? ExternalDocs { get; set; }
         public string? Format { get; set; }
         public string? Id { get; set; }
@@ -1032,7 +1032,7 @@ namespace Microsoft.OpenApi.Models
         public int? MaxLength { get; set; }
         public int? MaxProperties { get; set; }
         public string? Maximum { get; set; }
-        public System.Collections.Generic.Dictionary<string, object>? Metadata { get; set; }
+        public System.Collections.Generic.IDictionary<string, object>? Metadata { get; set; }
         public int? MinItems { get; set; }
         public int? MinLength { get; set; }
         public int? MinProperties { get; set; }
@@ -1041,8 +1041,8 @@ namespace Microsoft.OpenApi.Models
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema? Not { get; set; }
         public System.Collections.Generic.List<Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? OneOf { get; set; }
         public string? Pattern { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? PatternProperties { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Properties { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? PatternProperties { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Properties { get; set; }
         public bool ReadOnly { get; set; }
         public System.Collections.Generic.HashSet<string>? Required { get; set; }
         public System.Uri? Schema { get; set; }
@@ -1050,8 +1050,8 @@ namespace Microsoft.OpenApi.Models
         public Microsoft.OpenApi.Models.JsonSchemaType? Type { get; set; }
         public bool UnevaluatedProperties { get; set; }
         public bool? UniqueItems { get; set; }
-        public System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>? UnrecognizedKeywords { get; set; }
-        public System.Collections.Generic.Dictionary<string, bool>? Vocabulary { get; set; }
+        public System.Collections.Generic.IDictionary<string, System.Text.Json.Nodes.JsonNode>? UnrecognizedKeywords { get; set; }
+        public System.Collections.Generic.IDictionary<string, bool>? Vocabulary { get; set; }
         public bool WriteOnly { get; set; }
         public Microsoft.OpenApi.Models.OpenApiXml? Xml { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema CreateShallowCopy() { }
@@ -1071,7 +1071,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiSecurityScheme() { }
         public string? BearerFormat { get; set; }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public Microsoft.OpenApi.Models.OpenApiOAuthFlows? Flows { get; set; }
         public Microsoft.OpenApi.Models.ParameterLocation? In { get; set; }
         public string? Name { get; set; }
@@ -1088,9 +1088,9 @@ namespace Microsoft.OpenApi.Models
         public OpenApiServer() { }
         public OpenApiServer(Microsoft.OpenApi.Models.OpenApiServer server) { }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public string? Url { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiServerVariable>? Variables { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiServerVariable>? Variables { get; set; }
         public virtual void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public virtual void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public virtual void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1102,7 +1102,7 @@ namespace Microsoft.OpenApi.Models
         public string? Default { get; set; }
         public string? Description { get; set; }
         public System.Collections.Generic.List<string>? Enum { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public void SerializeAsV2(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV3(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public void SerializeAsV31(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1111,7 +1111,7 @@ namespace Microsoft.OpenApi.Models
     {
         public OpenApiTag() { }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public Microsoft.OpenApi.Models.OpenApiExternalDocs? ExternalDocs { get; set; }
         public string? Name { get; set; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiTag CreateShallowCopy() { }
@@ -1124,7 +1124,7 @@ namespace Microsoft.OpenApi.Models
         public OpenApiXml() { }
         public OpenApiXml(Microsoft.OpenApi.Models.OpenApiXml xml) { }
         public bool Attribute { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; set; }
         public string? Name { get; set; }
         public System.Uri? Namespace { get; set; }
         public string? Prefix { get; set; }
@@ -1226,7 +1226,7 @@ namespace Microsoft.OpenApi.Models.References
     public class OpenApiCallbackReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiCallback, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback>, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback
     {
         public OpenApiCallbackReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument? hostDocument = null, string? externalResource = null) { }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
         public System.Collections.Generic.Dictionary<Microsoft.OpenApi.Expressions.RuntimeExpression, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem>? PathItems { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback source) { }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback CreateShallowCopy() { }
@@ -1236,7 +1236,7 @@ namespace Microsoft.OpenApi.Models.References
     {
         public OpenApiExampleReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument? hostDocument = null, string? externalResource = null) { }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
         public string? ExternalValue { get; }
         public string? Summary { get; set; }
         public System.Text.Json.Nodes.JsonNode? Value { get; }
@@ -1249,13 +1249,13 @@ namespace Microsoft.OpenApi.Models.References
         public OpenApiHeaderReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument? hostDocument = null, string? externalResource = null) { }
         public bool AllowEmptyValue { get; }
         public bool AllowReserved { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
         public bool Deprecated { get; }
         public string? Description { get; set; }
         public System.Text.Json.Nodes.JsonNode? Example { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; }
         public bool Explode { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
         public bool Required { get; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema? Schema { get; }
         public Microsoft.OpenApi.Models.ParameterStyle? Style { get; }
@@ -1266,10 +1266,10 @@ namespace Microsoft.OpenApi.Models.References
     {
         public OpenApiLinkReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument? hostDocument = null, string? externalResource = null) { }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
         public string? OperationId { get; }
         public string? OperationRef { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper>? Parameters { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper>? Parameters { get; }
         public Microsoft.OpenApi.Models.RuntimeExpressionAnyWrapper? RequestBody { get; }
         public Microsoft.OpenApi.Models.OpenApiServer? Server { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiLink CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiLink source) { }
@@ -1281,13 +1281,13 @@ namespace Microsoft.OpenApi.Models.References
         public OpenApiParameterReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument? hostDocument = null, string? externalResource = null) { }
         public bool AllowEmptyValue { get; }
         public bool AllowReserved { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
         public bool Deprecated { get; }
         public string? Description { get; set; }
         public System.Text.Json.Nodes.JsonNode? Example { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample>? Examples { get; }
         public bool Explode { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
         public Microsoft.OpenApi.Models.ParameterLocation? In { get; }
         public string? Name { get; }
         public bool Required { get; }
@@ -1300,7 +1300,7 @@ namespace Microsoft.OpenApi.Models.References
     {
         public OpenApiPathItemReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument? hostDocument = null, string? externalResource = null) { }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
         public System.Collections.Generic.Dictionary<System.Net.Http.HttpMethod, Microsoft.OpenApi.Models.OpenApiOperation>? Operations { get; }
         public System.Collections.Generic.List<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>? Parameters { get; }
         public System.Collections.Generic.List<Microsoft.OpenApi.Models.OpenApiServer>? Servers { get; }
@@ -1312,9 +1312,9 @@ namespace Microsoft.OpenApi.Models.References
     public class OpenApiRequestBodyReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiRequestBody, Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiRequestBody
     {
         public OpenApiRequestBodyReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument? hostDocument = null, string? externalResource = null) { }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
         public bool Required { get; }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter? ConvertToBodyParameter(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
         public System.Collections.Generic.IEnumerable<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter>? ConvertToFormDataParameters(Microsoft.OpenApi.Writers.IOpenApiWriter writer) { }
@@ -1325,11 +1325,11 @@ namespace Microsoft.OpenApi.Models.References
     public class OpenApiResponseReference : Microsoft.OpenApi.Models.References.BaseOpenApiReferenceHolder<Microsoft.OpenApi.Models.OpenApiResponse, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>, Microsoft.OpenApi.Interfaces.IOpenApiElement, Microsoft.OpenApi.Interfaces.IOpenApiReadOnlyExtensible, Microsoft.OpenApi.Interfaces.IOpenApiReferenceable, Microsoft.OpenApi.Interfaces.IOpenApiSerializable, Microsoft.OpenApi.Interfaces.IShallowCopyable<Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse>, Microsoft.OpenApi.Models.Interfaces.IOpenApiDescribedElement, Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse
     {
         public OpenApiResponseReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument? hostDocument = null, string? externalResource = null) { }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType>? Content { get; }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>? Headers { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>? Links { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader>? Headers { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink>? Links { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse source) { }
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiResponse CreateShallowCopy() { }
     }
@@ -1343,8 +1343,8 @@ namespace Microsoft.OpenApi.Models.References
         public string? Comment { get; }
         public string? Const { get; }
         public System.Text.Json.Nodes.JsonNode? Default { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Definitions { get; }
-        public System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>>? DependentRequired { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Definitions { get; }
+        public System.Collections.Generic.IDictionary<string, System.Collections.Generic.HashSet<string>>? DependentRequired { get; }
         public bool Deprecated { get; }
         public string? Description { get; set; }
         public Microsoft.OpenApi.Models.OpenApiDiscriminator? Discriminator { get; }
@@ -1355,7 +1355,7 @@ namespace Microsoft.OpenApi.Models.References
         public System.Collections.Generic.List<System.Text.Json.Nodes.JsonNode>? Examples { get; }
         public string? ExclusiveMaximum { get; }
         public string? ExclusiveMinimum { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
         public Microsoft.OpenApi.Models.OpenApiExternalDocs? ExternalDocs { get; }
         public string? Format { get; }
         public string? Id { get; }
@@ -1372,8 +1372,8 @@ namespace Microsoft.OpenApi.Models.References
         public Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema? Not { get; }
         public System.Collections.Generic.List<Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? OneOf { get; }
         public string? Pattern { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? PatternProperties { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Properties { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? PatternProperties { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema>? Properties { get; }
         public bool ReadOnly { get; }
         public System.Collections.Generic.HashSet<string>? Required { get; }
         public System.Uri? Schema { get; }
@@ -1381,8 +1381,8 @@ namespace Microsoft.OpenApi.Models.References
         public Microsoft.OpenApi.Models.JsonSchemaType? Type { get; }
         public bool UnevaluatedProperties { get; }
         public bool? UniqueItems { get; }
-        public System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>? UnrecognizedKeywords { get; }
-        public System.Collections.Generic.Dictionary<string, bool>? Vocabulary { get; }
+        public System.Collections.Generic.IDictionary<string, System.Text.Json.Nodes.JsonNode>? UnrecognizedKeywords { get; }
+        public System.Collections.Generic.IDictionary<string, bool>? Vocabulary { get; }
         public bool WriteOnly { get; }
         public Microsoft.OpenApi.Models.OpenApiXml? Xml { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema CopyReferenceAsTargetElementWithOverrides(Microsoft.OpenApi.Models.Interfaces.IOpenApiSchema source) { }
@@ -1396,7 +1396,7 @@ namespace Microsoft.OpenApi.Models.References
         public OpenApiSecuritySchemeReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument? hostDocument = null, string? externalResource = null) { }
         public string? BearerFormat { get; }
         public string? Description { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
         public Microsoft.OpenApi.Models.OpenApiOAuthFlows? Flows { get; }
         public Microsoft.OpenApi.Models.ParameterLocation? In { get; }
         public string? Name { get; }
@@ -1410,7 +1410,7 @@ namespace Microsoft.OpenApi.Models.References
     {
         public OpenApiTagReference(string referenceId, Microsoft.OpenApi.Models.OpenApiDocument? hostDocument = null, string? externalResource = null) { }
         public string? Description { get; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? Extensions { get; }
         public Microsoft.OpenApi.Models.OpenApiExternalDocs? ExternalDocs { get; }
         public string? Name { get; }
         public override Microsoft.OpenApi.Models.Interfaces.IOpenApiTag? Target { get; }
@@ -1562,11 +1562,11 @@ namespace Microsoft.OpenApi.Services
     public class OpenApiUrlTreeNode
     {
         public static readonly System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.OpenApi.Services.MermaidNodeStyle> MermaidNodeStyles;
-        public System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> AdditionalData { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Services.OpenApiUrlTreeNode> Children { get; }
+        public System.Collections.Generic.IDictionary<string, System.Collections.Generic.List<string>> AdditionalData { get; set; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Services.OpenApiUrlTreeNode> Children { get; }
         public bool IsParameter { get; }
         public string Path { get; set; }
-        public System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem> PathItems { get; }
+        public System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem> PathItems { get; }
         public string Segment { get; }
         public void AddAdditionalData(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> additionalData) { }
         public void Attach(Microsoft.OpenApi.Models.OpenApiDocument doc, string label) { }
@@ -1613,17 +1613,17 @@ namespace Microsoft.OpenApi.Services
         public virtual void Visit(Microsoft.OpenApi.Models.OpenApiServerVariable serverVariable) { }
         public virtual void Visit(Microsoft.OpenApi.Models.OpenApiTag tag) { }
         public virtual void Visit(Microsoft.OpenApi.Models.References.OpenApiTagReference tag) { }
-        public virtual void Visit(System.Collections.Generic.Dictionary<System.Net.Http.HttpMethod, Microsoft.OpenApi.Models.OpenApiOperation> operations) { }
-        public virtual void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback> callbacks) { }
-        public virtual void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample> examples) { }
-        public virtual void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader> headers) { }
-        public virtual void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink> links) { }
-        public virtual void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem> webhooks) { }
-        public virtual void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiEncoding> encodings) { }
-        public virtual void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> content) { }
-        public virtual void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiServerVariable> serverVariables) { }
         public virtual void Visit(System.Collections.Generic.HashSet<Microsoft.OpenApi.Models.OpenApiTag> openApiTags) { }
         public virtual void Visit(System.Collections.Generic.HashSet<Microsoft.OpenApi.Models.References.OpenApiTagReference> openApiTags) { }
+        public virtual void Visit(System.Collections.Generic.IDictionary<System.Net.Http.HttpMethod, Microsoft.OpenApi.Models.OpenApiOperation> operations) { }
+        public virtual void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback> callbacks) { }
+        public virtual void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample> examples) { }
+        public virtual void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader> headers) { }
+        public virtual void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink> links) { }
+        public virtual void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiPathItem> webhooks) { }
+        public virtual void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiEncoding> encodings) { }
+        public virtual void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> content) { }
+        public virtual void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiServerVariable> serverVariables) { }
         public virtual void Visit(System.Collections.Generic.List<Microsoft.OpenApi.Models.Interfaces.IOpenApiExample> example) { }
         public virtual void Visit(System.Collections.Generic.List<Microsoft.OpenApi.Models.Interfaces.IOpenApiParameter> parameters) { }
         public virtual void Visit(System.Collections.Generic.List<Microsoft.OpenApi.Models.OpenApiSecurityRequirement> openApiSecurityRequirements) { }
@@ -1709,14 +1709,14 @@ namespace Microsoft.OpenApi.Validations
         public override void Visit(Microsoft.OpenApi.Models.OpenApiServer server) { }
         public override void Visit(Microsoft.OpenApi.Models.OpenApiServerVariable serverVariable) { }
         public override void Visit(Microsoft.OpenApi.Models.OpenApiTag tag) { }
-        public override void Visit(System.Collections.Generic.Dictionary<System.Net.Http.HttpMethod, Microsoft.OpenApi.Models.OpenApiOperation> operations) { }
-        public override void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback> callbacks) { }
-        public override void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample> examples) { }
-        public override void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader> headers) { }
-        public override void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink> links) { }
-        public override void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiEncoding> encodings) { }
-        public override void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> content) { }
-        public override void Visit(System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Models.OpenApiServerVariable> serverVariables) { }
+        public override void Visit(System.Collections.Generic.IDictionary<System.Net.Http.HttpMethod, Microsoft.OpenApi.Models.OpenApiOperation> operations) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiCallback> callbacks) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiExample> examples) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiHeader> headers) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.Interfaces.IOpenApiLink> links) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiEncoding> encodings) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiMediaType> content) { }
+        public override void Visit(System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Models.OpenApiServerVariable> serverVariables) { }
         public override void Visit(System.Collections.Generic.List<Microsoft.OpenApi.Models.Interfaces.IOpenApiExample> example) { }
     }
     public class OpenApiValidatorError : Microsoft.OpenApi.Models.OpenApiError
@@ -1911,7 +1911,7 @@ namespace Microsoft.OpenApi.Writers
     public static class OpenApiWriterAnyExtensions
     {
         public static void WriteAny(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, System.Text.Json.Nodes.JsonNode? node) { }
-        public static void WriteExtensions(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, System.Collections.Generic.Dictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? extensions, Microsoft.OpenApi.OpenApiSpecVersion specVersion) { }
+        public static void WriteExtensions(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, System.Collections.Generic.IDictionary<string, Microsoft.OpenApi.Interfaces.IOpenApiExtension>? extensions, Microsoft.OpenApi.OpenApiSpecVersion specVersion) { }
     }
     public abstract class OpenApiWriterBase : Microsoft.OpenApi.Writers.IOpenApiWriter
     {
@@ -1958,13 +1958,13 @@ namespace Microsoft.OpenApi.Writers
     {
         public static void WriteOptionalCollection(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.IEnumerable<string?>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, string?> action) { }
         public static void WriteOptionalCollection<T>(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.IEnumerable<T>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, T> action) { }
-        public static void WriteOptionalMap(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, System.Collections.Generic.HashSet<string>> action) { }
-        public static void WriteOptionalMap(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.Dictionary<string, System.Text.Json.Nodes.JsonNode>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, System.Text.Json.Nodes.JsonNode> action) { }
-        public static void WriteOptionalMap(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.Dictionary<string, bool>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, bool> action) { }
-        public static void WriteOptionalMap(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.Dictionary<string, string>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, string> action) { }
-        public static void WriteOptionalMap<T>(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.Dictionary<string, T>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, T> action)
+        public static void WriteOptionalMap(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.IDictionary<string, System.Collections.Generic.HashSet<string>>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, System.Collections.Generic.HashSet<string>> action) { }
+        public static void WriteOptionalMap(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.IDictionary<string, System.Text.Json.Nodes.JsonNode>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, System.Text.Json.Nodes.JsonNode> action) { }
+        public static void WriteOptionalMap(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.IDictionary<string, bool>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, bool> action) { }
+        public static void WriteOptionalMap(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.IDictionary<string, string>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, string> action) { }
+        public static void WriteOptionalMap<T>(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.IDictionary<string, T>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, T> action)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
-        public static void WriteOptionalMap<T>(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.Dictionary<string, T>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, string, T> action)
+        public static void WriteOptionalMap<T>(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.IDictionary<string, T>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, string, T> action)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
         public static void WriteOptionalObject<T>(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, T? value, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, T> action) { }
         public static void WriteOptionalOrEmptyCollection<T>(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.IEnumerable<T>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, T> action) { }
@@ -1977,8 +1977,8 @@ namespace Microsoft.OpenApi.Writers
             where T :  struct { }
         public static void WriteRequiredCollection<T>(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.IEnumerable<T> elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, T> action)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
-        public static void WriteRequiredMap(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.Dictionary<string, string>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, string> action) { }
-        public static void WriteRequiredMap<T>(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.Dictionary<string, T>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, T> action)
+        public static void WriteRequiredMap(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.IDictionary<string, string>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, string> action) { }
+        public static void WriteRequiredMap<T>(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, System.Collections.Generic.IDictionary<string, T>? elements, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, T> action)
             where T : Microsoft.OpenApi.Interfaces.IOpenApiElement { }
         public static void WriteRequiredObject<T>(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, T? value, System.Action<Microsoft.OpenApi.Writers.IOpenApiWriter, T> action) { }
         public static void WriteRequiredProperty(this Microsoft.OpenApi.Writers.IOpenApiWriter writer, string name, string? value) { }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -133,6 +133,13 @@ namespace Microsoft.OpenApi.Expressions
 }
 namespace Microsoft.OpenApi.Extensions
 {
+    public static class DictionaryExtensions
+    {
+        public static System.Collections.Generic.IDictionary<TKey, TValue> Sort<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> source)
+            where TKey :  notnull { }
+        public static System.Collections.Generic.IDictionary<TKey, TValue> Sort<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> source, System.Collections.Generic.IComparer<TKey> comparer)
+            where TKey :  notnull { }
+    }
     public static class EnumExtensions
     {
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2075", Justification="Fields are never trimmed for enum types.")]
@@ -1986,8 +1993,10 @@ namespace Microsoft.OpenApi.Writers
     public class OpenApiWriterSettings
     {
         public OpenApiWriterSettings() { }
+        public bool EnableSorting { get; set; }
         public bool InlineExternalReferences { get; set; }
         public bool InlineLocalReferences { get; set; }
+        public System.Collections.Generic.IComparer<string>? KeyComparer { get; set; }
     }
     public class OpenApiYamlWriter : Microsoft.OpenApi.Writers.OpenApiWriterBase
     {

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiReferenceValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiReferenceValidationTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.OpenApi.Tests.Validations
             var document = new OpenApiDocument();
             document.Components = new()
             {
-                Schemas = new()
+                Schemas = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["test"] = sharedSchema
                 }
@@ -47,7 +47,7 @@ namespace Microsoft.OpenApi.Tests.Validations
                             {
                                 ["200"] = new OpenApiResponse()
                                 {
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new()
                                         {
@@ -101,7 +101,7 @@ namespace Microsoft.OpenApi.Tests.Validations
                             {
                                 ["200"] = new OpenApiResponse()
                                 {
-                                    Content = new()
+                                    Content = new Dictionary<string, OpenApiMediaType>()
                                     {
                                         ["application/json"] = new()
                                         {

--- a/test/Microsoft.OpenApi.Tests/Visitors/InheritanceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Visitors/InheritanceTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.OpenApi.Tests.Visitors
                 base.Visit(serverVariable);
             }
 
-            public override void Visit(Dictionary<HttpMethod, OpenApiOperation> operations)
+            public override void Visit(IDictionary<HttpMethod, OpenApiOperation> operations)
             {
                 EncodeCall();
                 base.Visit(operations);
@@ -173,13 +173,13 @@ namespace Microsoft.OpenApi.Tests.Visitors
                 base.Visit(requestBody);
             }
 
-            public override void Visit(Dictionary<string, IOpenApiHeader> headers)
+            public override void Visit(IDictionary<string, IOpenApiHeader> headers)
             {
                 EncodeCall();
                 base.Visit(headers);
             }
 
-            public override void Visit(Dictionary<string, IOpenApiCallback> callbacks)
+            public override void Visit(IDictionary<string, IOpenApiCallback> callbacks)
             {
                 EncodeCall();
                 base.Visit(callbacks);
@@ -197,7 +197,7 @@ namespace Microsoft.OpenApi.Tests.Visitors
                 base.Visit(response);
             }
 
-            public override void Visit(Dictionary<string, OpenApiMediaType> content)
+            public override void Visit(IDictionary<string, OpenApiMediaType> content)
             {
                 EncodeCall();
                 base.Visit(content);
@@ -215,7 +215,7 @@ namespace Microsoft.OpenApi.Tests.Visitors
                 base.Visit(encoding);
             }
 
-            public override void Visit(Dictionary<string, IOpenApiExample> examples)
+            public override void Visit(IDictionary<string, IOpenApiExample> examples)
             {
                 EncodeCall();
                 base.Visit(examples);
@@ -239,7 +239,7 @@ namespace Microsoft.OpenApi.Tests.Visitors
                 base.Visit(schema);
             }
 
-            public override void Visit(Dictionary<string, IOpenApiLink> links)
+            public override void Visit(IDictionary<string, IOpenApiLink> links)
             {
                 EncodeCall();
                 base.Visit(links);
@@ -323,13 +323,13 @@ namespace Microsoft.OpenApi.Tests.Visitors
                 base.Visit(example);
             }
 
-            public override void Visit(Dictionary<string, OpenApiServerVariable> serverVariables)
+            public override void Visit(IDictionary<string, OpenApiServerVariable> serverVariables)
             {
                 EncodeCall();
                 base.Visit(serverVariables);
             }
 
-            public override void Visit(Dictionary<string, OpenApiEncoding> encodings)
+            public override void Visit(IDictionary<string, OpenApiEncoding> encodings)
             {
                 EncodeCall();
                 base.Visit(encodings);

--- a/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Walkers/WalkerLocationTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
                         {
                             ["200"] = new OpenApiResponse()
                             {
-                                Content = new()
+                                Content = new Dictionary<string, OpenApiMediaType>()
                                 {
                                     ["application/json"] = new()
                                     {
@@ -119,7 +119,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
             var loopySchema = new OpenApiSchema
             {
                 Type = JsonSchemaType.Object,
-                Properties = new()
+                Properties = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["name"] = new OpenApiSchema() { Type = JsonSchemaType.String }
                 }
@@ -131,7 +131,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
             {
                 Components = new()
                 {
-                    Schemas = new()
+                    Schemas = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["loopy"] = loopySchema
                     }
@@ -161,7 +161,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
             var baseSchema = new OpenApiSchema
             {
                 Type = JsonSchemaType.Object,
-                Properties = new()
+                Properties = new Dictionary<string, IOpenApiSchema>()
                 {
                     ["type"] = new OpenApiSchema() { Type = JsonSchemaType.String }
                 },
@@ -201,7 +201,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
                                 {
                                     ["200"] = new OpenApiResponse()
                                     {
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = new()
                                             {
@@ -220,7 +220,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
                 },
                 Components = new()
                 {
-                    Schemas = new()
+                    Schemas = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["derived"] = derivedSchema,
                         ["base"] = baseSchema,
@@ -302,7 +302,7 @@ namespace Microsoft.OpenApi.Tests.Walkers
         {
             Locations.Add("referenceAt: " + this.PathString);
         }
-        public override void Visit(Dictionary<string, OpenApiMediaType> content)
+        public override void Visit(IDictionary<string, OpenApiMediaType> content)
         {
             Locations.Add(this.PathString);
         }

--- a/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiWorkspaceTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Workspaces/OpenApiWorkspaceTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.OpenApi.Tests
                                 {
                                     ["200"] = new OpenApiResponse()
                                     {
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = new OpenApiMediaType()
                                             {
@@ -56,7 +56,7 @@ namespace Microsoft.OpenApi.Tests
             {
                 Components = new OpenApiComponents()
                 {
-                    Schemas = new()
+                    Schemas = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["test"] = testSchema
                     }
@@ -132,7 +132,7 @@ namespace Microsoft.OpenApi.Tests
             {
                 Components = new()
                 {
-                    Schemas = new()
+                    Schemas = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["test"] = new OpenApiSchema()
                         {

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiYamlWriterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiYamlWriterTests.cs
@@ -465,7 +465,7 @@ namespace Microsoft.OpenApi.Tests.Writers
                                     ["200"] = new OpenApiResponse()
                                     {
                                         Description = "OK",
-                                        Content = new()
+                                        Content = new Dictionary<string, OpenApiMediaType>()
                                         {
                                             ["application/json"] = new()
                                             {
@@ -480,7 +480,7 @@ namespace Microsoft.OpenApi.Tests.Writers
                 },
                 Components = new()
                 {
-                    Schemas = new()
+                    Schemas = new Dictionary<string, IOpenApiSchema>()
                     {
                         ["thing"] = thingSchema
                     }


### PR DESCRIPTION
- Changes the API surface area back to IDictionary to allow future implementations to use OrderedDictionary without it being a breaking change and continue allowing Swashbuckle customers to provide custom ordering.
- IDictionary will require customers to explicitly provide the type until .NET adds implicit support
- Adds `OpenApiWriterSettings` options to meet the need for deterministic ordering as per [this comment](https://github.com/microsoft/OpenAPI.NET/pull/2347#issuecomment-2876898641):
		1.  `EnableSorting` to enable sorting dictionary keys using a default comparer
		2. `KeyComparer` to allow consumers to plugin a custom comparer to sort dictionary entries
		


Fixes #2329