### PR TITLE
avoid stack overflow on cyclical references

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -498,10 +498,10 @@ namespace Microsoft.OpenApi
         /// <summary>
         /// Load the referenced <see cref="IOpenApiReferenceable"/> object from a <see cref="BaseOpenApiReference"/> object
         /// </summary>
-        internal T? ResolveReferenceTo<T>(BaseOpenApiReference reference) where T : IOpenApiReferenceable
+        internal T? ResolveReferenceTo<T>(BaseOpenApiReference reference, IOpenApiSchema? parentSchema) where T : IOpenApiReferenceable
         {
 
-            if (ResolveReference(reference, reference.IsExternal) is T result)
+            if (ResolveReference(reference, reference.IsExternal, parentSchema) is T result)
             {
                 return result;
             }
@@ -566,7 +566,7 @@ namespace Microsoft.OpenApi
         /// <summary>
         /// Load the referenced <see cref="IOpenApiReferenceable"/> object from a <see cref="BaseOpenApiReference"/> object
         /// </summary>
-        internal IOpenApiReferenceable? ResolveReference(BaseOpenApiReference? reference, bool useExternal)
+        internal IOpenApiReferenceable? ResolveReference(BaseOpenApiReference? reference, bool useExternal, IOpenApiSchema? parentSchema)
         {
             if (reference == null)
             {
@@ -621,9 +621,9 @@ namespace Microsoft.OpenApi
                 false => new Uri(uriLocation).AbsoluteUri
             };
 
-            if (reference.Type is ReferenceType.Schema && absoluteUri.Contains('#'))
+            if (reference.Type is ReferenceType.Schema && absoluteUri.Contains('#') && parentSchema is not null)
             {
-                return Workspace?.ResolveJsonSchemaReference(absoluteUri);
+                return Workspace?.ResolveJsonSchemaReference(absoluteUri, parentSchema);
             }
 
             return Workspace?.ResolveReference<IOpenApiReferenceable>(absoluteUri);

--- a/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
+++ b/src/Microsoft.OpenApi/Models/References/BaseOpenApiReferenceHolder.cs
@@ -15,7 +15,7 @@ public abstract class BaseOpenApiReferenceHolder<T, U, V> : IOpenApiReferenceHol
         get
         {
             if (Reference.HostDocument is null) return default;
-            return Reference.HostDocument.ResolveReferenceTo<U>(Reference);
+            return Reference.HostDocument.ResolveReferenceTo<U>(Reference, this as IOpenApiSchema);
         }
     }
     /// <inheritdoc/>

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiDocumentTests.cs
@@ -261,7 +261,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
             var schema1 = actual.Components.Schemas["AllPets"];
             var schema1Reference = Assert.IsType<OpenApiSchemaReference>(schema1);
             Assert.False(schema1Reference.UnresolvedReference);
-            var schema2 = actual.ResolveReferenceTo<OpenApiSchema>(schema1Reference.Reference);
+            var schema2 = actual.ResolveReferenceTo<OpenApiSchema>(schema1Reference.Reference, schema1Reference);
             Assert.IsType<OpenApiSchema>(schema2);
             if (string.IsNullOrEmpty(schema1Reference.Reference.Id) || schema1Reference.UnresolvedReference)
             {

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/RelativeReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/RelativeReferenceTests.cs
@@ -436,6 +436,16 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             Assert.Equal(JsonSchemaType.Array | JsonSchemaType.Null, updatedTagsProperty.Type);
             Assert.Equal(JsonSchemaType.Object, updatedTagsProperty.Items.Type);
 
+
+            // doing the same for the parent property
+
+            var parentProperty = Assert.IsType<OpenApiSchema>(schema.Properties["parent"]);
+            var parentSubProperty = Assert.IsType<OpenApiSchemaReference>(parentProperty.Properties["parent"]);
+            Assert.Equal("#/properties/parent", parentSubProperty.Reference.ReferenceV3);
+            parentProperty.Properties["parent"] = new OpenApiSchemaReference($"#/components/schemas/Foo{parentSubProperty.Reference.ReferenceV3.Replace("#", string.Empty)}", document);
+            var updatedParentSubProperty = Assert.IsType<OpenApiSchemaReference>(parentProperty.Properties["parent"]);
+            Assert.Equal(JsonSchemaType.Object | JsonSchemaType.Null, updatedParentSubProperty.Type);
+
             var pathItem = new OpenApiPathItem
             {
                 Operations = new Dictionary<HttpMethod, OpenApiOperation>

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/RelativeReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/RelativeReferenceTests.cs
@@ -505,6 +505,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             Assert.Null(tagsSchemaRef.Items);
             Assert.Equal("#/components/schemas/Category/properties/parent/properties/tags", tagsSchemaRef.Reference.ReferenceV3);
             Assert.Null(tagsSchemaRef.Target);
+
+            var parentSchemaRef = Assert.IsType<OpenApiSchemaReference>(categorySchema.Properties["parent"]);
+            Assert.Equal("#/components/schemas/Category", parentSchemaRef.Reference.ReferenceV3);
+            Assert.NotNull(parentSchemaRef.Target);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/RelativeReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/RelativeReferenceTests.cs
@@ -434,6 +434,39 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             var updatedTagsProperty = Assert.IsType<OpenApiSchemaReference>(schema.Properties["tags"]);
             Assert.Equal(absoluteReferenceId, updatedTagsProperty.Reference.ReferenceV3);
             Assert.Equal(JsonSchemaType.Array | JsonSchemaType.Null, updatedTagsProperty.Type);
+            Assert.Equal(JsonSchemaType.Object, updatedTagsProperty.Items.Type);
+
+            var pathItem = new OpenApiPathItem
+            {
+                Operations = new Dictionary<HttpMethod, OpenApiOperation>
+                {
+                    [HttpMethod.Post] = new OpenApiOperation
+                    {
+                        Responses = new OpenApiResponses
+                        {
+                            ["200"] = new OpenApiResponse
+                            {
+                            }
+                        },
+                        RequestBody = new OpenApiRequestBody
+                        {
+                            Content = new Dictionary<string, OpenApiMediaType>
+                            {
+                                ["application/json"] = new OpenApiMediaType
+                                {
+                                    Schema = new OpenApiSchemaReference("#/components/schemas/Foo", document)
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+            document.Paths.Add("/", pathItem);
+
+            var requestBodySchema = pathItem.Operations[HttpMethod.Post].RequestBody.Content["application/json"].Schema;
+            Assert.NotNull(requestBodySchema);
+            var requestBodyTagsProperty = Assert.IsType<OpenApiSchemaReference>(requestBodySchema.Properties["tags"]);
+            Assert.Equal(JsonSchemaType.Object, requestBodyTagsProperty.Items.Type);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/RelativeReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/RelativeReferenceTests.cs
@@ -501,7 +501,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             document.AddComponent("Category", categorySchema);
             document.RegisterComponents();
 
-            Assert.Null(categorySchema.Properties["tags"].Items);
+            var tagsSchemaRef = Assert.IsType<OpenApiSchemaReference>(categorySchema.Properties["tags"]);
+            Assert.Null(tagsSchemaRef.Items);
+            Assert.Equal("#/components/schemas/Category/properties/parent/properties/tags", tagsSchemaRef.Reference.ReferenceV3);
+            Assert.Null(tagsSchemaRef.Target);
         }
     }
 }


### PR DESCRIPTION
- **chore: adds additional multiple levels of references test cases**
- **chore: adds update to parent property**
- **fix: avoid stack overflow on cyclical references**
