### PR TITLE
Validate OpenAPI schema references

### DIFF
--- a/src/Microsoft.OpenApi/Properties/SRResource.Designer.cs
+++ b/src/Microsoft.OpenApi/Properties/SRResource.Designer.cs
@@ -385,6 +385,15 @@ namespace Microsoft.OpenApi {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The schema reference &apos;{0}&apos; does not point to an existing schema..
+        /// </summary>
+        internal static string Validation_SchemaReferenceDoesNotExist {
+            get {
+                return ResourceManager.GetString("Validation_SchemaReferenceDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Schema {0} must contain property specified in the discriminator {1} in the required field list..
         /// </summary>
         internal static string Validation_SchemaRequiredFieldListMustContainThePropertySpecifiedInTheDiscriminator {

--- a/src/Microsoft.OpenApi/Properties/SRResource.resx
+++ b/src/Microsoft.OpenApi/Properties/SRResource.resx
@@ -231,6 +231,9 @@
   <data name="ParseServerUrlValueNotValid" xml:space="preserve">
     <value>Value '{0}' is not a valid value for variable '{1}'. If an enum is provided, it should not be empty and the value provided should exist in the enum</value>
   </data>
+  <data name="Validation_SchemaReferenceDoesNotExist" xml:space="preserve">
+    <value>The schema reference '{0}' does not point to an existing schema.</value>
+  </data>
   <data name="ArgumentNull" xml:space="preserve">
     <value>The argument '{0}' is null.</value>
   </data>

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
@@ -81,14 +81,6 @@ namespace Microsoft.OpenApi
 
             private void ValidateSchemaReference(OpenApiSchemaReference reference)
             {
-                // Trim off the leading "#/" as the context is already at the root of the document
-                var segment =
-#if NET8_0_OR_GREATER
-                    $"{PathString[2..]}/$ref";
-#else
-                    PathString.Substring(2) + "/$ref";
-#endif
-
                 try
                 {
                     if (reference.RecursiveTarget is not null)
@@ -99,7 +91,7 @@ namespace Microsoft.OpenApi
                 }
                 catch (InvalidOperationException ex)
                 {
-                    context.Enter(segment);
+                    context.Enter(GetSegment());
                     context.CreateWarning(ruleName, ex.Message);
                     context.Exit();
 
@@ -129,7 +121,7 @@ namespace Microsoft.OpenApi
 
                     if (!isValid)
                     {
-                        context.Enter(segment);
+                        context.Enter(GetSegment());
                         context.CreateWarning(ruleName, string.Format(SRResource.Validation_SchemaReferenceDoesNotExist, id));
                         context.Exit();
                     }
@@ -142,6 +134,17 @@ namespace Microsoft.OpenApi
                 {
                     var pointer = new JsonPointer(id.Replace("#/", "/"));
                     return pointer.Find(baseNode);
+                }
+
+                string GetSegment()
+                {
+                    // Trim off the leading "#/" as the context is already at the root of the document
+                    return
+#if NET8_0_OR_GREATER
+                        $"{PathString[2..]}/$ref";
+#else
+                        PathString.Substring(2) + "/$ref";
+#endif
                 }
             }
         }

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using System;
+using System.Text.Json.Nodes;
+using Microsoft.OpenApi.Reader;
 
 namespace Microsoft.OpenApi
 {
@@ -23,9 +24,108 @@ namespace Microsoft.OpenApi
                     if (item.Info == null)
                     {
                         context.CreateError(nameof(OpenApiDocumentFieldIsMissing),
-                            String.Format(SRResource.Validation_FieldIsRequired, "info", "document"));
+                            string.Format(SRResource.Validation_FieldIsRequired, "info", "document"));
                     }
                     context.Exit();
                 });
+
+        /// <summary>
+        /// All references in the OpenAPI document must be valid.
+        /// </summary>
+        public static ValidationRule<OpenApiDocument> OpenApiDocumentReferencesAreValid =>
+            new(nameof(OpenApiDocumentReferencesAreValid),
+                static (context, item) =>
+                {
+                    const string RuleName = nameof(OpenApiDocumentReferencesAreValid);
+
+                    JsonNode document;
+
+                    using (var textWriter = new System.IO.StringWriter())
+                    {
+                        var writer = new OpenApiJsonWriter(textWriter);
+
+                        item.SerializeAsV31(writer);
+
+                        var json = textWriter.ToString();
+
+                        document = JsonNode.Parse(json)!;
+                    }
+
+                    var visitor = new OpenApiSchemaReferenceVisitor(RuleName, context, document);
+                    var walker = new OpenApiWalker(visitor);
+
+                    walker.Walk(item);
+                });
+
+        private sealed class OpenApiSchemaReferenceVisitor(
+            string ruleName,
+            IValidationContext context,
+            JsonNode document) : OpenApiVisitorBase
+        {
+            public override void Visit(IOpenApiReferenceHolder referenceHolder)
+            {
+                if (referenceHolder is OpenApiSchemaReference { Reference.IsLocal: true } reference)
+                {
+                    ValidateSchemaReference(reference);
+                }
+            }
+
+            public override void Visit(IOpenApiSchema schema)
+            {
+                if (schema is OpenApiSchemaReference { Reference.IsLocal: true } reference)
+                {
+                    ValidateSchemaReference(reference);
+                }
+            }
+
+            private void ValidateSchemaReference(OpenApiSchemaReference reference)
+            {
+                var id = reference.Reference.ReferenceV3;
+
+                if (id is { Length: > 0 } && !IsValidSchemaReference(id, document))
+                {
+                    var isValid = false;
+
+                    // Sometimes ReferenceV3 is not a JSON valid JSON pointer, but the $ref
+                    // associated with it still points to a valid location in the document.
+                    // In these cases, we need to find it manually to verify that fact before
+                    // generating a warning that the schema reference is indeed invalid.
+                    // TODO Why is this, and can it be avoided?
+                    var parent = Find(PathString, document);
+
+                    if (parent?["$ref"] is { } @ref &&
+                        @ref.GetValueKind() is System.Text.Json.JsonValueKind.String &&
+                        @ref.GetValue<string>() is { Length: > 0 } refId)
+                    {
+                        id = refId;
+                        isValid = IsValidSchemaReference(id, document);
+                    }
+
+                    if (!isValid)
+                    {
+                        // Trim off the leading "#/" as the context is already at the root of the document
+                        var segment =
+#if NET8_0_OR_GREATER
+                            PathString[2..];
+#else
+                            PathString.Substring(2);
+#endif
+
+                        context.Enter(segment);
+                        context.CreateWarning(ruleName, string.Format(SRResource.Validation_SchemaReferenceDoesNotExist, id));
+                        context.Exit();
+                    }
+                }
+
+                static bool IsValidSchemaReference(string id, JsonNode baseNode)
+                    => Find(id, baseNode) is not null;
+
+                static JsonNode? Find(string id, JsonNode baseNode)
+                {
+                    var pointer = new JsonPointer(id.Replace("#/", "/"));
+                    return pointer.Find(baseNode);
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
@@ -41,7 +41,7 @@ namespace Microsoft.OpenApi
 
                     JsonNode document;
 
-                    using (var textWriter = new System.IO.StringWriter())
+                    using (var textWriter = new System.IO.StringWriter(System.Globalization.CultureInfo.InvariantCulture))
                     {
                         var writer = new OpenApiJsonWriter(textWriter);
 

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
@@ -93,12 +93,12 @@ namespace Microsoft.OpenApi
                 {
                     if (reference.RecursiveTarget is not null)
                     {
+                        // The reference was followed to a valid schema somewhere in the document
                         return;
                     }
                 }
                 catch (InvalidOperationException ex)
                 {
-                    // The reference was followed to a valid schema somewhere in the document
                     context.Enter(segment);
                     context.CreateWarning(ruleName, ex.Message);
                     context.Exit();

--- a/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
+++ b/src/Microsoft.OpenApi/Validations/Rules/OpenApiDocumentRules.cs
@@ -80,6 +80,12 @@ namespace Microsoft.OpenApi
 
             private void ValidateSchemaReference(OpenApiSchemaReference reference)
             {
+                if (reference.RecursiveTarget is not null)
+                {
+                    // The reference was followed to a valid schema somewhere in the document
+                    return;
+                }
+
                 var id = reference.Reference.ReferenceV3;
 
                 if (id is { Length: > 0 } && !IsValidSchemaReference(id, document))

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -627,6 +627,7 @@ namespace Microsoft.OpenApi
     public static class OpenApiDocumentRules
     {
         public static Microsoft.OpenApi.ValidationRule<Microsoft.OpenApi.OpenApiDocument> OpenApiDocumentFieldIsMissing { get; }
+        public static Microsoft.OpenApi.ValidationRule<Microsoft.OpenApi.OpenApiDocument> OpenApiDocumentReferencesAreValid { get; }
     }
     public static class OpenApiElementExtensions
     {

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiDocumentValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiDocumentValidationTests.cs
@@ -129,6 +129,6 @@ public static class OpenApiDocumentValidationTests
         Assert.NotNull(errors);
         var error = Assert.Single(errors);
         Assert.Equal("The schema reference '#/components/schemas/Pet' does not point to an existing schema.", error.Message);
-        Assert.Equal("#/paths/~1pets/get/responses/200/content/application~1json/schema", error.Pointer);
+        Assert.Equal("#/paths/~1pets/get/responses/200/content/application~1json/schema/$ref", error.Pointer);
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiDocumentValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiDocumentValidationTests.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using Xunit;
+
+namespace Microsoft.OpenApi.Validations.Tests;
+
+public static class OpenApiDocumentValidationTests
+{
+    [Fact]
+    public static void ValidateSchemaReferencesAreValid()
+    {
+        // Arrange
+        var document = new OpenApiDocument
+        {
+            Components = new OpenApiComponents(),
+            Info = new OpenApiInfo
+            {
+                Title = "People Document",
+                Version = "1.0.0"
+            },
+            Paths = [],
+            Workspace = new()
+        };
+
+        document.AddComponent("Person", new OpenApiSchema
+        {
+            Type = JsonSchemaType.Object,
+            Properties = new Dictionary<string, IOpenApiSchema>()
+            {
+                ["name"] = new OpenApiSchema { Type = JsonSchemaType.String },
+                ["email"] = new OpenApiSchema { Type = JsonSchemaType.String, Format = "email" }
+            }
+        });
+
+        document.Paths.Add("/people", new OpenApiPathItem
+        {
+            Operations = new Dictionary<HttpMethod, OpenApiOperation>()
+            {
+                [HttpMethod.Get] = new OpenApiOperation
+                {
+                    Responses = new()
+                    {
+                        ["200"] = new OpenApiResponse
+                        {
+                            Description = "OK",
+                            Content = new Dictionary<string, OpenApiMediaType>()
+                            {
+                                ["application/json"] = new OpenApiMediaType
+                                {
+                                    Schema = new OpenApiSchemaReference("Person", document),
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        // Act
+        var errors = document.Validate(ValidationRuleSet.GetDefaultRuleSet());
+        var result = !errors.Any();
+
+        // Assert
+        Assert.True(result);
+        Assert.NotNull(errors);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public static void ValidateSchemaReferencesAreInvalid()
+    {
+        // Arrange
+        var document = new OpenApiDocument
+        {
+            Components = new OpenApiComponents(),
+            Info = new OpenApiInfo
+            {
+                Title = "Pets Document",
+                Version = "1.0.0"
+            },
+            Paths = [],
+            Workspace = new()
+        };
+
+        document.AddComponent("Person", new OpenApiSchema
+        {
+            Type = JsonSchemaType.Object,
+            Properties = new Dictionary<string, IOpenApiSchema>()
+            {
+                ["name"] = new OpenApiSchema { Type = JsonSchemaType.String },
+                ["email"] = new OpenApiSchema { Type = JsonSchemaType.String, Format = "email" }
+            }
+        });
+
+        document.Paths.Add("/pets", new OpenApiPathItem
+        {
+            Operations = new Dictionary<HttpMethod, OpenApiOperation>()
+            {
+                [HttpMethod.Get] = new OpenApiOperation
+                {
+                    Responses = new()
+                    {
+                        ["200"] = new OpenApiResponse
+                        {
+                            Description = "OK",
+                            Content = new Dictionary<string, OpenApiMediaType>()
+                            {
+                                ["application/json"] = new OpenApiMediaType
+                                {
+                                    Schema = new OpenApiSchemaReference("Pet", document),
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        // Act
+        var errors = document.Validate(ValidationRuleSet.GetDefaultRuleSet());
+        var result = !errors.Any();
+
+        // Assert
+        Assert.False(result);
+        Assert.NotNull(errors);
+        var error = Assert.Single(errors);
+        Assert.Equal("The schema reference '#/components/schemas/Pet' does not point to an existing schema.", error.Message);
+        Assert.Equal("#/paths/~1pets/get/responses/200/content/application~1json/schema", error.Pointer);
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/ValidationRuleSetTests.cs
@@ -53,8 +53,8 @@ namespace Microsoft.OpenApi.Validations.Tests
             Assert.Empty(ruleSet_4.Rules);
 
             // Update the number if you add new default rule(s).
-            Assert.Equal(19, ruleSet_1.Rules.Count);
-            Assert.Equal(19, ruleSet_2.Rules.Count);
+            Assert.Equal(20, ruleSet_1.Rules.Count);
+            Assert.Equal(20, ruleSet_2.Rules.Count);
             Assert.Equal(3, ruleSet_3.Rules.Count);
         }
 


### PR DESCRIPTION
Add validation rule for OpenAPI document schema references.

Resolves #2453.

---

~~Initial draft for now based on testing this approach with https://github.com/dotnet/aspnetcore/pull/63095. Needs tests, plus rebasing after #2460 is merged.~~
