### PR TITLE
Improve OpenApiWalker performance

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -75,6 +75,13 @@ jobs:
           dotnet run -c Release
         working-directory: ./performance/benchmark
 
+      - name: Publish benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: benchmark-results
+          path: "${{ github.workspace }}/performance/benchmark/BenchmarkDotNet.Artifacts/results"
+
       - name: Run comparison tool for empty models
         run: dotnet run -c Release --project ./performance/resultsComparer/resultsComparer.csproj -- compare $OLD_REPORT $NEW_REPORT -p IdenticalMemoryUsage
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ ipch/
 *.VC.VC.opendb
 
 # Visual Studio profiler
+*.diagsession
 *.psess
 *.vsp
 *.vspx
@@ -286,3 +287,7 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+# BenchmarkDotNet profiler files
+*.nettrace
+*.speedscope.json


### PR DESCRIPTION
Benchmark results: https://github.com/microsoft/OpenAPI.NET/pull/2459#issuecomment-3204949255

Given that the hardware between my local setup and GitHub Actions is quite different, I suggest merging this PR once happy with the code changes with the failing benchmark comparison, then downloading the results from the run in main and opening a new PR to use those files to replace the contents of [`performance/benchmark/BenchmarkDotNet.Artifacts/results`](https://github.com/microsoft/OpenAPI.NET/tree/main/performance/benchmark/BenchmarkDotNet.Artifacts/results) and update the baseline.

## Changes

- Avoid allocations from lambda closures.
- Avoid allocations from context strings.
- Avoid allocations from copying arrays.
- Remove redundant null checks.
- Ignore BenchmarkDotNet profiler files.
- Ignore Visual Studio profiler session files.
- Publish benchmark results to GitHub Actions workflow artifacts.
