### PR TITLE
Fix missing examples when one example is with an empty array.

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiExample.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiExample.cs
@@ -70,7 +70,10 @@ namespace Microsoft.OpenApi
             writer.WriteProperty(OpenApiConstants.Description, Description);
 
             // value
-            writer.WriteOptionalObject(OpenApiConstants.Value, Value, (w, v) => w.WriteAny(v));
+            if (Value is not null)
+            {
+                writer.WriteRequiredObject(OpenApiConstants.Value, Value, (w, v) => w.WriteAny(v));    
+            }
 
             // externalValue
             writer.WriteProperty(OpenApiConstants.ExternalValue, ExternalValue);

--- a/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiMediaType.cs
@@ -95,7 +95,7 @@ namespace Microsoft.OpenApi
             // examples
             if (Examples != null && Examples.Any())
             {
-                SerializeExamples(writer, Examples, callback);
+                writer.WriteOptionalMap(OpenApiConstants.Examples, Examples, callback);
             }
 
             // encoding
@@ -113,34 +113,6 @@ namespace Microsoft.OpenApi
         public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             // Media type does not exist in V2.
-        }
-
-        private static void SerializeExamples(IOpenApiWriter writer, IDictionary<string, IOpenApiExample> examples, Action<IOpenApiWriter, IOpenApiSerializable> callback)
-        {
-            /* Special case for writing out empty arrays as valid response examples
-            * Check if there is any example with an empty array as its value and set the flag `hasEmptyArray` to true
-            * */
-            var hasEmptyArray = examples.Values.Any( static example =>
-                example.Value is JsonArray arr && arr.Count == 0
-            );
-
-            if (hasEmptyArray)
-            {
-                writer.WritePropertyName(OpenApiConstants.Examples);
-                writer.WriteStartObject();
-                foreach (var kvp in examples.Where(static kvp => kvp.Value.Value is JsonArray arr && arr.Count == 0))
-                {
-                    writer.WritePropertyName(kvp.Key);
-                    writer.WriteStartObject();
-                    writer.WriteRequiredObject(OpenApiConstants.Value, kvp.Value.Value, (w, v) => w.WriteAny(v));
-                    writer.WriteEndObject();
-                }
-                writer.WriteEndObject();
-            }
-            else
-            {
-                writer.WriteOptionalMap(OpenApiConstants.Examples, examples, callback);
-            }
         }
     }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiMediaTypeTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiMediaTypeTests.cs
@@ -87,7 +87,16 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
   },
   ""examples"": {
     ""Success response - no results"": {
+      ""summary"": ""empty array summary"",
+      ""description"": ""empty array description"",
       ""value"": [ ]
+    },
+    ""Success response - with results"": {
+      ""summary"": ""array summary"",
+      ""description"": ""array description"",
+      ""value"": [ 
+        1
+      ]
     }
   }
 }

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiMediaType/examplesWithEmptyArray.json
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/Samples/OpenApiMediaType/examplesWithEmptyArray.json
@@ -12,7 +12,14 @@
   },
   "examples": {
     "Success response - no results": {
+      "summary": "empty array summary",
+      "description": "empty array description",
       "value": []
+    },
+    "Success response - with results": {
+      "summary": "array summary",
+      "description": "array description",
+      "value": [ 1 ]
     }
   }
 }


### PR DESCRIPTION
Fix issue when response has several example and one is with empty array as `value`
**Expected:**  all examples are present
**Actual:** only example with empty array is present and without summary and description.

Fixes https://github.com/microsoft/OpenAPI.NET/issues/1643 in another way without such side effect.
Please release also to v1.