### PR TITLE
feat: adds the detected format as part of the diagnostics

### DIFF
--- a/src/Microsoft.OpenApi.YamlReader/OpenApiYamlReader.cs
+++ b/src/Microsoft.OpenApi.YamlReader/OpenApiYamlReader.cs
@@ -67,11 +67,11 @@ namespace Microsoft.OpenApi.YamlReader
             {
                 var diagnostic = new OpenApiDiagnostic();
                 diagnostic.Errors.Add(new($"#line={ex.LineNumber}", ex.Message));
+                diagnostic.Format = OpenApiConstants.Yaml;
                 return new()
                 {
                     Document = null,
                     Diagnostic = diagnostic,
-                    Format = OpenApiConstants.Yaml,
                 };
             }
 
@@ -79,7 +79,8 @@ namespace Microsoft.OpenApi.YamlReader
         }
         private static ReadResult UpdateFormat(ReadResult result)
         {
-            result.Format = OpenApiConstants.Yaml;
+            result.Diagnostic ??= new OpenApiDiagnostic();
+            result.Diagnostic.Format = OpenApiConstants.Yaml;
             return result;
         }
 

--- a/src/Microsoft.OpenApi.YamlReader/OpenApiYamlReader.cs
+++ b/src/Microsoft.OpenApi.YamlReader/OpenApiYamlReader.cs
@@ -31,14 +31,14 @@ namespace Microsoft.OpenApi.YamlReader
             if (input is null) throw new ArgumentNullException(nameof(input));
             if (input is MemoryStream memoryStream)
             {
-                return Read(memoryStream, location, settings);
+                return UpdateFormat(Read(memoryStream, location, settings));
             } 
             else 
             {
                 using var preparedStream = new MemoryStream();
                 await input.CopyToAsync(preparedStream, copyBufferSize, cancellationToken).ConfigureAwait(false);
                 preparedStream.Position = 0;
-                return Read(preparedStream, location, settings);
+                return UpdateFormat(Read(preparedStream, location, settings));
             }
         }
 
@@ -70,17 +70,23 @@ namespace Microsoft.OpenApi.YamlReader
                 return new()
                 {
                     Document = null,
-                    Diagnostic = diagnostic
+                    Diagnostic = diagnostic,
+                    Format = OpenApiConstants.Yaml,
                 };
             }
 
-            return Read(jsonNode, location, settings);
+            return UpdateFormat(Read(jsonNode, location, settings));
+        }
+        private static ReadResult UpdateFormat(ReadResult result)
+        {
+            result.Format = OpenApiConstants.Yaml;
+            return result;
         }
 
         /// <inheritdoc/>
         public static ReadResult Read(JsonNode jsonNode, Uri location, OpenApiReaderSettings settings)
         {
-            return _jsonReader.Read(jsonNode, location, settings);
+            return UpdateFormat(_jsonReader.Read(jsonNode, location, settings));
         }
 
         /// <inheritdoc/>

--- a/src/Microsoft.OpenApi/Reader/OpenApiDiagnostic.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiDiagnostic.cs
@@ -26,6 +26,11 @@ namespace Microsoft.OpenApi.Reader
         public OpenApiSpecVersion SpecificationVersion { get; set; }
 
         /// <summary>
+        /// The format of the OpenAPI document (e.g., "json", "yaml").
+        /// </summary>
+        public string? Format { get; set; }
+
+        /// <summary>
         /// Append another set of diagnostic Errors and Warnings to this one, this may be appended from another external
         /// document's parsing and we want to indicate which file it originated from.
         /// </summary>

--- a/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
@@ -42,11 +42,11 @@ namespace Microsoft.OpenApi.Reader
             catch (JsonException ex)
             {
                 diagnostic.Errors.Add(new OpenApiError($"#line={ex.LineNumber}", $"Please provide the correct format, {ex.Message}"));
+                diagnostic.Format = OpenApiConstants.Json;
                 return new ReadResult
                 {
                     Document = null,
                     Diagnostic = diagnostic,
-                    Format = OpenApiConstants.Json,
                 };
             }
 
@@ -103,12 +103,11 @@ namespace Microsoft.OpenApi.Reader
                     }
                 }                
             }
-
+            diagnostic.Format = OpenApiConstants.Json;
             return new()
             {
                 Document = document,
                 Diagnostic = diagnostic,
-                Format = OpenApiConstants.Json
             };
         }
 
@@ -140,11 +139,11 @@ namespace Microsoft.OpenApi.Reader
             catch (JsonException ex)
             {
                 diagnostic.Errors.Add(new OpenApiError($"#line={ex.LineNumber}", $"Please provide the correct format, {ex.Message}"));
+                diagnostic.Format = OpenApiConstants.Json;
                 return new ReadResult
                 {
                     Document = null,
                     Diagnostic = diagnostic,
-                    Format = OpenApiConstants.Json,
                 };
             }
 

--- a/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
+++ b/src/Microsoft.OpenApi/Reader/OpenApiJsonReader.cs
@@ -45,7 +45,8 @@ namespace Microsoft.OpenApi.Reader
                 return new ReadResult
                 {
                     Document = null,
-                    Diagnostic = diagnostic
+                    Diagnostic = diagnostic,
+                    Format = OpenApiConstants.Json,
                 };
             }
 
@@ -106,7 +107,8 @@ namespace Microsoft.OpenApi.Reader
             return new()
             {
                 Document = document,
-                Diagnostic = diagnostic
+                Diagnostic = diagnostic,
+                Format = OpenApiConstants.Json
             };
         }
 
@@ -141,7 +143,8 @@ namespace Microsoft.OpenApi.Reader
                 return new ReadResult
                 {
                     Document = null,
-                    Diagnostic = diagnostic
+                    Diagnostic = diagnostic,
+                    Format = OpenApiConstants.Json,
                 };
             }
 

--- a/src/Microsoft.OpenApi/Reader/ReadResult.cs
+++ b/src/Microsoft.OpenApi/Reader/ReadResult.cs
@@ -16,12 +16,24 @@ public class ReadResult
     /// </summary>
     public OpenApiDiagnostic? Diagnostic { get; set; }
     /// <summary>
+    /// The format of the OpenAPI document (e.g., "json", "yaml").
+    /// </summary>
+    public string? Format { get; set; }
+    /// <summary>
     /// Deconstructs the result for easier assignment on the client application.
     /// </summary>
     public void Deconstruct(out OpenApiDocument? document, out OpenApiDiagnostic? diagnostic)
     {
+        Deconstruct(out document, out diagnostic, out _);
+    }
+    /// <summary>
+    /// Deconstructs the result for easier assignment on the client application.
+    /// </summary>
+    public void Deconstruct(out OpenApiDocument? document, out OpenApiDiagnostic? diagnostic, out string? format)
+    {
         document = Document;
         diagnostic = Diagnostic;
+        format = Format;
     }
 }
 

--- a/src/Microsoft.OpenApi/Reader/ReadResult.cs
+++ b/src/Microsoft.OpenApi/Reader/ReadResult.cs
@@ -16,24 +16,12 @@ public class ReadResult
     /// </summary>
     public OpenApiDiagnostic? Diagnostic { get; set; }
     /// <summary>
-    /// The format of the OpenAPI document (e.g., "json", "yaml").
-    /// </summary>
-    public string? Format { get; set; }
-    /// <summary>
     /// Deconstructs the result for easier assignment on the client application.
     /// </summary>
     public void Deconstruct(out OpenApiDocument? document, out OpenApiDiagnostic? diagnostic)
     {
-        Deconstruct(out document, out diagnostic, out _);
-    }
-    /// <summary>
-    /// Deconstructs the result for easier assignment on the client application.
-    /// </summary>
-    public void Deconstruct(out OpenApiDocument? document, out OpenApiDiagnostic? diagnostic, out string? format)
-    {
         document = Document;
         diagnostic = Diagnostic;
-        format = Format;
     }
 }
 

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiStreamReaderTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiStreamReaderTests.cs
@@ -20,8 +20,9 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "petStore.yaml"));
             var settings = new OpenApiReaderSettings { LeaveStreamOpen = false };
             settings.AddYamlReader();
-            _ = await OpenApiDocument.LoadAsync(stream, settings: settings);
+            (_, _, var format) = await OpenApiDocument.LoadAsync(stream, settings: settings);
             Assert.False(stream.CanRead);
+            Assert.Equal(OpenApiConstants.Yaml, format);
         }
 
         [Fact]

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiStreamReaderTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiReaderTests/OpenApiStreamReaderTests.cs
@@ -20,9 +20,9 @@ namespace Microsoft.OpenApi.Readers.Tests.OpenApiReaderTests
             using var stream = Resources.GetStream(Path.Combine(SampleFolderPath, "petStore.yaml"));
             var settings = new OpenApiReaderSettings { LeaveStreamOpen = false };
             settings.AddYamlReader();
-            (_, _, var format) = await OpenApiDocument.LoadAsync(stream, settings: settings);
+            (_, var diagnostic) = await OpenApiDocument.LoadAsync(stream, settings: settings);
             Assert.False(stream.CanRead);
-            Assert.Equal(OpenApiConstants.Yaml, format);
+            Assert.Equal(OpenApiConstants.Yaml, diagnostic.Format);
         }
 
         [Fact]

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiServerTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiServerTests.cs
@@ -314,7 +314,8 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                     {
                         new OpenApiError("#/", "Invalid host")
                     },
-                    SpecificationVersion = OpenApiSpecVersion.OpenApi2_0
+                    SpecificationVersion = OpenApiSpecVersion.OpenApi2_0,
+                    Format = OpenApiConstants.Yaml
                 }, result.Diagnostic);
         }
     }

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiDocumentTests.cs
@@ -207,7 +207,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             };
 
             // Assert            
-            Assert.Equivalent(new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_1 }, actual.Diagnostic);
+            Assert.Equivalent(new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_1, Format = OpenApiConstants.Yaml }, actual.Diagnostic);
             actual.Document.Should().BeEquivalentTo(expected, options => options.Excluding(x => x.Workspace).Excluding(y => y.BaseUri));
         }
 
@@ -414,7 +414,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             .Excluding(x => x.Workspace)
             .Excluding(y => y.BaseUri));
             Assert.Equivalent(
-                new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_1 }, actual.Diagnostic);
+                new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_1, Format = OpenApiConstants.Yaml }, actual.Diagnostic);
         }
 
         [Fact]

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiCallbackTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiCallbackTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             var callback = subscribeOperation.Callbacks["simpleHook"];
 
             Assert.Equivalent(
-                new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0 }, result.Diagnostic);
+                new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0, Format = OpenApiConstants.Yaml }, result.Diagnostic);
 
             Assert.Equivalent(
                 new OpenApiCallbackReference("simpleHook", result.Document)
@@ -120,7 +120,7 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             var subscribeOperation = path.Operations[HttpMethod.Post];
 
             Assert.Equivalent(
-                new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0 }, result.Diagnostic);
+                new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0, Format = OpenApiConstants.Yaml }, result.Diagnostic);
 
             var callback1 = subscribeOperation.Callbacks["simpleHook"];
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiDocumentTests.cs
@@ -69,7 +69,8 @@ paths: {}",
             Assert.Equivalent(
                 new OpenApiDiagnostic()
                 {
-                    SpecificationVersion = OpenApiSpecVersion.OpenApi3_0
+                    SpecificationVersion = OpenApiSpecVersion.OpenApi3_0,
+                    Format = OpenApiConstants.Yaml
                 }, result.Diagnostic);
         }
 
@@ -147,7 +148,8 @@ paths: {}
                     {
                             new OpenApiValidatorError(nameof(OpenApiInfoRules.InfoRequiredFields),"#/info/title", "The field 'title' in 'info' object is REQUIRED.")
                     },
-                    SpecificationVersion = OpenApiSpecVersion.OpenApi3_0
+                    SpecificationVersion = OpenApiSpecVersion.OpenApi3_0,
+                    Format = OpenApiConstants.Yaml
                 }, result.Diagnostic);
         }
 
@@ -170,7 +172,8 @@ paths: {}
             Assert.Equivalent(
                 new OpenApiDiagnostic()
                 {
-                    SpecificationVersion = OpenApiSpecVersion.OpenApi3_0
+                    SpecificationVersion = OpenApiSpecVersion.OpenApi3_0,
+                    Format = OpenApiConstants.Yaml
                 }, result.Diagnostic);
         }
 
@@ -557,7 +560,7 @@ paths: {}
             actual.Document.Should().BeEquivalentTo(expectedDoc, options => options.Excluding(x => x.Workspace).Excluding(y => y.BaseUri));
 
             Assert.Equivalent(
-                new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0 }, actual.Diagnostic);
+                new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0, Format = OpenApiConstants.Yaml }, actual.Diagnostic);
         }
 
         [Fact]
@@ -1031,7 +1034,7 @@ paths: {}
             .Excluding(y => y.BaseUri));
 
             Assert.Equivalent(
-                    new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0 }, actual.Diagnostic);
+                    new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0, Format = OpenApiConstants.Yaml }, actual.Diagnostic);
         }
 
         [Fact]
@@ -1042,7 +1045,7 @@ paths: {}
             // TODO: Create the object in memory and compare with the one read from YAML file.
 
             Assert.Equivalent(
-                    new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0 }, actual.Diagnostic);
+                    new OpenApiDiagnostic() { SpecificationVersion = OpenApiSpecVersion.OpenApi3_0, Format = OpenApiConstants.Yaml }, actual.Diagnostic);
         }
 
         [Fact]
@@ -1444,9 +1447,10 @@ components:
             };
 
             Assert.Equivalent(
-                new OpenApiDiagnostic 
-                { 
-                    SpecificationVersion = OpenApiSpecVersion.OpenApi3_0
+                new OpenApiDiagnostic
+                {
+                    SpecificationVersion = OpenApiSpecVersion.OpenApi3_0,
+                    Format = OpenApiConstants.Yaml
                 }, result.Diagnostic);
 
             result.Document.Should().BeEquivalentTo(expected, options => options.Excluding(x => x.BaseUri));

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
@@ -231,7 +231,8 @@ get:
             Assert.Equivalent(
                 new OpenApiDiagnostic()
                 {
-                    SpecificationVersion = OpenApiSpecVersion.OpenApi3_0
+                    SpecificationVersion = OpenApiSpecVersion.OpenApi3_0,
+                    Format = OpenApiConstants.Yaml
                 }, result.Diagnostic);
 
             var expectedComponents = new OpenApiComponents
@@ -394,7 +395,8 @@ get:
             Assert.Equivalent(
                 new OpenApiDiagnostic()
                 {
-                    SpecificationVersion = OpenApiSpecVersion.OpenApi3_0
+                    SpecificationVersion = OpenApiSpecVersion.OpenApi3_0,
+                    Format = OpenApiConstants.Yaml
                 }, result.Diagnostic);
 
             var expectedComponents = new OpenApiComponents

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -2007,6 +2007,8 @@ namespace Microsoft.OpenApi.Reader
         public ReadResult() { }
         public Microsoft.OpenApi.Reader.OpenApiDiagnostic? Diagnostic { get; set; }
         public Microsoft.OpenApi.OpenApiDocument? Document { get; set; }
+        public string? Format { get; set; }
         public void Deconstruct(out Microsoft.OpenApi.OpenApiDocument? document, out Microsoft.OpenApi.Reader.OpenApiDiagnostic? diagnostic) { }
+        public void Deconstruct(out Microsoft.OpenApi.OpenApiDocument? document, out Microsoft.OpenApi.Reader.OpenApiDiagnostic? diagnostic, out string? format) { }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -1934,6 +1934,7 @@ namespace Microsoft.OpenApi.Reader
     {
         public OpenApiDiagnostic() { }
         public System.Collections.Generic.IList<Microsoft.OpenApi.OpenApiError> Errors { get; set; }
+        public string? Format { get; set; }
         public Microsoft.OpenApi.OpenApiSpecVersion SpecificationVersion { get; set; }
         public System.Collections.Generic.IList<Microsoft.OpenApi.OpenApiError> Warnings { get; set; }
         public void AppendDiagnostic(Microsoft.OpenApi.Reader.OpenApiDiagnostic diagnosticToAdd, string? fileNameToAdd = null) { }
@@ -2007,8 +2008,6 @@ namespace Microsoft.OpenApi.Reader
         public ReadResult() { }
         public Microsoft.OpenApi.Reader.OpenApiDiagnostic? Diagnostic { get; set; }
         public Microsoft.OpenApi.OpenApiDocument? Document { get; set; }
-        public string? Format { get; set; }
         public void Deconstruct(out Microsoft.OpenApi.OpenApiDocument? document, out Microsoft.OpenApi.Reader.OpenApiDiagnostic? diagnostic) { }
-        public void Deconstruct(out Microsoft.OpenApi.OpenApiDocument? document, out Microsoft.OpenApi.Reader.OpenApiDiagnostic? diagnostic, out string? format) { }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Reader/OpenApiModelFactoryTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Reader/OpenApiModelFactoryTests.cs
@@ -114,7 +114,7 @@ $$$"""
             BaseUrl = baseUri, 
         };
         var readResult = await OpenApiDocument.LoadAsync(stream, settings: settings);
-        Assert.Equal(OpenApiConstants.Json, readResult.Format);
+        Assert.Equal(OpenApiConstants.Json, readResult.Diagnostic.Format);
         Assert.NotNull(readResult.Document);
         Assert.NotNull(readResult.Document.Components);
         Assert.Equal(baseUri, readResult.Document.BaseUri);

--- a/test/Microsoft.OpenApi.Tests/Reader/OpenApiModelFactoryTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Reader/OpenApiModelFactoryTests.cs
@@ -114,6 +114,7 @@ $$$"""
             BaseUrl = baseUri, 
         };
         var readResult = await OpenApiDocument.LoadAsync(stream, settings: settings);
+        Assert.Equal(OpenApiConstants.Json, readResult.Format);
         Assert.NotNull(readResult.Document);
         Assert.NotNull(readResult.Document.Components);
         Assert.Equal(baseUri, readResult.Document.BaseUri);


### PR DESCRIPTION
This pull request is adding the format to the diagnostics.
This is helpful as the library does auto-detection of the format of the document. So any tool using the library to arbitrarily open a json/yaml document, apply a couple of changes, and serialize back, can now maintain the output format.