### PR TITLE
Fix file access for "file" URI scheme

### DIFF
--- a/src/Microsoft.OpenApi/Reader/Services/DefaultStreamLoader.cs
+++ b/src/Microsoft.OpenApi/Reader/Services/DefaultStreamLoader.cs
@@ -36,7 +36,7 @@ namespace Microsoft.OpenApi.Reader
 
             return absoluteUri.Scheme switch
             {
-                "file" => File.OpenRead(absoluteUri.AbsolutePath),
+                "file" => File.OpenRead(absoluteUri.LocalPath),
                 "http" or "https" =>
 #if NET5_0_OR_GREATER
                     await _httpClient.GetStreamAsync(absoluteUri, cancellationToken).ConfigureAwait(false),


### PR DESCRIPTION
fix: Allow files with spaces in path to work

Updated the file access method to use `absoluteUri.LocalPath` instead of `absoluteUri.AbsolutePath` when the URI scheme is "file". This change ensures correct file opening for local files when there are escaped characters in the path such as spaces.

