### PR TITLE
Fix OpenApiEncoding explode property serialization (to main)

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiEncoding.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiEncoding.cs
@@ -12,6 +12,10 @@ namespace Microsoft.OpenApi
     public class OpenApiEncoding : IOpenApiSerializable, IOpenApiExtensible
     {
         /// <summary>
+        /// Explode backing variable
+        /// </summary>
+        private bool? _explode;
+        /// <summary>
         /// The Content-Type for encoding a specific property.
         /// The value can be a specific media type (e.g. application/json),
         /// a wildcard media type (e.g. image/*), or a comma-separated list of the two types.
@@ -35,7 +39,11 @@ namespace Microsoft.OpenApi
         /// For all other styles, the default value is false.
         /// This property SHALL be ignored if the request body media type is not application/x-www-form-urlencoded.
         /// </summary>
-        public bool? Explode { get; set; }
+        public bool? Explode
+        {
+            get => _explode ?? Style == ParameterStyle.Form;
+            set => _explode = value;
+        }
 
         /// <summary>
         /// Determines whether the parameter value SHOULD allow reserved characters,
@@ -63,7 +71,7 @@ namespace Microsoft.OpenApi
             ContentType = encoding?.ContentType ?? ContentType;
             Headers = encoding?.Headers != null ? new Dictionary<string, IOpenApiHeader>(encoding.Headers) : null;
             Style = encoding?.Style ?? Style;
-            Explode = encoding?.Explode ?? Explode;
+            Explode = encoding?._explode;
             AllowReserved = encoding?.AllowReserved ?? AllowReserved;
             Extensions = encoding?.Extensions != null ? new Dictionary<string, IOpenApiExtension>(encoding.Extensions) : null;
         }
@@ -106,7 +114,10 @@ namespace Microsoft.OpenApi
             writer.WriteProperty(OpenApiConstants.Style, Style?.GetDisplayName());
 
             // explode
-            writer.WriteProperty(OpenApiConstants.Explode, Explode, false);
+            if (_explode.HasValue)
+            {
+                writer.WriteProperty(OpenApiConstants.Explode, Explode);
+            }
 
             // allowReserved
             writer.WriteProperty(OpenApiConstants.AllowReserved, AllowReserved, false);

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiEncodingTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiEncodingTests.cs
@@ -76,5 +76,55 @@ namespace Microsoft.OpenApi.Tests.Models
             expected = expected.MakeLineBreaksEnvironmentNeutral();
             Assert.Equal(expected, actual);
         }
+
+        [Theory]
+        [InlineData(ParameterStyle.Form, true)]
+        [InlineData(ParameterStyle.SpaceDelimited, false)]
+        [InlineData(null, false)]
+        public void WhenStyleIsFormTheDefaultValueOfExplodeShouldBeTrueOtherwiseFalse(ParameterStyle? style, bool expectedExplode)
+        {
+            // Arrange
+            var parameter = new OpenApiEncoding
+            {
+                Style = style
+            };
+
+            // Act & Assert
+            parameter.Explode.Should().Be(expectedExplode);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        [InlineData(null, false)]
+        public void WhenExplodeIsSetOutputShouldHaveExplode(bool? expectedExplode, bool hasExplode)
+        {
+            // Arrange
+            OpenApiEncoding parameter = new()
+            {
+                ContentType = "multipart/form-data",
+                Style = ParameterStyle.Form,
+                Explode = expectedExplode,
+            };
+
+            var expected =
+                $"""
+                contentType: multipart/form-data
+                style: form
+                """;
+
+            if (hasExplode)
+            {
+                expected = expected + $"\nexplode: {expectedExplode.ToString().ToLower()}";
+            }
+
+            // Act
+            var actual = parameter.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_0);
+
+            // Assert
+            actual = actual.MakeLineBreaksEnvironmentNeutral();
+            expected = expected.MakeLineBreaksEnvironmentNeutral();
+            actual.Should().Be(expected);
+        }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiEncodingTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiEncodingTests.cs
@@ -90,14 +90,14 @@ namespace Microsoft.OpenApi.Tests.Models
             };
 
             // Act & Assert
-            parameter.Explode.Should().Be(expectedExplode);
+            Assert.Equal(parameter.Explode, expectedExplode);
         }
 
         [Theory]
         [InlineData(true, true)]
         [InlineData(false, true)]
         [InlineData(null, false)]
-        public void WhenExplodeIsSetOutputShouldHaveExplode(bool? expectedExplode, bool hasExplode)
+        public async Task WhenExplodeIsSetOutputShouldHaveExplode(bool? expectedExplode, bool hasExplode)
         {
             // Arrange
             OpenApiEncoding parameter = new()
@@ -119,12 +119,12 @@ namespace Microsoft.OpenApi.Tests.Models
             }
 
             // Act
-            var actual = parameter.SerializeAsYaml(OpenApiSpecVersion.OpenApi3_0);
+            var actual = await parameter.SerializeAsYamlAsync(OpenApiSpecVersion.OpenApi3_0);
 
             // Assert
             actual = actual.MakeLineBreaksEnvironmentNeutral();
             expected = expected.MakeLineBreaksEnvironmentNeutral();
-            actual.Should().Be(expected);
+            Assert.Equal(actual, expected);
         }
     }
 }


### PR DESCRIPTION
Fix: Explode serialization is wrong when style is "form"

This fixes the same problem as https://github.com/microsoft/OpenAPI.NET/pull/544 but for OpenApiEncoding.
The spec describes different behavior depending on if it is set or not (see: https://spec.openapis.org/oas/v3.1.0.html#fixed-fields-12) and also different defaults depending on the style value.

Cherry pick for https://github.com/microsoft/OpenAPI.NET/pull/2508 to the main branch

I don't have dotnet 10 installed yet so I hope this works without it.