### PR TITLE
Enhance server creation logic and add unit tests

### DIFF
--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs
@@ -145,8 +145,8 @@ namespace Microsoft.OpenApi.Readers.V2
                 basePath = "/";
             }
 
-            // If nothing is provided, don't create a server
-            if (host == null && basePath == null && schemes == null)
+            // If nothing is provided and there's no defaultUrl, don't create a server
+            if (host == null && basePath == null && schemes == null && defaultUrl == null)
             {
                 return;
             }
@@ -161,7 +161,7 @@ namespace Microsoft.OpenApi.Readers.V2
             // Fill in missing information based on the defaultUrl
             if (defaultUrl != null)
             {
-                host = host ?? defaultUrl.GetComponents(UriComponents.NormalizedHost, UriFormat.SafeUnescaped);
+                host = host ?? defaultUrl.GetComponents(UriComponents.Host | UriComponents.Port, UriFormat.SafeUnescaped);
                 basePath = basePath ?? defaultUrl.GetComponents(UriComponents.Path, UriFormat.SafeUnescaped);
                 schemes = schemes ?? new List<string> { defaultUrl.GetComponents(UriComponents.Scheme, UriFormat.SafeUnescaped) };
             }

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiServerTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiServerTests.cs
@@ -323,5 +323,74 @@ namespace Microsoft.OpenApi.Readers.Tests.V2Tests
                     SpecificationVersion = OpenApiSpecVersion.OpenApi2_0
                 });
         }
+
+        [Fact]
+        public void BaseUrlWithPortShouldPreservePort()
+        {
+            var input =
+                """
+                swagger: 2.0
+                info:
+                  title: test
+                  version: 1.0.0
+                paths: {}
+                """;
+            var reader = new OpenApiStringReader(new()
+            {
+                BaseUrl = new("http://demo.testfire.net:8080")
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
+            var server = doc.Servers.First();
+            Assert.Single(doc.Servers);
+            Assert.Equal("http://demo.testfire.net:8080", server.Url);
+        }
+
+        [Fact]
+        public void BaseUrlWithPortAndPathShouldPreservePort()
+        {
+            var input =
+                """
+                swagger: 2.0
+                info:
+                  title: test
+                  version: 1.0.0
+                paths: {}
+                """;
+            var reader = new OpenApiStringReader(new()
+            {
+                BaseUrl = new("http://demo.testfire.net:8080/swagger/properties.json")
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
+            var server = doc.Servers.First();
+            Assert.Single(doc.Servers);
+            Assert.Equal("http://demo.testfire.net:8080/swagger/properties.json", server.Url);
+        }
+
+        [Fact]
+        public void BaseUrlWithNonStandardPortShouldPreservePort()
+        {
+            var input =
+                """
+                swagger: 2.0
+                info:
+                  title: test
+                  version: 1.0.0
+                paths: {}
+                """;
+            var reader = new OpenApiStringReader(new()
+            {
+                BaseUrl = new("https://api.example.com:9443/v1/openapi.yaml")
+            });
+
+            var doc = reader.Read(input, out var diagnostic);
+
+            var server = doc.Servers.First();
+            Assert.Single(doc.Servers);
+            Assert.Equal("https://api.example.com:9443/v1/openapi.yaml", server.Url);
+        }
     }
 }


### PR DESCRIPTION


 Fix port omission from BaseUrl in V2 server deserialization

 Problem
When setting a `BaseUrl` with a non-standard port and the OpenAPI V2 document doesn't contain any server definitions, the port number was being omitted from the default server URL.

Example:
- Input: `BaseUrl = "http://demo.testfire.net:8080"`
- Current behavior: Server URL = `"http://demo.testfire.net"` ❌
- Expected behavior: Server URL = `"http://demo.testfire.net:8080"` ✅

 Root Cause
The `MakeServers` method in `OpenApiDocumentDeserializer.cs` was using `UriComponents.NormalizedHost` which only extracts the hostname without the port number.

 Solution
Changed `UriComponents.NormalizedHost` to `UriComponents.Host | UriComponents.Port` to preserve port information when extracting host details from the BaseUrl. This approach is consistent with the existing pattern used in `OpenApiDocument.WriteHostInfoV2`.

Additionally, fixed the early return logic to allow server creation from BaseUrl even when no host, basePath, or schemes are defined in the document.

 Changes
1. **`src/Microsoft.OpenApi.Readers/V2/OpenApiDocumentDeserializer.cs`**:
   - Line 154: Changed from `UriComponents.NormalizedHost` to `UriComponents.Host | UriComponents.Port`
   - Line 144: Modified early return condition to check for `defaultUrl != null`

2. **`test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiServerTests.cs`**:
   - Added 3 new test cases to verify port preservation in various scenarios

 Testing
- All existing tests pass ✅
- Added comprehensive test coverage for port preservation scenarios
- 16/16 OpenApiServerTests passing
- 78/78 V2Tests passing

Fixes #1294