### PR TITLE
ci: fixes target branch definition to support multiple releases automatically

### DIFF
--- a/.github/workflows/release-please-gha.yml
+++ b/.github/workflows/release-please-gha.yml
@@ -35,3 +35,4 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
The auto-release detection on support/v1 has not been working as expected forcing me to create those releases manually.
https://github.com/microsoft/OpenAPI.NET/actions/runs/18290786080/job/52077236107

This is time consuming, and not my primary responsibility.
This PR aims to dynamically set the target branch based off the trigger to patch for the failing automatic branch detection