### PR TITLE
fix: a bug where null sentinel value would appear in YAML documents

### DIFF
--- a/src/Microsoft.OpenApi.YamlReader/YamlConverter.cs
+++ b/src/Microsoft.OpenApi.YamlReader/YamlConverter.cs
@@ -63,6 +63,10 @@ namespace Microsoft.OpenApi.YamlReader
             {
                 JsonObject obj => obj.ToYamlMapping(),
                 JsonArray arr => arr.ToYamlSequence(),
+                JsonValue nullVal when JsonNullSentinel.IsJsonNullSentinel(nullVal) => new YamlScalarNode("null")
+                {
+                    Style = ScalarStyle.Plain
+                },
                 JsonValue val => val.ToYamlScalar(),
                 _ => throw new NotSupportedException("This isn't a supported JsonNode")
             };

--- a/test/Microsoft.OpenApi.Readers.Tests/YamlConverterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/YamlConverterTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.OpenApi.YamlReader;
 using SharpYaml;
 using SharpYaml.Serialization;
+using System;
 using System.IO;
 using System.Text.Json.Nodes;
 using Xunit;
@@ -302,9 +303,17 @@ public class YamlConverterTests
         var jsonNode = ConvertYamlStringToJsonNode(yamlInput);
         var convertedBack = jsonNode.ToYamlNode();
         var convertedBackOutput = ConvertYamlNodeToString(convertedBack);
-    
+
         // Then
         Assert.Equal(yamlInput.MakeLineBreaksEnvironmentNeutral(), convertedBackOutput.MakeLineBreaksEnvironmentNeutral());
+    }
+    [Fact]
+    public void ItDoesNotSerializeTheSentinelValue()
+    {
+        var yamlValue = JsonNullSentinel.JsonNull.ToYamlNode();
+
+        var scalarNode = Assert.IsType<YamlScalarNode>(yamlValue);
+        Assert.Equal("null", scalarNode.Value, StringComparer.OrdinalIgnoreCase);
     }
 
     private static JsonNode ConvertYamlStringToJsonNode(string yamlInput)


### PR DESCRIPTION
Signed-off-by: Vincent Biret <vibiret@microsoft.com>
