### PR TITLE
Add `type: "null"` downcasting when in oneOf and anyOf for OpenAPI v3

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -884,15 +884,7 @@ namespace Microsoft.OpenApi
                     commonType |= schema.Type.GetValueOrDefault() & ~JsonSchemaType.Null;
                 }
 
-                if (HasMultipleTypes(commonType) || commonType == 0)
-                {
-                    return (nonNullSchemas, null, true);
-                }
-                else
-                {
-                    // Single common type
-                    return (nonNullSchemas, commonType, true);
-                }
+                return (nonNullSchemas, commonType, true);
             }
             else
             {

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -844,7 +844,7 @@ namespace Microsoft.OpenApi.Tests.Models
                 {
                     new OpenApiSchema { Type = JsonSchemaType.Null },
                     new OpenApiSchema { Type = JsonSchemaType.String },
-                    new OpenApiSchema { Type = JsonSchemaType.Number }
+                    new OpenApiSchema { Type = JsonSchemaType.Number },
                 }
             };
 


### PR DESCRIPTION
# Add `type: "null"` downcasting when in oneOf and anyOf for OpenAPI v3

## Description
This PR adds downcasting of oneOf and anyOf for openapi v3.

When writing OpenAPI v3 it will remove schemas from oneOf and anyOf with `{ "type": "null" }` and apply it to the parent as `nullable: true`. It also tries to find a common overlapping `type` which will also be applied to the parent schema as `nullable: true` is only doing something when `type` is specified.

It's between a bug-fix and a feature as the current situation downcasts `{ "type": "null" }` to `{ "nullable": true }` which according to some clarifications of the spec doesn't do anything and tools expect the `nullable: true` on the parent schema.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issue(s)

- https://github.com/microsoft/OpenAPI.NET/issues/2629
- https://github.com/dotnet/aspnetcore/issues/64648


## Changes Made
- Add detection and processing of compositions where there could be a `type: null` for OpenAPI v3.
- Apply either the type of the schema or the inferred type on the schema, a possible explicit type is not overwritten.
- When multiple possible types are detected it will omit the inferred type.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Versions applicability

- [ ] My change applies to the version 1.X of the library, if so PR link:
- [x] My change applies to the version 2.X of the library, if so PR link:
- [ ] My change applies to the version 3.X of the library, if so PR link:
- [ ] I have evaluated the applicability of my change against the other versions above.
