### PR TITLE
fix(schema): always serialize `additionalProperties: false`

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -489,9 +489,8 @@ namespace Microsoft.OpenApi
                     AdditionalProperties,
                     callback);
             }
-            // true is the default in earlier versions 3, no need to write it out
-            // boolean value is only supported for version 3 and earlier (version 2 is implemented in the other serialize method, the condition is a failsafe)
-            else if (!AdditionalPropertiesAllowed && version <= OpenApiSpecVersion.OpenApi3_0)
+            // true is the default, no need to write it out
+            else if (!AdditionalPropertiesAllowed)
             {
                 writer.WriteProperty(OpenApiConstants.AdditionalProperties, AdditionalPropertiesAllowed);
             }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -754,8 +754,10 @@ namespace Microsoft.OpenApi.Tests.Models
             Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(actual)));
         }
 
-        [Fact]
-        public async Task SerializeAdditionalPropertiesAllowedAsV3FalseEmits()
+        [Theory]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi3_1)]
+        public async Task SerializeAdditionalPropertiesAllowedAsV3PlusFalseEmits(OpenApiSpecVersion version)
         {
             var expected = @"{ ""additionalProperties"": false }";
             // Given
@@ -765,7 +767,7 @@ namespace Microsoft.OpenApi.Tests.Models
             };
 
             // When
-            var actual = await schema.SerializeAsJsonAsync(OpenApiSpecVersion.OpenApi3_0);
+            var actual = await schema.SerializeAsJsonAsync(version);
 
             // Then
             Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(actual)));


### PR DESCRIPTION
# Pull Request

## Description
Ensures consistent schema output across OpenAPI versions when `AdditionalPropertiesAllowed` is false.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issue(s)
Fixes #2646

## Changes Made
- Updates serialization logic to emit `additionalProperties: false` for all OpenAPI versions when `AdditionalPropertiesAllowed` is false.
- Refactors related test to a theory and verifies behavior for both OpenAPI 3.0 and 3.1.

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [X] All existing tests pass

## Checklist
- [X] My code follows the code style of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Versions applicability

- [ ] My change applies to the version 1.X of the library, if so PR link:
- [X] My change applies to the version 2.X of the library, if so PR link:
- [ ] My change applies to the version 3.X of the library, if so PR link:
- [ ] I have evaluated the applicability of my change against the other versions above.

See [the contributing guidelines](https://github.com/microsoft/OpenAPI.NET/blob/main/CONTRIBUTING.md) for more information about how patches are applied across multiple versions.

## Additional Notes