### PR TITLE
chore: adds 3.2 version to the workbench chore: sets 3.2 as default version for the workbench

### DIFF
--- a/src/Microsoft.OpenApi.Workbench/MainModel.cs
+++ b/src/Microsoft.OpenApi.Workbench/MainModel.cs
@@ -42,7 +42,7 @@ namespace Microsoft.OpenApi.Workbench
         /// <summary>
         /// Default version.
         /// </summary>
-        private OpenApiSpecVersion _version = OpenApiSpecVersion.OpenApi3_0;
+        private OpenApiSpecVersion _version = OpenApiSpecVersion.OpenApi3_2;
 
         private static readonly HttpClient _httpClient = new();
 

--- a/src/Microsoft.OpenApi.Workbench/MainWindow.xaml
+++ b/src/Microsoft.OpenApi.Workbench/MainWindow.xaml
@@ -40,8 +40,9 @@
                     </StackPanel>
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                         <Label>Version:</Label>
-                        <RadioButton GroupName="Format" Content="V3.1.1" Padding="5" Height="24" VerticalAlignment="Top" IsChecked="{Binding IsV3_1}" />
-                        <RadioButton GroupName="Format" Content="V3.0.4" Padding="5" Height="24" VerticalAlignment="Top" IsChecked="{Binding IsV3_0}" />
+                        <RadioButton GroupName="Format" Content="V3.2" Padding="5" Height="24" VerticalAlignment="Top" IsChecked="{Binding IsV3_2}" />
+                        <RadioButton GroupName="Format" Content="V3.1" Padding="5" Height="24" VerticalAlignment="Top" IsChecked="{Binding IsV3_1}" />
+                        <RadioButton GroupName="Format" Content="V3.0" Padding="5" Height="24" VerticalAlignment="Top" IsChecked="{Binding IsV3_0}" />
                         <RadioButton GroupName="Format" Content="V2.0" Padding="5" Height="24" VerticalAlignment="Top" IsChecked="{Binding IsV2_0}" />
                     </StackPanel>
                     <CheckBox Name="InlineLocal" Content="Inline Local" IsChecked="{Binding InlineLocal}" />


### PR DESCRIPTION
Signed-off-by: Vincent Biret <vibiret@microsoft.com>
