### PR TITLE
fix: Support custom tag ordering

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+#if NET
+using System.Collections.Immutable;
+#endif
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -83,9 +86,15 @@ namespace Microsoft.OpenApi
                 {
                     return;
                 }
-                _tags = value is HashSet<OpenApiTag> tags && tags.Comparer is OpenApiTagComparer ?
-                        tags :
-                        new HashSet<OpenApiTag>(value, OpenApiTagComparer.Instance);
+                _tags = value switch
+                {
+                    HashSet<OpenApiTag> tags when tags.Comparer != EqualityComparer<OpenApiTag>.Default => value,
+                    SortedSet<OpenApiTag> => value,
+#if NET
+                    ImmutableSortedSet<OpenApiTag> => value,
+#endif
+                    _ => new HashSet<OpenApiTag>(value, OpenApiTagComparer.Instance),
+                };
             }
         }
 


### PR DESCRIPTION
# Pull Request

## Description
Makes `OpenApiDocument.Tags` preserve the provided set when it is a `HashSet` with custom comparer, a `SortedSet`, or an `ImmutableSortedSet` (not available when targeting netstandard2.0). Previously, the setter would make a copy of the set using an internal comparer.

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issue(s)
Fixes #2678

## Changes Made
- Update the `OpenApiDocument.Tags` setter to preserve sets with a custom comparer and sorted sets

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [X] All existing tests pass

## Checklist
- [X] My code follows the code style of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Versions applicability

- [ ] My change applies to the version 1.X of the library, if so PR link:
- [X] My change applies to the version 2.X of the library, if so PR link:
- [X] My change applies to the version 3.X of the library, if so PR link:
- [X] I have evaluated the applicability of my change against the other versions above.

See [the contributing guidelines](https://github.com/microsoft/OpenAPI.NET/blob/main/CONTRIBUTING.md) for more information about how patches are applied across multiple versions.

## Additional Notes
This PR targets support/v2 per the comments in the related issue. Let me know if I should rebase onto main instead.