### PR TITLE
fix: discriminator property validation fails any/allOf cases when it shouldn't

### DIFF
--- a/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
+++ b/test/Microsoft.OpenApi.Tests/PublicApi/PublicApi.approved.txt
@@ -1261,7 +1261,11 @@ namespace Microsoft.OpenApi
     {
         public static Microsoft.OpenApi.ValidationRule<Microsoft.OpenApi.IOpenApiSchema> ValidateSchemaDiscriminator { get; }
         public static Microsoft.OpenApi.ValidationRule<Microsoft.OpenApi.IOpenApiSchema> ValidateSchemaPropertyHasValue { get; }
+        [System.ComponentModel.Browsable(false)]
+        [System.Obsolete("This method will be made private in future versions.")]
         public static bool TraverseSchemaElements(string discriminatorName, System.Collections.Generic.IList<Microsoft.OpenApi.IOpenApiSchema>? childSchema) { }
+        [System.ComponentModel.Browsable(false)]
+        [System.Obsolete("This method will be made private in future versions.")]
         public static bool ValidateChildSchemaAgainstDiscriminator(Microsoft.OpenApi.IOpenApiSchema schema, string? discriminatorName) { }
     }
     public class OpenApiSecurityRequirement : System.Collections.Generic.Dictionary<Microsoft.OpenApi.OpenApiSecuritySchemeReference, System.Collections.Generic.List<string>>, Microsoft.OpenApi.IOpenApiElement, Microsoft.OpenApi.IOpenApiSerializable

--- a/test/Microsoft.OpenApi.Tests/Validations/OpenApiSchemaValidationTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Validations/OpenApiSchemaValidationTests.cs
@@ -246,7 +246,7 @@ namespace Microsoft.OpenApi.Validations.Tests
         }
 
         [Fact]
-        public void ValidateOneOfSchemaPropertyNameContainsPropertySpecifiedInTheDiscriminator()
+        public void ValidateOneOfSchemaPropertyNameContainsPropertySpecifiedInTheDiscriminatorOneOf()
         {
             // Arrange
             var components = new OpenApiComponents
@@ -263,6 +263,103 @@ namespace Microsoft.OpenApi.Validations.Tests
                                 PropertyName = "type"
                             },
                             OneOf =
+                            [
+                                new OpenApiSchema()
+                                {
+                                    Properties = new Dictionary<string, IOpenApiSchema>
+                                    {
+                                        {
+                                            "type",
+                                            new OpenApiSchema
+                                            {
+                                                Type = JsonSchemaType.Array
+                                            }
+                                        }
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                }
+            };
+
+            // Act
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
+            var walker = new OpenApiWalker(validator);
+            walker.Walk(components);
+
+            var errors = validator.Errors;
+
+            //Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void ValidateOneOfSchemaPropertyNameContainsPropertySpecifiedInTheDiscriminatorAnyOf()
+        {
+            // Arrange
+            var components = new OpenApiComponents
+            {
+                Schemas = new Dictionary<string, IOpenApiSchema>
+                {
+                    {
+                        "Person",
+                        new OpenApiSchema
+                        {
+                            Type = JsonSchemaType.Array,
+                            Discriminator = new()
+                            {
+                                PropertyName = "type"
+                            },
+                            AnyOf =
+                            [
+                                new OpenApiSchema()
+                                {
+                                    Properties = new Dictionary<string, IOpenApiSchema>
+                                    {
+                                        {
+                                            "type",
+                                            new OpenApiSchema
+                                            {
+                                                Type = JsonSchemaType.Array
+                                            }
+                                        }
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                }
+            };
+
+            // Act
+            var validator = new OpenApiValidator(ValidationRuleSet.GetDefaultRuleSet());
+            var walker = new OpenApiWalker(validator);
+            walker.Walk(components);
+
+            var errors = validator.Errors;
+
+            //Assert
+            Assert.Empty(errors);
+        }
+        [Fact]
+        public void ValidateOneOfSchemaPropertyNameContainsPropertySpecifiedInTheDiscriminatorAllOf()
+        {
+            // Arrange
+            var components = new OpenApiComponents
+            {
+                Schemas = new Dictionary<string, IOpenApiSchema>
+                {
+                    {
+                        "Person",
+                        new OpenApiSchema
+                        {
+                            Type = JsonSchemaType.Array,
+                            Discriminator = new()
+                            {
+                                PropertyName = "type"
+                            },
+                            AllOf =
                             [
                                 new OpenApiSchema()
                                 {


### PR DESCRIPTION
fixes a bug where discriminator properties validation would fail for any/all of when it shouldn't