### PR TITLE
fix(models): reject RFC 6570 operators for <3.2

### DIFF
--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiPathsTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiPathsTests.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.IO;
+using Xunit;
+
+namespace Microsoft.OpenApi.Tests.Models
+{
+    [Collection("DefaultSettings")]
+    public class OpenApiPathsTests
+    {
+        [Fact]
+        public void SerializePaths_WithRfc6570Operator_BelowV32_Throws()
+        {
+            var paths = new OpenApiPaths
+            {
+                ["/files/{+path}"] = new OpenApiPathItem()
+            };
+
+            var writer = new OpenApiJsonWriter(new StringWriter());
+
+            Assert.Throws<OpenApiException>(() => paths.SerializeAsV3(writer));
+            Assert.Throws<OpenApiException>(() => paths.SerializeAsV31(writer));
+            Assert.Throws<OpenApiException>(() => paths.SerializeAsV2(writer));
+        }
+
+        [Fact]
+        public void SerializePaths_WithExplodeOperator_BelowV32_Throws()
+        {
+            var paths = new OpenApiPaths
+            {
+                ["/files/{path*}"] = new OpenApiPathItem()
+            };
+
+            var writer = new OpenApiJsonWriter(new StringWriter());
+
+            Assert.Throws<OpenApiException>(() => paths.SerializeAsV3(writer));
+            Assert.Throws<OpenApiException>(() => paths.SerializeAsV31(writer));
+            Assert.Throws<OpenApiException>(() => paths.SerializeAsV2(writer));
+        }
+
+        [Fact]
+        public void SerializePaths_WithRfc6570Operator_V32_Succeeds()
+        {
+            var paths = new OpenApiPaths
+            {
+                ["/files/{+path}"] = new OpenApiPathItem()
+            };
+
+            var writer = new OpenApiJsonWriter(new StringWriter());
+
+            paths.SerializeAsV32(writer);
+        }
+
+        [Fact]
+        public void SerializePaths_WithoutOperators_BelowV32_Succeeds()
+        {
+            var paths = new OpenApiPaths
+            {
+                ["/files/{path}"] = new OpenApiPathItem()
+            };
+
+            var writer = new OpenApiJsonWriter(new StringWriter());
+
+            paths.SerializeAsV3(writer);
+            paths.SerializeAsV31(writer);
+            paths.SerializeAsV2(writer);
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
Reject RFC 6570 URI template operators (e.g. `{+path}`, `{path*}`, `{?q}`) in path keys when serializing OpenAPI <= 3.1. These operators are only valid starting in OpenAPI 3.2.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issue(s)
Fixes #2704

## Changes Made
- Throw `OpenApiException` if an `OpenApiPaths` key contains RFC 6570 operators when targeting OpenAPI 2.0/3.0/3.1.
- Add unit tests for operator paths (`{+var}`, `{var*}`) and a non-operator control case.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

Ran:
- `dotnet test test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj --filter FullyQualifiedName~Microsoft.OpenApi.Tests.Models.OpenApiPathsTests`

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Versions applicability

- [ ] My change applies to the version 1.X of the library, if so PR link:
- [ ] My change applies to the version 2.X of the library, if so PR link:
- [x] My change applies to the version 3.X of the library, if so PR link:
- [x] I have evaluated the applicability of my change against the other versions above.

## Additional Notes
None.
