### PR TITLE
fix(hidi): update Microsoft.OpenApi.OData to 3.2.1

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -39,7 +39,7 @@
     </PackageReference>
     <PackageReference Include="System.CommandLine" Version="2.0.5" />
     <PackageReference Include="Microsoft.OData.Edm" Version="8.4.3" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="3.2.0" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="3.2.1" />
     <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="3.0.0-preview.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.25306.1" />
   </ItemGroup>


### PR DESCRIPTION
Fixes CSDL to OpenAPI conversion issue with binding functions to multiple types in an inheritance tree.

Updates Microsoft.OpenApi.OData from 3.2.0 to 3.2.1.

Closes #2811
Parent issue: #2810