### PR TITLE
fix(hidi): update Microsoft.OpenApi.OData to 2.2.1

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -39,7 +39,7 @@
     </PackageReference>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="8.4.3" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="2.0.0" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="2.2.1" />
     <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="2.0.0-preview5" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.25306.1" />
   </ItemGroup>


### PR DESCRIPTION
Fixes CSDL to OpenAPI conversion issue with binding functions to multiple types in an inheritance tree.

Updates Microsoft.OpenApi.OData from 2.0.0 to 2.2.1.

Closes #2812
Parent issue: #2810