### PR TITLE
fix(hidi): update Microsoft.OpenApi.OData to 1.7.6

### DIFF
--- a/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
+++ b/src/Microsoft.OpenApi.Hidi/Microsoft.OpenApi.Hidi.csproj
@@ -40,7 +40,7 @@
     <!-- maintaining edm on 7.X because yoko 1.X is on 7.X-->
     <PackageReference Include="Microsoft.OData.Edm" Version="7.21.6" />
     <!-- maintaining yoko to 1.X because 2.X uses oai.net 2.X -->
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.7.5" />
+    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.7.6" />
     <!-- maintaining api manifest to 0.5.6 because it's the last version with OAI.net 1.X-->
     <PackageReference Include="Microsoft.OpenApi.ApiManifest" Version="0.5.6-preview" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />


### PR DESCRIPTION
Fixes CSDL to OpenAPI conversion issue with binding functions to multiple types in an inheritance tree.

Updates Microsoft.OpenApi.OData from 1.7.5 to 1.7.6.

Closes #2813
Parent issue: #2810