### PR TITLE
fix(library): avoid false circular refs for external schema re-exports

### DIFF
--- a/src/Microsoft.OpenApi/Services/OpenApiWorkspace.cs
+++ b/src/Microsoft.OpenApi/Services/OpenApiWorkspace.cs
@@ -94,8 +94,13 @@ namespace Microsoft.OpenApi
                 foreach (var item in document.Components.Schemas)
                 {
                     if (item.Value == null) continue;
-                    location = item.Value.Id ?? baseUri + ReferenceType.Schema.GetDisplayName() + ComponentSegmentSeparator + item.Key;
+                    location = baseUri + ReferenceType.Schema.GetDisplayName() + ComponentSegmentSeparator + item.Key;
                     RegisterComponent(location, item.Value);
+
+                    if (item.Value is not OpenApiSchemaReference && item.Value.Id is string schemaId && schemaId.Length > 0)
+                    {
+                        RegisterComponent(schemaId, item.Value);
+                    }
                 }
             }
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/RelativeReferenceTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/RelativeReferenceTests.cs
@@ -204,6 +204,75 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
         }
 
         [Fact]
+        public async Task ParseExternalSchemaReferencedDirectlyAndReExportedAtRootWorks()
+        {
+            var tempDirectory = Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDirectory);
+
+            var rootPath = Path.Join(tempDirectory, "root.yaml");
+            var sharedPath = Path.Join(tempDirectory, "shared.yaml");
+
+            await File.WriteAllTextAsync(rootPath,
+            @"openapi: 3.1.0
+info:
+  title: T
+  version: 1.0.0
+paths:
+  /a:
+    get:
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  meta:
+                    $ref: './shared.yaml#/Leaf'
+components:
+  schemas:
+    Leaf:
+      $ref: './shared.yaml#/Leaf'
+");
+
+            await File.WriteAllTextAsync(sharedPath,
+            @"Leaf:
+  type: object
+  properties:
+    x:
+      type: string
+    y:
+      type: integer
+");
+
+            try
+            {
+                var settings = new OpenApiReaderSettings
+                {
+                    LoadExternalRefs = true,
+                    BaseUrl = new Uri(rootPath),
+                };
+                settings.AddYamlReader();
+
+                var result = await OpenApiDocument.LoadAsync(rootPath, settings);
+                var responseSchema = result.Document.Paths["/a"].Operations[HttpMethod.Get].Responses["200"].Content["application/json"].Schema;
+                var metaSchema = responseSchema.Properties["meta"];
+                var leafSchema = result.Document.Components.Schemas["Leaf"];
+
+                Assert.NotNull(result.Document);
+                Assert.DoesNotContain(result.Diagnostic.Errors, error => error.Message.Contains("Circular reference detected while resolving schema", StringComparison.Ordinal));
+                Assert.DoesNotContain(result.Diagnostic.Warnings, warning => warning.Message.Contains("Circular reference detected while resolving schema", StringComparison.Ordinal));
+                Assert.IsType<OpenApiSchemaReference>(metaSchema);
+                Assert.IsType<OpenApiSchemaReference>(leafSchema);
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+        }
+
+        [Fact]
         public void ResolveSubSchema_ShouldTraverseKnownKeywords()
         {
             var schema = new OpenApiSchema


### PR DESCRIPTION
## Summary
- stop `OpenApiWorkspace.RegisterComponents` from dereferencing schema refs while registering component aliases
- keep `$id`-based registration for concrete schemas so canonical identifier lookups still work
- add a regression test for the split-file OpenAPI 3.1 re-export scenario from #2872

## Why
Fixes #2872.

The faulty behavior was introduced by #1826, which added the `item.Value.Id ?? ...` fallback in schema registration to support identifier-based resolution. That was correct for concrete schemas, but it is unsafe for `OpenApiSchemaReference` because accessing `Id` resolves the external target eagerly during workspace registration.

## JSON Schema reference-resolution implications
Under JSON Schema 2020-12, a JSON Pointer can still address a lexical location within the containing document, but `$id` defines the canonical URI of a schema resource. For this code path, component registration should therefore:
- always register the component-key alias for schema references
- only register `$id` aliases for concrete schemas that already own that canonical identifier
- avoid dereferencing references during registration, because registration is establishing lookup keys, not traversing schema resources