### PR TITLE
Don't silently skip null assignment to OpenApiDocument.Tags

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -89,6 +89,7 @@ namespace Microsoft.OpenApi
             {
                 if (value is null)
                 {
+                    _tags = null;
                     return;
                 }
                 _tags = value switch

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
@@ -2145,6 +2145,17 @@ components:
             Assert.Equal(2, document.Tags.Count);
         }
 
+        [Fact]
+        public void TagsCanBeReInitializedToNull()
+        {
+            var document = new OpenApiDocument();
+            Assert.Null(document.Tags);
+            document.Tags = new HashSet<OpenApiTag>();
+            Assert.NotNull(document.Tags);
+            document.Tags = null;
+            Assert.Null(document.Tags);
+        }
+
         private sealed class CaseInsensitiveOpenApiTagEqualityComparer : IEqualityComparer<OpenApiTag>
         {
             public bool Equals(OpenApiTag x, OpenApiTag y)


### PR DESCRIPTION
# Don't silently skip null assignment to OpenApiDocument.Tags

## Description

Currently, assigning null to the Tags property will silently be skipped. This regression from https://github.com/microsoft/OpenAPI.NET/commit/93c468ebd9ee30b0cb32a583821d8abe3d017b18

The property is updated so that it doesn't silently return without doing the assignment.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Related Issue(s)
<!-- Link to any related issues using "Fixes #123" or "Closes #123" -->

## Changes Made
<!-- List the main changes made in this PR -->
-
-
-

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

## Checklist
<!-- Mark completed items with an "x" -->
- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Versions applicability

- [ ] My change applies to the version 1.X of the library, if so PR link:
- [ ] My change applies to the version 2.X of the library, if so PR link:
- [ ] My change applies to the version 3.X of the library, if so PR link:
- [ ] I have evaluated the applicability of my change against the other versions above.

See [the contributing guidelines](https://github.com/microsoft/OpenAPI.NET/blob/main/CONTRIBUTING.md) for more information about how patches are applied across multiple versions.

## Additional Notes
<!-- Add any additional information that reviewers should know -->