### PR TITLE
fix: Don't silently skip null assignment to OpenApiDocument.Tags

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiDocument.cs
@@ -84,6 +84,7 @@ namespace Microsoft.OpenApi
             {
                 if (value is null)
                 {
+                    _tags = null;
                     return;
                 }
                 _tags = value switch

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiDocumentTests.cs
@@ -2145,6 +2145,17 @@ components:
             Assert.Equal(2, document.Tags.Count);
         }
 
+        [Fact]
+        public void TagsCanBeReInitializedToNull()
+        {
+            var document = new OpenApiDocument();
+            Assert.Null(document.Tags);
+            document.Tags = new HashSet<OpenApiTag>();
+            Assert.NotNull(document.Tags);
+            document.Tags = null;
+            Assert.Null(document.Tags);
+        }
+
         private sealed class CaseInsensitiveOpenApiTagEqualityComparer : IEqualityComparer<OpenApiTag>
         {
             public bool Equals(OpenApiTag x, OpenApiTag y)


### PR DESCRIPTION
port of #2916 to v2