### PR TITLE
Fix handling of nullable enums for 3.0

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -554,7 +554,7 @@ namespace Microsoft.OpenApi
                     var clonedToMutateEnum = element.CreateShallowCopy();
                     if (clonedToMutateEnum is OpenApiSchema { Enum: { } existingEnum } concreteCloned)
                     {
-                        concreteCloned.Enum = [.. existingEnum, null!];
+                        concreteCloned.Enum = [.. existingEnum, JsonNullSentinel.JsonNull];
                         callback(writer, clonedToMutateEnum);
                     }
                     else

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -1100,23 +1100,21 @@ namespace Microsoft.OpenApi
                     }
                     else if (schema.Enum is { Count: > 0 })
                     {
-                        foreach (var enumValue in schema.Enum)
+                        foreach (var enumValue in schema.Enum.Where(x => x is not null))
                         {
-                            if (enumValue is not null)
+                            var currentType = enumValue.GetValueKind() switch
                             {
-                                var currentType = enumValue.GetValueKind() switch
-                                {
-                                    JsonValueKind.Array => JsonSchemaType.Array,
-                                    JsonValueKind.String => JsonSchemaType.String,
-                                    JsonValueKind.Number => JsonSchemaType.Number,
-                                    JsonValueKind.True or JsonValueKind.False => JsonSchemaType.Boolean,
-                                    JsonValueKind.Null => (JsonSchemaType)0,
-                                    _ => JsonSchemaType.Object,
-                                };
+                                JsonValueKind.Array => JsonSchemaType.Array,
+                                JsonValueKind.String => JsonSchemaType.String,
+                                JsonValueKind.Number => JsonSchemaType.Number,
+                                JsonValueKind.True or JsonValueKind.False => JsonSchemaType.Boolean,
+                                JsonValueKind.Null => (JsonSchemaType)0,
+                                _ => JsonSchemaType.Object,
+                            };
 
-                                commonType |= currentType;
-                            }
+                            commonType |= currentType;
                         }
+
                         commonType |= JsonSchemaType.String;
                     }
                 }

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -521,6 +521,7 @@ namespace Microsoft.OpenApi
             IList<IOpenApiSchema>? effectiveOneOf = OneOf;
             IList<IOpenApiSchema>? effectiveAnyOf = AnyOf;
             bool hasNullInComposition = false;
+            bool hasOneOfNullAndSingleEnumWith3_0 = false;
             JsonSchemaType? inferredType = null;
 
             if (version == OpenApiSpecVersion.OpenApi3_0)
@@ -531,6 +532,9 @@ namespace Microsoft.OpenApi
                 (effectiveAnyOf, var inferredAnyOf, var nullInAnyOf) = ProcessCompositionForNull(AnyOf);
                 hasNullInComposition |= nullInAnyOf;
                 inferredType = inferredAnyOf ?? inferredType;
+
+                hasOneOfNullAndSingleEnumWith3_0 = nullInOneOf && effectiveOneOf is { Count: 1 } &&
+                    effectiveOneOf[0].Enum is { Count: > 0 };
             }
 
             // type
@@ -543,7 +547,21 @@ namespace Microsoft.OpenApi
             writer.WriteOptionalCollection(OpenApiConstants.AnyOf, effectiveAnyOf, callback);
 
             // oneOf
-            writer.WriteOptionalCollection(OpenApiConstants.OneOf, effectiveOneOf, callback);
+            if (hasOneOfNullAndSingleEnumWith3_0 &&
+                effectiveOneOf![0] is OpenApiSchema { Enum.Count: > 0 } singleEffectiveOneOf)
+            {
+                writer.WriteRequiredCollection(OpenApiConstants.OneOf, effectiveOneOf, (writer, element) =>
+                {
+                    var clonedToMutateEnum = (OpenApiSchema)((OpenApiSchema)element).MemberwiseClone();
+                    clonedToMutateEnum.Enum = [.. clonedToMutateEnum.Enum!, null!];
+                    callback(writer, clonedToMutateEnum);
+                });
+            }
+            else
+            {
+                writer.WriteOptionalCollection(OpenApiConstants.OneOf, effectiveOneOf, callback);
+            }
+
 
             // not
             writer.WriteOptionalObject(OpenApiConstants.Not, Not, callback);
@@ -1070,10 +1088,17 @@ namespace Microsoft.OpenApi
 
                 foreach (var schema in nonNullSchemas)
                 {
-                    commonType |= schema.Type.GetValueOrDefault() & ~JsonSchemaType.Null;
+                    if (schema.Type.HasValue)
+                    {
+                        commonType |= schema.Type.Value & ~JsonSchemaType.Null;
+                    }
+                    else if (schema.Enum is { Count: > 0 })
+                    {
+                        commonType |= JsonSchemaType.String;
+                    }
                 }
 
-                return (nonNullSchemas, commonType, true);
+                return (nonNullSchemas, commonType == 0 ? null : commonType, true);
             }
             else
             {

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -547,14 +547,20 @@ namespace Microsoft.OpenApi
             writer.WriteOptionalCollection(OpenApiConstants.AnyOf, effectiveAnyOf, callback);
 
             // oneOf
-            if (hasOneOfNullAndSingleEnumWith3_0 &&
-                effectiveOneOf![0] is OpenApiSchema { Enum.Count: > 0 } singleEffectiveOneOf)
+            if (hasOneOfNullAndSingleEnumWith3_0)
             {
-                writer.WriteRequiredCollection(OpenApiConstants.OneOf, effectiveOneOf, (writer, element) =>
-                {
-                    var clonedToMutateEnum = (OpenApiSchema)((OpenApiSchema)element).MemberwiseClone();
-                    clonedToMutateEnum.Enum = [.. clonedToMutateEnum.Enum!, null!];
-                    callback(writer, clonedToMutateEnum);
+                writer.WriteRequiredCollection(OpenApiConstants.OneOf, effectiveOneOf!, (writer, element) =>
+                {                    
+                    var clonedToMutateEnum = element.CreateShallowCopy();
+                    if (clonedToMutateEnum is OpenApiSchema { Enum: { } existingEnum } concreteCloned)
+                    {
+                        concreteCloned.Enum = [.. existingEnum, null!];
+                        callback(writer, clonedToMutateEnum);
+                    }
+                    else
+                    {
+                        callback(writer, element);
+                    }
                 });
             }
             else
@@ -1094,6 +1100,23 @@ namespace Microsoft.OpenApi
                     }
                     else if (schema.Enum is { Count: > 0 })
                     {
+                        foreach (var enumValue in schema.Enum)
+                        {
+                            if (enumValue is not null)
+                            {
+                                var currentType = enumValue.GetValueKind() switch
+                                {
+                                    JsonValueKind.Array => JsonSchemaType.Array,
+                                    JsonValueKind.String => JsonSchemaType.String,
+                                    JsonValueKind.Number => JsonSchemaType.Number,
+                                    JsonValueKind.True or JsonValueKind.False => JsonSchemaType.Boolean,
+                                    JsonValueKind.Null => (JsonSchemaType)0,
+                                    _ => JsonSchemaType.Object,
+                                };
+
+                                commonType |= currentType;
+                            }
+                        }
                         commonType |= JsonSchemaType.String;
                     }
                 }

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -1868,7 +1868,7 @@ namespace Microsoft.OpenApi.Tests.Models
             // It's unclear if it's an issue of the validators or not, but it's safer to do it that way.
             var schema = CreateNullableEnumSchema();
             var result = await schema.SerializeAsJsonAsync(OpenApiSpecVersion.OpenApi3_0);
-            Assert.Equal("""
+            var expected = """
                 {
                   "type": "string",
                   "oneOf": [
@@ -1882,7 +1882,9 @@ namespace Microsoft.OpenApi.Tests.Models
                   ],
                   "nullable": true
                 }
-                """.ReplaceLineEndings(), result.ReplaceLineEndings());
+                """;
+
+            Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(result)));
         }
 
         [Theory]
@@ -1892,7 +1894,7 @@ namespace Microsoft.OpenApi.Tests.Models
         {
             var schema = CreateNullableEnumSchema();
             var result = await schema.SerializeAsJsonAsync(version);
-            Assert.Equal("""
+            var expected = """
                 {
                   "oneOf": [
                     {
@@ -1906,7 +1908,8 @@ namespace Microsoft.OpenApi.Tests.Models
                     }
                   ]
                 }
-                """.ReplaceLineEndings(), result.ReplaceLineEndings());
+                """;
+            Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(result)));
         }
 
         private OpenApiSchema CreateNullableEnumSchema()
@@ -1923,11 +1926,6 @@ namespace Microsoft.OpenApi.Tests.Models
                 }
             });
             return schema;
-        }
-
-        private enum MyEnum
-        {
-            A, B
         }
 
         internal class SchemaVisitor : OpenApiVisitorBase

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -5,7 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Schema;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using FluentAssertions;
 using VerifyXunit;
@@ -1851,6 +1854,80 @@ namespace Microsoft.OpenApi.Tests.Models
             Assert.True(schema.Extensions is null || !schema.Extensions.ContainsKey(OpenApiConstants.ContainsExtension));
             Assert.True(schema.Extensions is null || !schema.Extensions.ContainsKey(OpenApiConstants.MaxContainsExtension));
             Assert.True(schema.Extensions is null || !schema.Extensions.ContainsKey(OpenApiConstants.MinContainsExtension));
+        }
+
+        [Fact]
+        public async Task SerializeNullableEnumWith3_0()
+        {
+            // https://spec.openapis.org/oas/v3.0.4.html#fixed-fields-20
+            // Documentation for nullable states:
+            // This keyword only takes effect if type is explicitly defined within the same Schema Object.
+            // So, we want to ensure that we emit the type property if we will be adding nullable property.
+            // In addition, we need to still keep 'null' in the enum array.
+            // Otherwise, validators will consider null as invalid even if nullable is set to true.
+            // It's unclear if it's an issue of the validators or not, but it's safer to do it that way.
+            var schema = CreateNullableEnumSchema();
+            var result = await schema.SerializeAsJsonAsync(OpenApiSpecVersion.OpenApi3_0);
+            Assert.Equal("""
+                {
+                  "type": "string",
+                  "oneOf": [
+                    {
+                      "enum": [
+                        "A",
+                        "B",
+                        null
+                      ]
+                    }
+                  ],
+                  "nullable": true
+                }
+                """.ReplaceLineEndings(), result.ReplaceLineEndings());
+        }
+
+        [Theory]
+        [InlineData(OpenApiSpecVersion.OpenApi3_1)]
+        [InlineData(OpenApiSpecVersion.OpenApi3_2)]
+        public async Task SerializeNullableEnumWith3_1_And_Later(OpenApiSpecVersion version)
+        {
+            var schema = CreateNullableEnumSchema();
+            var result = await schema.SerializeAsJsonAsync(version);
+            Assert.Equal("""
+                {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "enum": [
+                        "A",
+                        "B"
+                      ]
+                    }
+                  ]
+                }
+                """.ReplaceLineEndings(), result.ReplaceLineEndings());
+        }
+
+        private OpenApiSchema CreateNullableEnumSchema()
+        {
+            var schema = new OpenApiSchema();
+            schema.OneOf ??= [];
+            schema.OneOf.Add(new OpenApiSchema() { Type = JsonSchemaType.Null });
+            schema.OneOf.Add(new OpenApiSchema()
+            {
+                Enum = new List<JsonNode>
+                {
+                    JsonValue.Create("A"),
+                    JsonValue.Create("B")
+                }
+            });
+            return schema;
+        }
+
+        private enum MyEnum
+        {
+            A, B
         }
 
         internal class SchemaVisitor : OpenApiVisitorBase


### PR DESCRIPTION
Previously, this scenario wasn't producing a `type` and wasn't producing a null value in the enum array.

This fixes it so that they are produced.

In the future, we could also avoid adding a `oneOf` with a single element in this scenario.