### PR TITLE
fix(schema): apply additive JSON Schema semantics to $ref sibling getters

### DIFF
--- a/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
+++ b/src/Microsoft.OpenApi/Models/References/OpenApiSchemaReference.cs
@@ -9,7 +9,11 @@ namespace Microsoft.OpenApi
 {
 #pragma warning disable CS0618
     /// <summary>
-    /// Schema reference object
+    /// Schema reference object.
+    /// Convenience getters return <c>$ref</c>-sibling keyword values authored on
+    /// <see cref="IOpenApiReferenceHolder{V}.Reference"/> before falling back to resolved values from <see cref="Target"/>.
+    /// These getters are object-model conveniences and do not represent JSON Schema
+    /// evaluation semantics.
     /// </summary>
     public class OpenApiSchemaReference : BaseOpenApiReferenceHolder<OpenApiSchema, IOpenApiSchema, JsonSchemaReference>, IOpenApiSchema, IOpenApiSchemaMissingProperties, IOpenApiSchemaWithUnevaluatedProperties, IOpenApiExtensible
     {


### PR DESCRIPTION
## Summary

Following the discussion in #2919 with @handrews and @baywet, this PR is now documentation-only.

## Changes

Adds XML documentation to `OpenApiSchemaReference` clarifying that convenience getters return authored sibling keyword values from `Reference` before falling back to resolved `Target` values. These getters are object-model conveniences and do not represent JSON Schema evaluation semantics.

## Rationale

The reference-first getter behavior (`Reference.X ?? Target?.X`) was an explicit design decision (#2903). Per #2919:
- Assertion keywords alongside `$ref` are additive in JSON Schema evaluation, not overrides
- The library does not perform validation — splitting getter behavior per keyword type creates setter/getter asymmetry and keyword-specific edge cases
- The safest direction is to keep consistent reference-first getters and document the contract explicitly

Consumers that need precise JSON Schema semantics should inspect both `Reference` and `Target`, or use a JSON Schema validator.

Fixes #2919
