### PR TITLE
Handle nullability more accurately

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -514,28 +514,17 @@ namespace Microsoft.OpenApi
                 : Enum;
             writer.WriteOptionalCollection(OpenApiConstants.Enum, enumValue, (nodeWriter, s) => nodeWriter.WriteAny(s));
 
-            // Handle oneOf/anyOf with null type for v3.0 downcast
-            bool hasNullInComposition = false;
-            JsonSchemaType? inferredType = null;
-
             if (version == OpenApiSpecVersion.OpenApi3_0)
             {
-                (var inferredOneOf, var nullInOneOf) = ProcessCompositionForNull(OneOf);
-                hasNullInComposition |= nullInOneOf;
-                inferredType = inferredOneOf ?? inferredType;
-                (var inferredAnyOf, var nullInAnyOf) = ProcessCompositionForNull(AnyOf);
-                hasNullInComposition |= nullInAnyOf;
-                inferredType = inferredAnyOf ?? inferredType;
-
                 // If we have a schema that's only just { "type": "null" }, we serialize it as enum with null value.
-                if (Type == JsonSchemaType.Null && OneOf is not { Count: > 0 } && AnyOf is not { Count: > 0 })
+                if (Type == JsonSchemaType.Null && OneOf is not { Count: > 0 } && AnyOf is not { Count: > 0 } && Enum is not { Count: > 0 })
                 {
                     writer.WriteOptionalCollection(OpenApiConstants.Enum, s_singleNullElementList, (nodeWriter, s) => nodeWriter.WriteAny(s));
                 }
             }
 
             // type
-            var serializedTypeProperty = TrySerializeTypeProperty(writer, version, inferredType);
+            var serializedTypeProperty = TrySerializeTypeProperty(writer, version);
 
             // allOf
             writer.WriteOptionalCollection(OpenApiConstants.AllOf, AllOf, callback);
@@ -587,7 +576,7 @@ namespace Microsoft.OpenApi
                 //
                 // If the user explicitly set IsNullable to true, we serialize it even if redundant.
                 // But if **we** are inferring it (from oneOf/anyOf), we don't serialize it when it's redundant.
-                SerializeNullable(writer, version, hasNullInComposition);
+                SerializeNullable(writer, version);
             }
 
             // discriminator
@@ -1037,9 +1026,9 @@ namespace Microsoft.OpenApi
             }
         }
 
-        private void SerializeNullable(IOpenApiWriter writer, OpenApiSpecVersion version, bool hasNullInComposition = false)
+        private void SerializeNullable(IOpenApiWriter writer, OpenApiSpecVersion version)
         {
-            if (HasNullType || hasNullInComposition)
+            if (HasNullType)
             {
                 switch (version)
                 {
@@ -1050,61 +1039,6 @@ namespace Microsoft.OpenApi
                         writer.WriteProperty(OpenApiConstants.Nullable, true);
                         break;
                 }
-            }
-        }
-
-        /// <summary>
-        /// Processes a composition (oneOf or anyOf) for null types, filtering out null schemas and inferring common type.
-        /// </summary>
-        /// <param name="composition">The list of schemas in the composition.</param>
-        /// <returns>A tuple with the effective list, inferred type, and whether null is present in composition.</returns>
-        private static (JsonSchemaType? inferredType, bool hasNullInComposition)
-            ProcessCompositionForNull(IList<IOpenApiSchema>? composition)
-        {
-            if (composition is null || !composition.Any(static s => s.Type is JsonSchemaType.Null))
-            {
-                // Nothing to patch
-                return (null, false);
-            }
-
-            var nonNullSchemas = composition
-                .Where(static s => s.Type is null or not JsonSchemaType.Null)
-                .ToList();
-
-            if (nonNullSchemas.Count > 0)
-            {
-                JsonSchemaType commonType = 0;
-
-                foreach (var schema in nonNullSchemas)
-                {
-                    if (schema.Type.HasValue)
-                    {
-                        commonType |= schema.Type.Value & ~JsonSchemaType.Null;
-                    }
-                    else if (schema.Enum is { Count: > 0 })
-                    {
-                        foreach (var enumValue in schema.Enum.Where(x => x is not null))
-                        {
-                            var currentType = enumValue.GetValueKind() switch
-                            {
-                                JsonValueKind.Array => JsonSchemaType.Array,
-                                JsonValueKind.String => JsonSchemaType.String,
-                                JsonValueKind.Number => JsonSchemaType.Number,
-                                JsonValueKind.True or JsonValueKind.False => JsonSchemaType.Boolean,
-                                JsonValueKind.Null => (JsonSchemaType)0,
-                                _ => JsonSchemaType.Object,
-                            };
-
-                            commonType |= currentType;
-                        }
-                    }
-                }
-
-                return (commonType == 0 ? null : commonType, true);
-            }
-            else
-            {
-                return (null, true);
             }
         }
 

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -517,7 +517,11 @@ namespace Microsoft.OpenApi
             if (version == OpenApiSpecVersion.OpenApi3_0)
             {
                 // If we have a schema that's only just { "type": "null" }, we serialize it as enum with null value.
-                if (Type == JsonSchemaType.Null && OneOf is not { Count: > 0 } && AnyOf is not { Count: > 0 } && Enum is not { Count: > 0 })
+                if (Type == JsonSchemaType.Null &&
+                    OneOf is not { Count: > 0 } &&
+                    AnyOf is not { Count: > 0 } &&
+                    AllOf is not { Count: > 0 } &&
+                    Enum is not { Count: > 0 })
                 {
                     writer.WriteOptionalCollection(OpenApiConstants.Enum, s_singleNullElementList, (nodeWriter, s) => nodeWriter.WriteAny(s));
                 }

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -111,12 +111,18 @@ namespace Microsoft.OpenApi
         /// <inheritdoc />
         public JsonSchemaType? Type { get; set; }
 
+        /// <summary>
+        /// This property is internal and is only used to mark the "nullable" state when doing deserialization.
+        /// It's only set during deserialization to flag whether we encountered "nullable" or not.
+        /// And it's read:
+        /// 1. During FinalizeDeserialization to determine whether the Type should be changed to include null or not.
+        /// 2. When serializing nullable, if IsNullable was false and IsNullableFromDeserialization was true, we will still serialize "nullable".
+        /// </summary>
+        internal bool IsNullableFromDeserialization { get; set; }
+
         // x-nullable is filtered out by deserializers, but keep the check here in case it gets added from user code.
         internal bool IsNullable
-        {
-            get => field || HasTrueNullableExtension || (Type.HasValue && Type.Value.HasFlag(JsonSchemaType.Null));
-            set => field = value;
-        }
+            => HasTrueNullableExtension || (Type.HasValue && Type.Value.HasFlag(JsonSchemaType.Null));
 
         private bool HasTrueNullableExtension
             => Extensions is not null &&
@@ -798,11 +804,11 @@ namespace Microsoft.OpenApi
         {
             if (HasTrueNullableExtension)
             {
-                IsNullable = true;
                 Extensions!.Remove(OpenApiConstants.NullableExtension);
+                IsNullableFromDeserialization = true;
             }
 
-            if (IsNullable && Type is not null && Type != 0)
+            if (IsNullableFromDeserialization && Type is not null && Type != 0)
             {
                 Type |= JsonSchemaType.Null;
             }
@@ -1065,7 +1071,7 @@ namespace Microsoft.OpenApi
 
         private void SerializeNullable(IOpenApiWriter writer, OpenApiSpecVersion version, bool hasNullInComposition = false)
         {
-            if (IsNullable || hasNullInComposition)
+            if (IsNullable || IsNullableFromDeserialization || hasNullInComposition)
             {
                 switch (version)
                 {

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -114,12 +114,6 @@ namespace Microsoft.OpenApi
         private bool HasNullType
             => Type.HasValue && Type.Value.HasFlag(JsonSchemaType.Null);
 
-        private bool HasTrueNullableExtension
-            => Extensions is not null &&
-                Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullExtRawValue) &&
-                nullExtRawValue is JsonNodeExtension { Node: JsonNode jsonNode } &&
-                jsonNode.GetValueKind() is JsonValueKind.True;
-
         /// <inheritdoc />
         public string? Const { get; set; }
 
@@ -788,18 +782,6 @@ namespace Microsoft.OpenApi
 
             // extensions
             writer.WriteExtensions(Extensions, OpenApiSpecVersion.OpenApi2_0);
-        }
-
-        internal void FinalizeDeserialization(OpenApiSpecVersion version)
-        {
-            if (version is OpenApiSpecVersion.OpenApi2_0 or OpenApiSpecVersion.OpenApi3_0 && HasTrueNullableExtension)
-            {
-                Extensions!.Remove(OpenApiConstants.NullableExtension);
-                if (Type is not null && Type != 0)
-                {
-                    Type |= JsonSchemaType.Null;
-                }
-            }
         }
 
         private void WriteFormatProperty(IOpenApiWriter writer)

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -111,19 +111,12 @@ namespace Microsoft.OpenApi
         /// <inheritdoc />
         public JsonSchemaType? Type { get; set; }
 
-        /// <summary>
-        /// This property is internal and is only used to mark the "nullable" state when doing deserialization.
-        /// It's only set during deserialization to flag whether we encountered "nullable" or not.
-        /// And it's read:
-        /// 1. During FinalizeDeserialization to determine whether the Type should be changed to include null or not.
-        /// 2. When serializing nullable, if IsNullable was false and IsNullableFromDeserialization was true, we will still serialize "nullable".
-        /// </summary>
-        internal bool IsNullableFromDeserialization { get; set; }
+        internal bool Nullable { get; set; }
+
+        private bool NullableOrHasNullType
+            => Nullable || (Type.HasValue && Type.Value.HasFlag(JsonSchemaType.Null));
 
         // x-nullable is filtered out by deserializers, but keep the check here in case it gets added from user code.
-        internal bool IsNullable
-            => HasTrueNullableExtension || (Type.HasValue && Type.Value.HasFlag(JsonSchemaType.Null));
-
         private bool HasTrueNullableExtension
             => Extensions is not null &&
                 Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullExtRawValue) &&
@@ -802,16 +795,13 @@ namespace Microsoft.OpenApi
 
         internal void FinalizeDeserialization(OpenApiSpecVersion version)
         {
-            if (version is OpenApiSpecVersion.OpenApi2_0)
+            if (version is OpenApiSpecVersion.OpenApi2_0 && HasTrueNullableExtension)
             {
-                if (HasTrueNullableExtension)
-                {
-                    Extensions!.Remove(OpenApiConstants.NullableExtension);
-                    IsNullableFromDeserialization = true;
-                }
+                Extensions!.Remove(OpenApiConstants.NullableExtension);
+                Nullable = true;
             }
 
-            if (IsNullableFromDeserialization && Type is not null && Type != 0)
+            if (Nullable && Type is not null && Type != 0)
             {
                 Type |= JsonSchemaType.Null;
             }
@@ -1031,7 +1021,7 @@ namespace Microsoft.OpenApi
                     }
                     break;
                 default:
-                    WriteUnifiedSchemaType(IsNullable ? typeToUse.Value | JsonSchemaType.Null : typeToUse.Value, writer);
+                    WriteUnifiedSchemaType(typeToUse.Value, writer);
                     return true;
             }
 
@@ -1072,7 +1062,7 @@ namespace Microsoft.OpenApi
 
         private void SerializeNullable(IOpenApiWriter writer, OpenApiSpecVersion version, bool hasNullInComposition = false)
         {
-            if (IsNullable || IsNullableFromDeserialization || hasNullInComposition)
+            if (NullableOrHasNullType || hasNullInComposition)
             {
                 switch (version)
                 {

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -800,12 +800,15 @@ namespace Microsoft.OpenApi
             writer.WriteExtensions(Extensions, OpenApiSpecVersion.OpenApi2_0);
         }
 
-        internal void FinalizeDeserialization()
+        internal void FinalizeDeserialization(OpenApiSpecVersion version)
         {
-            if (HasTrueNullableExtension)
+            if (version is OpenApiSpecVersion.OpenApi2_0)
             {
-                Extensions!.Remove(OpenApiConstants.NullableExtension);
-                IsNullableFromDeserialization = true;
+                if (HasTrueNullableExtension)
+                {
+                    Extensions!.Remove(OpenApiConstants.NullableExtension);
+                    IsNullableFromDeserialization = true;
+                }
             }
 
             if (IsNullableFromDeserialization && Type is not null && Type != 0)

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -111,12 +111,9 @@ namespace Microsoft.OpenApi
         /// <inheritdoc />
         public JsonSchemaType? Type { get; set; }
 
-        internal bool Nullable { get; set; }
+        private bool HasNullType
+            => Type.HasValue && Type.Value.HasFlag(JsonSchemaType.Null);
 
-        private bool NullableOrHasNullType
-            => Nullable || (Type.HasValue && Type.Value.HasFlag(JsonSchemaType.Null));
-
-        // x-nullable is filtered out by deserializers, but keep the check here in case it gets added from user code.
         private bool HasTrueNullableExtension
             => Extensions is not null &&
                 Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullExtRawValue) &&
@@ -795,15 +792,13 @@ namespace Microsoft.OpenApi
 
         internal void FinalizeDeserialization(OpenApiSpecVersion version)
         {
-            if (version is OpenApiSpecVersion.OpenApi2_0 && HasTrueNullableExtension)
+            if (version is OpenApiSpecVersion.OpenApi2_0 or OpenApiSpecVersion.OpenApi3_0 && HasTrueNullableExtension)
             {
                 Extensions!.Remove(OpenApiConstants.NullableExtension);
-                Nullable = true;
-            }
-
-            if (Nullable && Type is not null && Type != 0)
-            {
-                Type |= JsonSchemaType.Null;
+                if (Type is not null && Type != 0)
+                {
+                    Type |= JsonSchemaType.Null;
+                }
             }
         }
 
@@ -1062,7 +1057,7 @@ namespace Microsoft.OpenApi
 
         private void SerializeNullable(IOpenApiWriter writer, OpenApiSpecVersion version, bool hasNullInComposition = false)
         {
-            if (NullableOrHasNullType || hasNullInComposition)
+            if (HasNullType || hasNullInComposition)
             {
                 switch (version)
                 {

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -114,11 +114,11 @@ namespace Microsoft.OpenApi
         // x-nullable is filtered out by deserializers, but keep the check here in case it gets added from user code.
         internal bool IsNullable
         {
-            get => field || HasNullableExtension || (Type.HasValue && Type.Value.HasFlag(JsonSchemaType.Null));
+            get => field || HasTrueNullableExtension || (Type.HasValue && Type.Value.HasFlag(JsonSchemaType.Null));
             set => field = value;
         }
 
-        private bool HasNullableExtension
+        private bool HasTrueNullableExtension
             => Extensions is not null &&
                 Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullExtRawValue) &&
                 nullExtRawValue is JsonNodeExtension { Node: JsonNode jsonNode } &&
@@ -792,6 +792,20 @@ namespace Microsoft.OpenApi
 
             // extensions
             writer.WriteExtensions(Extensions, OpenApiSpecVersion.OpenApi2_0);
+        }
+
+        internal void FinalizeDeserialization()
+        {
+            if (HasTrueNullableExtension)
+            {
+                IsNullable = true;
+                Extensions!.Remove(OpenApiConstants.NullableExtension);
+            }
+
+            if (IsNullable && Type is not null && Type != 0)
+            {
+                Type |= JsonSchemaType.Null;
+            }
         }
 
         private void WriteFormatProperty(IOpenApiWriter writer)

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -545,7 +545,7 @@ namespace Microsoft.OpenApi
             }
 
             // type
-            var serializedTypeProperty = SerializeTypeProperty(writer, version, inferredType);
+            var serializedTypeProperty = TrySerializeTypeProperty(writer, version, inferredType);
 
             // allOf
             writer.WriteOptionalCollection(OpenApiConstants.AllOf, AllOf, callback);
@@ -838,7 +838,7 @@ namespace Microsoft.OpenApi
             writer.WriteStartObject();
 
             // type
-            SerializeTypeProperty(writer, OpenApiSpecVersion.OpenApi2_0);
+            TrySerializeTypeProperty(writer, OpenApiSpecVersion.OpenApi2_0);
 
             // description
             writer.WriteProperty(OpenApiConstants.Description, Description);
@@ -1001,7 +1001,7 @@ namespace Microsoft.OpenApi
             writer.WriteEndObject();
         }
 
-        private bool SerializeTypeProperty(IOpenApiWriter writer, OpenApiSpecVersion version, JsonSchemaType? inferredType = null)
+        private bool TrySerializeTypeProperty(IOpenApiWriter writer, OpenApiSpecVersion version, JsonSchemaType? inferredType = null)
         {
             // Use original type or inferred type when the explicit type is not set
             var typeToUse = Type ?? inferredType;

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -1017,12 +1017,10 @@ namespace Microsoft.OpenApi
                 return false;
             }
 
-            var unifiedType = IsNullable ? typeToUse.Value | JsonSchemaType.Null : typeToUse.Value;
-            var typeWithoutNull = unifiedType & ~JsonSchemaType.Null;
-
             switch (version)
             {
                 case OpenApiSpecVersion.OpenApi2_0 or OpenApiSpecVersion.OpenApi3_0:
+                    var typeWithoutNull = typeToUse.Value & ~JsonSchemaType.Null;
                     if (typeWithoutNull != 0 && !HasMultipleTypes(typeWithoutNull))
                     {
                         writer.WriteProperty(OpenApiConstants.Type, typeWithoutNull.ToFirstIdentifier());
@@ -1030,7 +1028,7 @@ namespace Microsoft.OpenApi
                     }
                     break;
                 default:
-                    WriteUnifiedSchemaType(unifiedType, writer);
+                    WriteUnifiedSchemaType(IsNullable ? typeToUse.Value | JsonSchemaType.Null : typeToUse.Value, writer);
                     return true;
             }
 

--- a/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiSchema.cs
@@ -21,6 +21,8 @@ namespace Microsoft.OpenApi
     /// </summary>
     public class OpenApiSchema : IOpenApiExtensible, IOpenApiSchema, IOpenApiSchemaMissingProperties, IOpenApiSchemaWithUnevaluatedProperties, IMetadataContainer
     {
+        private static readonly IEnumerable<JsonNode> s_singleNullElementList = [ JsonNullSentinel.JsonNull ];
+
         /// <inheritdoc />
         public string? Title { get; set; }
 
@@ -110,12 +112,17 @@ namespace Microsoft.OpenApi
         public JsonSchemaType? Type { get; set; }
 
         // x-nullable is filtered out by deserializers, but keep the check here in case it gets added from user code.
-        private bool IsNullable =>
-            (Type.HasValue && Type.Value.HasFlag(JsonSchemaType.Null)) ||
-            Extensions is not null &&
-            Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullExtRawValue) &&
-            nullExtRawValue is JsonNodeExtension { Node: JsonNode jsonNode } &&
-            jsonNode.GetValueKind() is JsonValueKind.True;
+        internal bool IsNullable
+        {
+            get => field || HasNullableExtension || (Type.HasValue && Type.Value.HasFlag(JsonSchemaType.Null));
+            set => field = value;
+        }
+
+        private bool HasNullableExtension
+            => Extensions is not null &&
+                Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullExtRawValue) &&
+                nullExtRawValue is JsonNodeExtension { Node: JsonNode jsonNode } &&
+                jsonNode.GetValueKind() is JsonValueKind.True;
 
         /// <inheritdoc />
         public string? Const { get; set; }
@@ -518,56 +525,36 @@ namespace Microsoft.OpenApi
             writer.WriteOptionalCollection(OpenApiConstants.Enum, enumValue, (nodeWriter, s) => nodeWriter.WriteAny(s));
 
             // Handle oneOf/anyOf with null type for v3.0 downcast
-            IList<IOpenApiSchema>? effectiveOneOf = OneOf;
-            IList<IOpenApiSchema>? effectiveAnyOf = AnyOf;
             bool hasNullInComposition = false;
-            bool hasOneOfNullAndSingleEnumWith3_0 = false;
             JsonSchemaType? inferredType = null;
 
             if (version == OpenApiSpecVersion.OpenApi3_0)
             {
-                (effectiveOneOf, var inferredOneOf, var nullInOneOf) = ProcessCompositionForNull(OneOf);
+                (var inferredOneOf, var nullInOneOf) = ProcessCompositionForNull(OneOf);
                 hasNullInComposition |= nullInOneOf;
                 inferredType = inferredOneOf ?? inferredType;
-                (effectiveAnyOf, var inferredAnyOf, var nullInAnyOf) = ProcessCompositionForNull(AnyOf);
+                (var inferredAnyOf, var nullInAnyOf) = ProcessCompositionForNull(AnyOf);
                 hasNullInComposition |= nullInAnyOf;
                 inferredType = inferredAnyOf ?? inferredType;
 
-                hasOneOfNullAndSingleEnumWith3_0 = nullInOneOf && effectiveOneOf is { Count: 1 } &&
-                    effectiveOneOf[0].Enum is { Count: > 0 };
+                // If we have a schema that's only just { "type": "null" }, we serialize it as enum with null value.
+                if (Type == JsonSchemaType.Null && OneOf is not { Count: > 0 } && AnyOf is not { Count: > 0 })
+                {
+                    writer.WriteOptionalCollection(OpenApiConstants.Enum, s_singleNullElementList, (nodeWriter, s) => nodeWriter.WriteAny(s));
+                }
             }
 
             // type
-            SerializeTypeProperty(writer, version, inferredType);
+            var serializedTypeProperty = SerializeTypeProperty(writer, version, inferredType);
 
             // allOf
             writer.WriteOptionalCollection(OpenApiConstants.AllOf, AllOf, callback);
 
             // anyOf
-            writer.WriteOptionalCollection(OpenApiConstants.AnyOf, effectiveAnyOf, callback);
+            writer.WriteOptionalCollection(OpenApiConstants.AnyOf, AnyOf, callback);
 
             // oneOf
-            if (hasOneOfNullAndSingleEnumWith3_0)
-            {
-                writer.WriteRequiredCollection(OpenApiConstants.OneOf, effectiveOneOf!, (writer, element) =>
-                {                    
-                    var clonedToMutateEnum = element.CreateShallowCopy();
-                    if (clonedToMutateEnum is OpenApiSchema { Enum: { } existingEnum } concreteCloned)
-                    {
-                        concreteCloned.Enum = [.. existingEnum, JsonNullSentinel.JsonNull];
-                        callback(writer, clonedToMutateEnum);
-                    }
-                    else
-                    {
-                        callback(writer, element);
-                    }
-                });
-            }
-            else
-            {
-                writer.WriteOptionalCollection(OpenApiConstants.OneOf, effectiveOneOf, callback);
-            }
-
+            writer.WriteOptionalCollection(OpenApiConstants.OneOf, OneOf, callback);
 
             // not
             writer.WriteOptionalObject(OpenApiConstants.Not, Not, callback);
@@ -603,8 +590,13 @@ namespace Microsoft.OpenApi
             writer.WriteOptionalObject(OpenApiConstants.Default, Default, (w, d) => w.WriteAny(d));
 
             // nullable
-            if (version == OpenApiSpecVersion.OpenApi3_0)
+            if (version == OpenApiSpecVersion.OpenApi3_0 && serializedTypeProperty)
             {
+                // https://spec.openapis.org/oas/v3.0.4.html#fixed-fields-20
+                // This keyword only takes effect if type is explicitly defined within the same Schema Object.
+                //
+                // If the user explicitly set IsNullable to true, we serialize it even if redundant.
+                // But if **we** are inferring it (from oneOf/anyOf), we don't serialize it when it's redundant.
                 SerializeNullable(writer, version, hasNullInComposition);
             }
 
@@ -995,14 +987,14 @@ namespace Microsoft.OpenApi
             writer.WriteEndObject();
         }
 
-        private void SerializeTypeProperty(IOpenApiWriter writer, OpenApiSpecVersion version, JsonSchemaType? inferredType = null)
+        private bool SerializeTypeProperty(IOpenApiWriter writer, OpenApiSpecVersion version, JsonSchemaType? inferredType = null)
         {
             // Use original type or inferred type when the explicit type is not set
             var typeToUse = Type ?? inferredType;
 
             if (typeToUse is null)
             {
-                return;
+                return false;
             }
 
             var unifiedType = IsNullable ? typeToUse.Value | JsonSchemaType.Null : typeToUse.Value;
@@ -1014,12 +1006,15 @@ namespace Microsoft.OpenApi
                     if (typeWithoutNull != 0 && !HasMultipleTypes(typeWithoutNull))
                     {
                         writer.WriteProperty(OpenApiConstants.Type, typeWithoutNull.ToFirstIdentifier());
+                        return true;
                     }
                     break;
                 default:
                     WriteUnifiedSchemaType(unifiedType, writer);
-                    break;
+                    return true;
             }
+
+            return false;
         }
 
         private static bool IsPowerOfTwo(int x)
@@ -1075,13 +1070,13 @@ namespace Microsoft.OpenApi
         /// </summary>
         /// <param name="composition">The list of schemas in the composition.</param>
         /// <returns>A tuple with the effective list, inferred type, and whether null is present in composition.</returns>
-        private static (IList<IOpenApiSchema>? effective, JsonSchemaType? inferredType, bool hasNullInComposition)
+        private static (JsonSchemaType? inferredType, bool hasNullInComposition)
             ProcessCompositionForNull(IList<IOpenApiSchema>? composition)
         {
             if (composition is null || !composition.Any(static s => s.Type is JsonSchemaType.Null))
             {
                 // Nothing to patch
-                return (composition, null, false);
+                return (null, false);
             }
 
             var nonNullSchemas = composition
@@ -1114,16 +1109,14 @@ namespace Microsoft.OpenApi
 
                             commonType |= currentType;
                         }
-
-                        commonType |= JsonSchemaType.String;
                     }
                 }
 
-                return (nonNullSchemas, commonType == 0 ? null : commonType, true);
+                return (commonType == 0 ? null : commonType, true);
             }
             else
             {
-                return (null, null, true);
+                return (null, true);
             }
         }
 

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
@@ -16,6 +16,8 @@ namespace Microsoft.OpenApi.Reader.V2
     /// </summary>
     internal static partial class OpenApiV2Deserializer
     {
+        private const string EncounteredNullableExtensionTrueMetadataKey = "encounteredNullable";
+
         private static readonly FixedFieldMap<OpenApiSchema> _openApiSchemaFixedFields = new()
         {
             {
@@ -228,7 +230,7 @@ namespace Microsoft.OpenApi.Reader.V2
                             // If, at a later point during deserialization, Type was set, we apply nullable to it.
                             // Otherwise, we throw it away.
                             o.Metadata ??= new Dictionary<string, object>();
-                            o.Metadata["encounteredNullable"] = true;
+                            o.Metadata[EncounteredNullableExtensionTrueMetadataKey] = true;
                         }
                     }
                 }
@@ -291,9 +293,9 @@ namespace Microsoft.OpenApi.Reader.V2
 
             ParseMap(jsonObject, schema, _openApiSchemaFixedFields, _openApiSchemaPatternFields, hostDocument, context);
 
-            if (schema.Metadata?.TryGetValue("encounteredNullable", out var value) == true)
+            if (schema.Metadata?.TryGetValue(EncounteredNullableExtensionTrueMetadataKey, out var value) == true)
             {
-                schema.Metadata.Remove("encounteredNullable");
+                schema.Metadata.Remove(EncounteredNullableExtensionTrueMetadataKey);
                 if (schema.Type is not null && schema.Type != 0 && value is bool isNullable && isNullable)
                 {
                     schema.Type |= JsonSchemaType.Null;

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
@@ -268,7 +268,16 @@ namespace Microsoft.OpenApi.Reader.V2
 
             ParseMap(jsonObject, schema, _openApiSchemaFixedFields, _openApiSchemaPatternFields, hostDocument, context);
 
-            schema.FinalizeDeserialization(OpenApiSpecVersion.OpenApi2_0);
+            var extensions = schema.Extensions;
+            if (extensions?.TryGetValue(OpenApiConstants.NullableExtension, out var nullExtRawValue) == true &&
+                nullExtRawValue is JsonNodeExtension { Node: JsonNode jsonNode })
+            {
+                extensions.Remove(OpenApiConstants.NullableExtension);
+                if (schema.Type is not null && schema.Type != 0 && jsonNode.GetValueKind() is JsonValueKind.True)
+                {
+                    schema.Type |= JsonSchemaType.Null;
+                }
+            }
 
             return schema;
         }

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
@@ -211,6 +211,29 @@ namespace Microsoft.OpenApi.Reader.V2
                 (o, n, _, _) => o.Default = n
             },
             {
+                OpenApiConstants.NullableExtension,
+                (o, n, _, _) =>
+                {
+                    if (bool.TryParse(n.GetScalarValue(), out var parsed) && parsed)
+                    {
+                        if (o.Type is not null && o.Type != 0)
+                        {
+                            o.Type |= JsonSchemaType.Null;
+                        }
+                        else
+                        {
+                            // We mirror the same behavior of OpenAPI 3.0 "nullable" which is a type modifier.
+                            // It only has effect if there is a "Type" set.
+                            // Given that we don't have a Type set yet, we want to keep track of it until the end of deserialization.
+                            // If, at a later point during deserialization, Type was set, we apply nullable to it.
+                            // Otherwise, we throw it away.
+                            o.Metadata ??= new Dictionary<string, object>();
+                            o.Metadata["encounteredNullable"] = true;
+                        }
+                    }
+                }
+            },
+            {
                 "discriminator", (o, n, _, _) =>
                 {
                     o.Discriminator = new()
@@ -268,12 +291,10 @@ namespace Microsoft.OpenApi.Reader.V2
 
             ParseMap(jsonObject, schema, _openApiSchemaFixedFields, _openApiSchemaPatternFields, hostDocument, context);
 
-            var extensions = schema.Extensions;
-            if (extensions?.TryGetValue(OpenApiConstants.NullableExtension, out var nullExtRawValue) == true &&
-                nullExtRawValue is JsonNodeExtension { Node: JsonNode jsonNode })
+            if (schema.Metadata?.TryGetValue("encounteredNullable", out var value) == true)
             {
-                extensions.Remove(OpenApiConstants.NullableExtension);
-                if (schema.Type is not null && schema.Type != 0 && jsonNode.GetValueKind() is JsonValueKind.True)
+                schema.Metadata.Remove("encounteredNullable");
+                if (schema.Type is not null && schema.Type != 0 && value is bool isNullable && isNullable)
                 {
                     schema.Type |= JsonSchemaType.Null;
                 }

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
@@ -268,7 +268,7 @@ namespace Microsoft.OpenApi.Reader.V2
 
             ParseMap(jsonObject, schema, _openApiSchemaFixedFields, _openApiSchemaPatternFields, hostDocument, context);
 
-            schema.FinalizeDeserialization();
+            schema.FinalizeDeserialization(OpenApiSpecVersion.OpenApi2_0);
 
             return schema;
         }

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
@@ -1,12 +1,12 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using System.Text.Json.Nodes;
-
+using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace Microsoft.OpenApi.Reader.V2
 {
@@ -268,14 +268,16 @@ namespace Microsoft.OpenApi.Reader.V2
 
             ParseMap(jsonObject, schema, _openApiSchemaFixedFields, _openApiSchemaPatternFields, hostDocument, context);
 
-            if (schema.Extensions is not null && schema.Extensions.ContainsKey(OpenApiConstants.NullableExtension))
+            if (schema.Extensions is not null && schema.Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullableExtension))
             {
-                if (schema.Type.HasValue)
-                    schema.Type |= JsonSchemaType.Null;
-                else
-                    schema.Type = JsonSchemaType.Null;
-
+                var isNullable = nullableExtension is JsonNodeExtension { Node: JsonNode jsonNode } && jsonNode.GetValueKind() is JsonValueKind.True;
+                schema.IsNullable = isNullable;
                 schema.Extensions.Remove(OpenApiConstants.NullableExtension);
+            }
+
+            if (schema.IsNullable && schema.Type is not null && schema.Type != 0)
+            {
+                schema.Type |= JsonSchemaType.Null;
             }
 
             return schema;

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
@@ -268,17 +268,7 @@ namespace Microsoft.OpenApi.Reader.V2
 
             ParseMap(jsonObject, schema, _openApiSchemaFixedFields, _openApiSchemaPatternFields, hostDocument, context);
 
-            if (schema.Extensions is not null && schema.Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullableExtension))
-            {
-                var isNullable = nullableExtension is JsonNodeExtension { Node: JsonNode jsonNode } && jsonNode.GetValueKind() is JsonValueKind.True;
-                schema.IsNullable = isNullable;
-                schema.Extensions.Remove(OpenApiConstants.NullableExtension);
-            }
-
-            if (schema.IsNullable && schema.Type is not null && schema.Type != 0)
-            {
-                schema.Type |= JsonSchemaType.Null;
-            }
+            schema.FinalizeDeserialization();
 
             return schema;
         }

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
@@ -225,7 +225,7 @@ namespace Microsoft.OpenApi.Reader.V3
                 {
                     if (bool.TryParse(n.GetScalarValue(), out var parsed) && parsed)
                     {
-                        o.IsNullableFromDeserialization = true;
+                        o.Nullable = true;
                     }
                 }
             },

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
@@ -385,17 +385,7 @@ namespace Microsoft.OpenApi.Reader.V3
 
             ParseMap(jsonObject, schema, _openApiSchemaFixedFields, _openApiSchemaPatternFields, hostDocument, context);
 
-            if (schema.Extensions is not null && schema.Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullableExtension))
-            {
-                var isNullable = nullableExtension is JsonNodeExtension { Node: JsonNode jsonNode } && jsonNode.GetValueKind() is JsonValueKind.True;
-                schema.IsNullable = isNullable;
-                schema.Extensions.Remove(OpenApiConstants.NullableExtension);
-            }
-
-            if (schema.IsNullable && schema.Type is not null && schema.Type != 0)
-            {
-                schema.Type |= JsonSchemaType.Null;
-            }
+            schema.FinalizeDeserialization();
 
             return schema;
         }

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
@@ -385,7 +385,7 @@ namespace Microsoft.OpenApi.Reader.V3
 
             ParseMap(jsonObject, schema, _openApiSchemaFixedFields, _openApiSchemaPatternFields, hostDocument, context);
 
-            schema.FinalizeDeserialization();
+            schema.FinalizeDeserialization(OpenApiSpecVersion.OpenApi3_0);
 
             return schema;
         }

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
@@ -17,8 +17,6 @@ namespace Microsoft.OpenApi.Reader.V3
     /// </summary>
     internal static partial class OpenApiV3Deserializer
     {
-        private static readonly IOpenApiExtension _nullableTrueExtension = new JsonNodeExtension(JsonValue.Create(true));
-
         private static readonly FixedFieldMap<OpenApiSchema> _openApiSchemaFixedFields = new()
         {
             {
@@ -231,15 +229,13 @@ namespace Microsoft.OpenApi.Reader.V3
                         }
                         else
                         {
-                            // While we are dealing with v3 document, we are still using x-nullable extension here.
-                            // This is used only as a marker during deserialization to indicate that the schema is nullable.
-                            // When we complete the deserialization, we will modify the OpenApiSchema.Type to
-                            // include JsonSchemaType.Null (**only if** needed), and always remove the extension.
-                            // The reason is that "nullable" property should only take effect if "Type" is set.
-                            // If we knew Type is set, we add "Null" to it.
-                            // Otherwise, it might be that it will be set later.
-                            // In this case, we add the marker extension, and check at the end of deserialization, and remove the extension.
-                            o.AddExtension(OpenApiConstants.NullableExtension, _nullableTrueExtension);
+                            // "nullable" is a type modifier.
+                            // It only has effect if there is a "Type" set.
+                            // Given that we don't have a Type set yet, we want to keep track of it until the end of deserialization.
+                            // If, at a later point during deserialization, Type was set, we apply nullable to it.
+                            // Otherwise, we throw it away.
+                            o.Metadata ??= new Dictionary<string, object>();
+                            o.Metadata["encounteredNullable"] = true;
                         }
                     }
                 }
@@ -400,15 +396,10 @@ namespace Microsoft.OpenApi.Reader.V3
 
             ParseMap(jsonObject, schema, _openApiSchemaFixedFields, _openApiSchemaPatternFields, hostDocument, context);
 
-            if (schema.Extensions?.TryGetValue(OpenApiConstants.NullableExtension, out var value) == true &&
-                value == _nullableTrueExtension)
+            if (schema.Metadata?.TryGetValue("encounteredNullable", out var value) == true)
             {
-                // If this is "our own" internal _nullableTrueExtension instance, then we know we encountered "nullable": true in the schema
-                // at a point where Type wasn't set yet.
-                // We check now if schema.Type is set.
-                // If it is, we add JsonSchemaType.Null to it.
-                schema.Extensions.Remove(OpenApiConstants.NullableExtension);
-                if (schema.Type is not null && schema.Type != 0)
+                schema.Metadata.Remove("encounteredNullable");
+                if (schema.Type is not null && schema.Type != 0 && value is bool isNullable && isNullable)
                 {
                     schema.Type |= JsonSchemaType.Null;
                 }

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
@@ -1,12 +1,13 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-
-using System.Text.Json.Nodes;
 
 using System;
 using System.Collections.Generic;
+using System.Data.SqlTypes;
 using System.Globalization;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace Microsoft.OpenApi.Reader.V3
 {
@@ -16,6 +17,8 @@ namespace Microsoft.OpenApi.Reader.V3
     /// </summary>
     internal static partial class OpenApiV3Deserializer
     {
+        private static readonly IOpenApiExtension _nullableTrueExtension = new JsonNodeExtension(JsonValue.Create(true));
+
         private static readonly FixedFieldMap<OpenApiSchema> _openApiSchemaFixedFields = new()
         {
             {
@@ -222,10 +225,7 @@ namespace Microsoft.OpenApi.Reader.V3
                 {
                     if (bool.TryParse(n.GetScalarValue(), out var parsed) && parsed)
                     {
-                        if (o.Type.HasValue)
-                            o.Type |= JsonSchemaType.Null;
-                        else
-                            o.Type = JsonSchemaType.Null;
+                        o.IsNullable = true;
                     }
                 }
             },
@@ -385,14 +385,16 @@ namespace Microsoft.OpenApi.Reader.V3
 
             ParseMap(jsonObject, schema, _openApiSchemaFixedFields, _openApiSchemaPatternFields, hostDocument, context);
 
-            if (schema.Extensions is not null && schema.Extensions.ContainsKey(OpenApiConstants.NullableExtension))
+            if (schema.Extensions is not null && schema.Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullableExtension))
             {
-                if (schema.Type.HasValue)
-                    schema.Type |= JsonSchemaType.Null;
-                else
-                    schema.Type = JsonSchemaType.Null;
-
+                var isNullable = nullableExtension is JsonNodeExtension { Node: JsonNode jsonNode } && jsonNode.GetValueKind() is JsonValueKind.True;
+                schema.IsNullable = isNullable;
                 schema.Extensions.Remove(OpenApiConstants.NullableExtension);
+            }
+
+            if (schema.IsNullable && schema.Type is not null && schema.Type != 0)
+            {
+                schema.Type |= JsonSchemaType.Null;
             }
 
             return schema;

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
@@ -225,7 +225,7 @@ namespace Microsoft.OpenApi.Reader.V3
                 {
                     if (bool.TryParse(n.GetScalarValue(), out var parsed) && parsed)
                     {
-                        o.IsNullable = true;
+                        o.IsNullableFromDeserialization = true;
                     }
                 }
             },

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
@@ -225,7 +225,11 @@ namespace Microsoft.OpenApi.Reader.V3
                 {
                     if (bool.TryParse(n.GetScalarValue(), out var parsed) && parsed)
                     {
-                        o.Nullable = true;
+                        // While we are dealing with v3 document, we are still using x-nullable extension here.
+                        // This is used only as a marker during deserialization to indicate that the schema is nullable.
+                        // When we do FinalizeDeserialization, we will modify the OpenApiSchema.Type to
+                        // include JsonSchemaType.Null (only if needed), and always remove the extension.
+                        o.AddExtension(OpenApiConstants.NullableExtension, new JsonNodeExtension(JsonValue.Create(true)));
                     }
                 }
             },

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
@@ -17,6 +17,8 @@ namespace Microsoft.OpenApi.Reader.V3
     /// </summary>
     internal static partial class OpenApiV3Deserializer
     {
+        private const string EncounteredNullableTrueMetadataKey = "encounteredNullable";
+
         private static readonly FixedFieldMap<OpenApiSchema> _openApiSchemaFixedFields = new()
         {
             {
@@ -235,7 +237,7 @@ namespace Microsoft.OpenApi.Reader.V3
                             // If, at a later point during deserialization, Type was set, we apply nullable to it.
                             // Otherwise, we throw it away.
                             o.Metadata ??= new Dictionary<string, object>();
-                            o.Metadata["encounteredNullable"] = true;
+                            o.Metadata[EncounteredNullableTrueMetadataKey] = true;
                         }
                     }
                 }
@@ -396,9 +398,9 @@ namespace Microsoft.OpenApi.Reader.V3
 
             ParseMap(jsonObject, schema, _openApiSchemaFixedFields, _openApiSchemaPatternFields, hostDocument, context);
 
-            if (schema.Metadata?.TryGetValue("encounteredNullable", out var value) == true)
+            if (schema.Metadata?.TryGetValue(EncounteredNullableTrueMetadataKey, out var value) == true)
             {
-                schema.Metadata.Remove("encounteredNullable");
+                schema.Metadata.Remove(EncounteredNullableTrueMetadataKey);
                 if (schema.Type is not null && schema.Type != 0 && value is bool isNullable && isNullable)
                 {
                     schema.Type |= JsonSchemaType.Null;

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
@@ -229,7 +229,7 @@ namespace Microsoft.OpenApi.Reader.V3
                         // This is used only as a marker during deserialization to indicate that the schema is nullable.
                         // When we do FinalizeDeserialization, we will modify the OpenApiSchema.Type to
                         // include JsonSchemaType.Null (only if needed), and always remove the extension.
-                        o.AddExtension(OpenApiConstants.NullableExtension, new JsonNodeExtension(JsonValue.Create(true)));
+                        o.AddExtension(OpenApiConstants.NullableExtension, _nullableTrueExtension);
                     }
                 }
             },

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
@@ -233,8 +233,8 @@ namespace Microsoft.OpenApi.Reader.V3
                         {
                             // While we are dealing with v3 document, we are still using x-nullable extension here.
                             // This is used only as a marker during deserialization to indicate that the schema is nullable.
-                            // When we do FinalizeDeserialization, we will modify the OpenApiSchema.Type to
-                            // include JsonSchemaType.Null (only if needed), and always remove the extension.
+                            // When we complete the deserialization, we will modify the OpenApiSchema.Type to
+                            // include JsonSchemaType.Null (**only if** needed), and always remove the extension.
                             // The reason is that "nullable" property should only take effect if "Type" is set.
                             // If we knew Type is set, we add "Null" to it.
                             // Otherwise, it might be that it will be set later.
@@ -400,7 +400,19 @@ namespace Microsoft.OpenApi.Reader.V3
 
             ParseMap(jsonObject, schema, _openApiSchemaFixedFields, _openApiSchemaPatternFields, hostDocument, context);
 
-            schema.FinalizeDeserialization(OpenApiSpecVersion.OpenApi3_0);
+            if (schema.Extensions?.TryGetValue(OpenApiConstants.NullableExtension, out var value) == true &&
+                value == _nullableTrueExtension)
+            {
+                // If this is "our own" internal _nullableTrueExtension instance, then we know we encountered "nullable": true in the schema
+                // at a point where Type wasn't set yet.
+                // We check now if schema.Type is set.
+                // If it is, we add JsonSchemaType.Null to it.
+                schema.Extensions.Remove(OpenApiConstants.NullableExtension);
+                if (schema.Type is not null && schema.Type != 0)
+                {
+                    schema.Type |= JsonSchemaType.Null;
+                }
+            }
 
             return schema;
         }

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
@@ -225,11 +225,22 @@ namespace Microsoft.OpenApi.Reader.V3
                 {
                     if (bool.TryParse(n.GetScalarValue(), out var parsed) && parsed)
                     {
-                        // While we are dealing with v3 document, we are still using x-nullable extension here.
-                        // This is used only as a marker during deserialization to indicate that the schema is nullable.
-                        // When we do FinalizeDeserialization, we will modify the OpenApiSchema.Type to
-                        // include JsonSchemaType.Null (only if needed), and always remove the extension.
-                        o.AddExtension(OpenApiConstants.NullableExtension, _nullableTrueExtension);
+                        if (o.Type is not null && o.Type != 0)
+                        {
+                            o.Type |= JsonSchemaType.Null;
+                        }
+                        else
+                        {
+                            // While we are dealing with v3 document, we are still using x-nullable extension here.
+                            // This is used only as a marker during deserialization to indicate that the schema is nullable.
+                            // When we do FinalizeDeserialization, we will modify the OpenApiSchema.Type to
+                            // include JsonSchemaType.Null (only if needed), and always remove the extension.
+                            // The reason is that "nullable" property should only take effect if "Type" is set.
+                            // If we knew Type is set, we add "Null" to it.
+                            // Otherwise, it might be that it will be set later.
+                            // In this case, we add the marker extension, and check at the end of deserialization, and remove the extension.
+                            o.AddExtension(OpenApiConstants.NullableExtension, _nullableTrueExtension);
+                        }
                     }
                 }
             },

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
@@ -470,17 +470,7 @@ internal static partial class OpenApiV31Deserializer
                 schema.UnrecognizedKeywords[name] = value;
             });
 
-        if (schema.Extensions is not null && schema.Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullableExtension))
-        {
-            var isNullable = nullableExtension is JsonNodeExtension { Node: JsonNode jsonNode } && jsonNode.GetValueKind() is JsonValueKind.True;
-            schema.IsNullable = isNullable;
-            schema.Extensions.Remove(OpenApiConstants.NullableExtension);
-        }
-
-        if (schema.IsNullable && schema.Type is not null && schema.Type != 0)
-        {
-            schema.Type |= JsonSchemaType.Null;
-        }
+        schema.FinalizeDeserialization();
 
         if (!string.IsNullOrEmpty(identifier) && hostDocument.Workspace is not null)
         {

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
@@ -459,8 +459,6 @@ internal static partial class OpenApiV31Deserializer
                 schema.UnrecognizedKeywords[name] = value;
             });
 
-        schema.FinalizeDeserialization(OpenApiSpecVersion.OpenApi3_1);
-
         if (!string.IsNullOrEmpty(identifier) && hostDocument.Workspace is not null)
         {
             // register the schema in our registry using the identifier's URL

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
@@ -327,17 +327,6 @@ internal static partial class OpenApiV31Deserializer
             (o, n, _, _) => o.Default = n
         },
         {
-            "nullable",
-            (o, n, _, _) =>
-            {
-                var value = n.GetScalarValue();
-                if (value is not null)
-                {
-                    o.IsNullableFromDeserialization = bool.Parse(value);
-                }
-            }
-        },
-        {
             "discriminator",
             (o, n, doc, c) => o.Discriminator = LoadDiscriminator(n, doc, c)
         },
@@ -470,7 +459,7 @@ internal static partial class OpenApiV31Deserializer
                 schema.UnrecognizedKeywords[name] = value;
             });
 
-        schema.FinalizeDeserialization();
+        schema.FinalizeDeserialization(OpenApiSpecVersion.OpenApi3_1);
 
         if (!string.IsNullOrEmpty(identifier) && hostDocument.Workspace is not null)
         {

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
@@ -333,7 +333,7 @@ internal static partial class OpenApiV31Deserializer
                 var value = n.GetScalarValue();
                 if (value is not null)
                 {
-                    o.IsNullable = bool.Parse(value);
+                    o.IsNullableFromDeserialization = bool.Parse(value);
                 }
             }
         },

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.OpenApi.Reader.V31;
@@ -332,14 +333,7 @@ internal static partial class OpenApiV31Deserializer
                 var value = n.GetScalarValue();
                 if (value is not null)
                 {
-                    var nullable = bool.Parse(value);
-                    if (nullable) // if nullable, convert type into an array of type(s) and null
-                    {
-                        if (o.Type.HasValue)
-                            o.Type |= JsonSchemaType.Null;
-                        else
-                            o.Type = JsonSchemaType.Null;
-                    }
+                    o.IsNullable = bool.Parse(value);
                 }
             }
         },
@@ -476,14 +470,16 @@ internal static partial class OpenApiV31Deserializer
                 schema.UnrecognizedKeywords[name] = value;
             });
 
-        if (schema.Extensions is not null && schema.Extensions.ContainsKey(OpenApiConstants.NullableExtension))
+        if (schema.Extensions is not null && schema.Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullableExtension))
         {
-            if (schema.Type.HasValue)
-                schema.Type |= JsonSchemaType.Null;
-            else
-                schema.Type = JsonSchemaType.Null;
-
+            var isNullable = nullableExtension is JsonNodeExtension { Node: JsonNode jsonNode } && jsonNode.GetValueKind() is JsonValueKind.True;
+            schema.IsNullable = isNullable;
             schema.Extensions.Remove(OpenApiConstants.NullableExtension);
+        }
+
+        if (schema.IsNullable && schema.Type is not null && schema.Type != 0)
+        {
+            schema.Type |= JsonSchemaType.Null;
         }
 
         if (!string.IsNullOrEmpty(identifier) && hostDocument.Workspace is not null)

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
@@ -470,17 +470,7 @@ internal static partial class OpenApiV32Deserializer
                 schema.UnrecognizedKeywords[name] = value;
             });
 
-        if (schema.Extensions is not null && schema.Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullableExtension))
-        {
-            var isNullable = nullableExtension is JsonNodeExtension { Node: JsonNode jsonNode } && jsonNode.GetValueKind() is JsonValueKind.True;
-            schema.IsNullable = isNullable;
-            schema.Extensions.Remove(OpenApiConstants.NullableExtension);
-        }
-
-        if (schema.IsNullable && schema.Type is not null && schema.Type != 0)
-        {
-            schema.Type |= JsonSchemaType.Null;
-        }
+        schema.FinalizeDeserialization();
 
         if (!string.IsNullOrEmpty(identifier) && hostDocument.Workspace is not null)
         {

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.OpenApi.Reader.V32;
@@ -332,14 +333,7 @@ internal static partial class OpenApiV32Deserializer
                 var value = n.GetScalarValue();
                 if (value is not null)
                 {
-                    var nullable = bool.Parse(value);
-                    if (nullable) // if nullable, convert type into an array of type(s) and null
-                    {
-                        if (o.Type.HasValue)
-                            o.Type |= JsonSchemaType.Null;
-                        else
-                            o.Type = JsonSchemaType.Null;
-                    }
+                    o.IsNullable = bool.Parse(value);
                 }
             }
         },
@@ -476,14 +470,16 @@ internal static partial class OpenApiV32Deserializer
                 schema.UnrecognizedKeywords[name] = value;
             });
 
-        if (schema.Extensions is not null && schema.Extensions.ContainsKey(OpenApiConstants.NullableExtension))
+        if (schema.Extensions is not null && schema.Extensions.TryGetValue(OpenApiConstants.NullableExtension, out var nullableExtension))
         {
-            if (schema.Type.HasValue)
-                schema.Type |= JsonSchemaType.Null;
-            else
-                schema.Type = JsonSchemaType.Null;
-
+            var isNullable = nullableExtension is JsonNodeExtension { Node: JsonNode jsonNode } && jsonNode.GetValueKind() is JsonValueKind.True;
+            schema.IsNullable = isNullable;
             schema.Extensions.Remove(OpenApiConstants.NullableExtension);
+        }
+
+        if (schema.IsNullable && schema.Type is not null && schema.Type != 0)
+        {
+            schema.Type |= JsonSchemaType.Null;
         }
 
         if (!string.IsNullOrEmpty(identifier) && hostDocument.Workspace is not null)

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
@@ -459,8 +459,6 @@ internal static partial class OpenApiV32Deserializer
                 schema.UnrecognizedKeywords[name] = value;
             });
 
-        schema.FinalizeDeserialization(OpenApiSpecVersion.OpenApi3_2);
-
         if (!string.IsNullOrEmpty(identifier) && hostDocument.Workspace is not null)
         {
             // register the schema in our registry using the identifier's URL

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
@@ -327,17 +327,6 @@ internal static partial class OpenApiV32Deserializer
             (o, n, _, _) => o.Default = n
         },
         {
-            "nullable",
-            (o, n, _, _) =>
-            {
-                var value = n.GetScalarValue();
-                if (value is not null)
-                {
-                    o.IsNullableFromDeserialization = bool.Parse(value);
-                }
-            }
-        },
-        {
             "discriminator",
             (o, n, doc, c) => o.Discriminator = LoadDiscriminator(n, doc, c)
         },
@@ -470,7 +459,7 @@ internal static partial class OpenApiV32Deserializer
                 schema.UnrecognizedKeywords[name] = value;
             });
 
-        schema.FinalizeDeserialization();
+        schema.FinalizeDeserialization(OpenApiSpecVersion.OpenApi3_2);
 
         if (!string.IsNullOrEmpty(identifier) && hostDocument.Workspace is not null)
         {

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
@@ -333,7 +333,7 @@ internal static partial class OpenApiV32Deserializer
                 var value = n.GetScalarValue();
                 if (value is not null)
                 {
-                    o.IsNullable = bool.Parse(value);
+                    o.IsNullableFromDeserialization = bool.Parse(value);
                 }
             }
         },

--- a/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V2Tests/OpenApiSchemaTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
@@ -173,8 +173,10 @@ x-nullable: true";
         [Fact]
         public async Task SerializeSchemaWithOnlyNullableShouldSucceed()
         {
+            // NOTE: x-nullable extension has no effect on the schema if type is not specified, so it is omitted in the serialized output.
+
             // Arrange
-            var expected = @"x-nullable: true";
+            var expected = @"{ }";
 
             var path = Path.Combine(SampleFolderPath, "schemaWithOnlyNullableExtension.yaml");
 

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiSchemaTests.cs
@@ -141,13 +141,15 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
         [Theory]
         [InlineData(@"{ ""nullable"": true, ""type"": ""string"" }")]
         [InlineData(@"{ ""type"": ""string"", ""nullable"": true }")]
-        public void ParseSchemaWithNullableBeforeOrAfterTypePreservesNullFlag(string schemaJson)
+        public void ParseSchemaWithNullableBeforeOrAfterTypeDoesNotPreserveNullFlag(string schemaJson)
         {
+            // "nullable" is only for 3.0.
+
             // Act
             var schema = OpenApiModelFactory.Parse<OpenApiSchema>(schemaJson, OpenApiSpecVersion.OpenApi3_1, new(), out _, "json", SettingsFixture.ReaderSettings);
 
             // Assert
-            Assert.Equal(JsonSchemaType.String | JsonSchemaType.Null, schema.Type);
+            Assert.Equal(JsonSchemaType.String, schema.Type);
         }
 
         [Fact]
@@ -517,7 +519,7 @@ x-nullable: true";
 - ""int""
 nullable: true";
 
-            var expected = @"x-nullable: true";
+            var expected = @"{ }";
 
             var schema = OpenApiModelFactory.Parse<OpenApiSchema>(input, OpenApiSpecVersion.OpenApi3_1, new(), out _, "yaml", SettingsFixture.ReaderSettings);
 
@@ -531,8 +533,10 @@ nullable: true";
         [Theory]
         [InlineData("schemaWithNullable.yaml")]
         [InlineData("schemaWithNullableExtension.yaml")]
-        public async Task LoadSchemaWithNullableExtensionAsV31Works(string filePath)
+        public async Task LoadSchemaWithNullableExtensionAsV31ShouldNotWork(string filePath)
         {
+            // "nullable" is only for 3.0.
+            // and "x-nullable" is only for 2.0.
             // Arrange
             var path = Path.Combine(SampleFolderPath, filePath);
 
@@ -540,7 +544,7 @@ nullable: true";
             var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_1, new(), SettingsFixture.ReaderSettings);
 
             // Assert
-            Assert.Equal(JsonSchemaType.String | JsonSchemaType.Null, schema.Type);
+            Assert.Equal(JsonSchemaType.String, schema.Type);
         }
 
         [Fact]

--- a/test/Microsoft.OpenApi.Readers.Tests/V32Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V32Tests/OpenApiSchemaTests.cs
@@ -140,13 +140,15 @@ namespace Microsoft.OpenApi.Readers.Tests.V32Tests
         [Theory]
         [InlineData(@"{ ""nullable"": true, ""type"": ""string"" }")]
         [InlineData(@"{ ""type"": ""string"", ""nullable"": true }")]
-        public void ParseSchemaWithNullableBeforeOrAfterTypePreservesNullFlag(string schemaJson)
+        public void ParseSchemaWithNullableBeforeOrAfterTypeDoesNotPreserveNullFlag(string schemaJson)
         {
+            // "nullable" is only for 3.0.
+
             // Act
             var schema = OpenApiModelFactory.Parse<OpenApiSchema>(schemaJson, OpenApiSpecVersion.OpenApi3_2, new(), out _, "json", SettingsFixture.ReaderSettings);
 
             // Assert
-            Assert.Equal(JsonSchemaType.String | JsonSchemaType.Null, schema.Type);
+            Assert.Equal(JsonSchemaType.String, schema.Type);
         }
 
         [Fact]
@@ -419,7 +421,7 @@ x-nullable: true";
 - ""int""
 nullable: true";
 
-            var expected = @"x-nullable: true";
+            var expected = @"{ }";
 
             var schema = OpenApiModelFactory.Parse<OpenApiSchema>(input, OpenApiSpecVersion.OpenApi3_2, new(), out _, "yaml", SettingsFixture.ReaderSettings);
 
@@ -433,8 +435,11 @@ nullable: true";
         [Theory]
         [InlineData("schemaWithNullable.yaml")]
         [InlineData("schemaWithNullableExtension.yaml")]
-        public async Task LoadSchemaWithNullableExtensionAsV32Works(string filePath)
+        public async Task LoadSchemaWithNullableExtensionAsV32ShouldNotWork(string filePath)
         {
+            // "nullable" is only for 3.0.
+            // and "x-nullable" is only for 2.0.
+
             // Arrange
             var path = Path.Combine(SampleFolderPath, filePath);
 
@@ -442,7 +447,7 @@ nullable: true";
             var schema = await OpenApiModelFactory.LoadAsync<OpenApiSchema>(path, OpenApiSpecVersion.OpenApi3_2, new(), SettingsFixture.ReaderSettings);
 
             // Assert
-            Assert.Equal(JsonSchemaType.String | JsonSchemaType.Null, schema.Type);
+            Assert.Equal(JsonSchemaType.String, schema.Type);
         }
 
         [Fact]

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiSchemaTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
 using System.Collections.Generic;
@@ -532,8 +532,9 @@ nullable: true";
         [Fact]
         public async Task SerializeSchemaWithOnlyNullableShouldSucceed()
         {
+            // NOTE: nullable property has no effect on the schema if type is not specified, so it is omitted in the serialized output.
             // Arrange
-            var expected = @"nullable: true";
+            var expected = @"{ }";
 
             var path = Path.Combine(SampleFolderPath, "schemaWithOnlyNullable.yaml");
 

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -962,6 +962,11 @@ namespace Microsoft.OpenApi.Tests.Models
                   "type": "string",
                   "oneOf": [
                     {
+                      "enum": [
+                        null
+                      ]
+                    },
+                    {
                       "maxLength": 10,
                       "type": "string"
                     }
@@ -1002,13 +1007,17 @@ namespace Microsoft.OpenApi.Tests.Models
                 {
                   "oneOf": [
                     {
+                      "enum": [
+                        null
+                      ]
+                    },
+                    {
                       "type": "string"
                     },
                     {
                       "type": "number"
                     }
-                  ],
-                  "nullable": true
+                  ]
                 }
                 """;
 
@@ -1050,6 +1059,11 @@ namespace Microsoft.OpenApi.Tests.Models
                 {
                   "type": "object",
                   "anyOf": [
+                    {
+                      "enum": [
+                        null
+                      ]
+                    },
                     {
                       "type": "object",
                       "properties": {
@@ -1094,14 +1108,18 @@ namespace Microsoft.OpenApi.Tests.Models
                 {
                   "anyOf": [
                     {
+                      "enum": [
+                        null
+                      ]
+                    },
+                    {
                       "minLength": 1,
                       "type": "string"
                     },
                     {
                       "type": "integer"
                     }
-                  ],
-                  "nullable": true
+                  ]
                 }
                 """;
 
@@ -1133,7 +1151,13 @@ namespace Microsoft.OpenApi.Tests.Models
             var expectedV3Schema =
                 """
                 {
-                  "nullable": true
+                  "oneOf": [
+                    {
+                      "enum": [
+                        null
+                      ]
+                    }
+                  ]
                 }
                 """;
 
@@ -1232,6 +1256,11 @@ namespace Microsoft.OpenApi.Tests.Models
                 {
                   "type": "object",
                   "oneOf": [
+                    {
+                      "enum": [
+                        null
+                      ]
+                    },
                     {
                       "$ref": "#/components/schemas/Pet"
                     }
@@ -1874,9 +1903,13 @@ namespace Microsoft.OpenApi.Tests.Models
                   "oneOf": [
                     {
                       "enum": [
-                        "A",
-                        "B",
                         null
+                      ]
+                    },
+                    {
+                      "enum": [
+                        "A",
+                        "B"
                       ]
                     }
                   ],
@@ -1912,6 +1945,37 @@ namespace Microsoft.OpenApi.Tests.Models
             Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(result)));
         }
 
+        [Fact]
+        public async Task SerializeNullableTypeWith3_0()
+        {
+            var schema = CreateTypeNullSchema();
+            var result = await schema.SerializeAsJsonAsync(OpenApiSpecVersion.OpenApi3_0);
+            var expected = """
+                {
+                  "enum": [
+                    null
+                  ]
+                }
+                """;
+
+            Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(result)));
+        }
+
+        [Theory]
+        [InlineData(OpenApiSpecVersion.OpenApi3_1)]
+        [InlineData(OpenApiSpecVersion.OpenApi3_2)]
+        public async Task SerializeNullableTypeWith3_1_And_Later(OpenApiSpecVersion version)
+        {
+            var schema = CreateTypeNullSchema();
+            var result = await schema.SerializeAsJsonAsync(version);
+            var expected = """
+                {
+                  "type": "null"
+                }
+                """;
+            Assert.True(JsonNode.DeepEquals(JsonNode.Parse(expected), JsonNode.Parse(result)));
+        }
+
         private OpenApiSchema CreateNullableEnumSchema()
         {
             var schema = new OpenApiSchema();
@@ -1925,6 +1989,13 @@ namespace Microsoft.OpenApi.Tests.Models
                     JsonValue.Create("B")
                 }
             });
+            return schema;
+        }
+
+        private OpenApiSchema CreateTypeNullSchema()
+        {
+            var schema = new OpenApiSchema();
+            schema.Type = JsonSchemaType.Null;
             return schema;
         }
 

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiSchemaTests.cs
@@ -959,7 +959,6 @@ namespace Microsoft.OpenApi.Tests.Models
             var expectedV3Schema =
                 """
                 {
-                  "type": "string",
                   "oneOf": [
                     {
                       "enum": [
@@ -970,8 +969,7 @@ namespace Microsoft.OpenApi.Tests.Models
                       "maxLength": 10,
                       "type": "string"
                     }
-                  ],
-                  "nullable": true
+                  ]
                 }
                 """;
 
@@ -1057,7 +1055,6 @@ namespace Microsoft.OpenApi.Tests.Models
             var expectedV3Schema =
                 """
                 {
-                  "type": "object",
                   "anyOf": [
                     {
                       "enum": [
@@ -1072,8 +1069,7 @@ namespace Microsoft.OpenApi.Tests.Models
                         }
                       }
                     }
-                  ],
-                  "nullable": true
+                  ]
                 }
                 """;
             // Assert
@@ -1254,7 +1250,6 @@ namespace Microsoft.OpenApi.Tests.Models
             var expectedV3Schema =
                 """
                 {
-                  "type": "object",
                   "oneOf": [
                     {
                       "enum": [
@@ -1264,8 +1259,7 @@ namespace Microsoft.OpenApi.Tests.Models
                     {
                       "$ref": "#/components/schemas/Pet"
                     }
-                  ],
-                  "nullable": true
+                  ]
                 }
                 """;
 
@@ -1899,7 +1893,6 @@ namespace Microsoft.OpenApi.Tests.Models
             var result = await schema.SerializeAsJsonAsync(OpenApiSpecVersion.OpenApi3_0);
             var expected = """
                 {
-                  "type": "string",
                   "oneOf": [
                     {
                       "enum": [
@@ -1912,8 +1905,7 @@ namespace Microsoft.OpenApi.Tests.Models
                         "B"
                       ]
                     }
-                  ],
-                  "nullable": true
+                  ]
                 }
                 """;
 


### PR DESCRIPTION
My previous PR was trying to handle nullability for enums specifically. This PR is more generalized to handle nulls more correctly as it was still buggy for non-enums.

In addition, the previous fix for enums didn't also fix all enum scenarios. It only fixed it when we are given "oneOf (null, schemaWithEnum)". But if we are given a schema reference instead, we are not going to add "null" to the reference and we will produce the wrong thing.

I'll leave comments on some specific updated tests to explain.