### PR TITLE
PERF: Reduce boxing allocations in GetScalarValue

### DIFF
--- a/src/Microsoft.OpenApi.YamlReader/YamlConverter.cs
+++ b/src/Microsoft.OpenApi.YamlReader/YamlConverter.cs
@@ -130,7 +130,9 @@ namespace Microsoft.OpenApi.YamlReader
         {
             return yaml.Style switch
             {
-                ScalarStyle.Plain when decimal.TryParse(yaml.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var d) => JsonValue.Create(d),
+                // JsonNode.Parse will create a JsonValue that is suitable for representing any numeric value (it's wrapping JsonElement).
+                // So, if we call '.TryGetValue<int>' on it and the underlying value can be represented as int, it will succeed.
+                ScalarStyle.Plain when decimal.TryParse(yaml.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var d) => (JsonNode.Parse(yaml.Value) as JsonValue) ?? JsonValue.Create(d),
                 ScalarStyle.Plain when bool.TryParse(yaml.Value, out var b) => JsonValue.Create(b),
                 ScalarStyle.Plain when YamlNullRepresentations.Contains(yaml.Value) => (JsonValue)JsonNullSentinel.JsonNull.DeepClone(),
                 ScalarStyle.Plain => JsonValue.Create(yaml.Value),

--- a/src/Microsoft.OpenApi/Reader/JsonNodeHelper.cs
+++ b/src/Microsoft.OpenApi/Reader/JsonNodeHelper.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.OpenApi.Reader
@@ -169,6 +170,51 @@ namespace Microsoft.OpenApi.Reader
             }
 
             return Convert.ToString(scalarNode.GetValue<object>(), CultureInfo.InvariantCulture);
+        }
+
+        public static bool GetScalarBoolValue(this JsonNode? node)
+        {
+            var scalarNode = node is JsonValue value ? value : throw new OpenApiException("Expected scalar value.");
+            return scalarNode.GetValue<bool>();
+        }
+
+        public static int GetScalarIntValue(this JsonNode? node)
+        {
+            var scalarNode = node is JsonValue value && value.GetValueKind() == JsonValueKind.Number ? value : throw new OpenApiException("Expected numeric scalar value.");
+
+            if (scalarNode.TryGetValue<int>(out var intValue))
+            {
+                return intValue;
+            }
+            else if (scalarNode.TryGetValue<long>(out var longValue))
+            {
+                return (int)longValue;
+            }
+            else if (scalarNode.TryGetValue<decimal>(out var decimalValue))
+            {
+                return (int)decimalValue;
+            }
+
+            return Convert.ToInt32(scalarNode.GetValue<object>());
+        }
+
+        public static uint GetScalarUIntValue(this JsonNode? node)
+        {
+            var scalarNode = node is JsonValue value && value.GetValueKind() == JsonValueKind.Number ? value : throw new OpenApiException("Expected numeric scalar value.");
+            if (scalarNode.TryGetValue<uint>(out var uintValue))
+            {
+                return uintValue;
+            }
+            else if (scalarNode.TryGetValue<ulong>(out var ulongValue))
+            {
+                return (uint)ulongValue;
+            }
+            else if (scalarNode.TryGetValue<decimal>(out var decimalValue))
+            {
+                return (uint)decimalValue;
+            }
+
+            return Convert.ToUInt32(scalarNode.GetValue<object>());
         }
 
         public static string? GetReferencePointer(this JsonObject jsonObject)

--- a/src/Microsoft.OpenApi/Reader/JsonNodeHelper.cs
+++ b/src/Microsoft.OpenApi/Reader/JsonNodeHelper.cs
@@ -186,14 +186,6 @@ namespace Microsoft.OpenApi.Reader
             {
                 return intValue;
             }
-            else if (scalarNode.TryGetValue<long>(out var longValue))
-            {
-                return (int)longValue;
-            }
-            else if (scalarNode.TryGetValue<decimal>(out var decimalValue))
-            {
-                return (int)decimalValue;
-            }
 
             return Convert.ToInt32(scalarNode.GetValue<object>());
         }
@@ -204,14 +196,6 @@ namespace Microsoft.OpenApi.Reader
             if (scalarNode.TryGetValue<uint>(out var uintValue))
             {
                 return uintValue;
-            }
-            else if (scalarNode.TryGetValue<ulong>(out var ulongValue))
-            {
-                return (uint)ulongValue;
-            }
-            else if (scalarNode.TryGetValue<decimal>(out var decimalValue))
-            {
-                return (uint)decimalValue;
             }
 
             return Convert.ToUInt32(scalarNode.GetValue<object>());

--- a/src/Microsoft.OpenApi/Reader/JsonNodeHelper.cs
+++ b/src/Microsoft.OpenApi/Reader/JsonNodeHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -158,6 +158,15 @@ namespace Microsoft.OpenApi.Reader
         public static string? GetScalarValue(this JsonNode? node)
         {
             var scalarNode = node is JsonValue value ? value : throw new OpenApiException("Expected scalar value.");
+
+            // It's much more efficient to call scalarNode.TryGetValue<string> than to call scalarNode.GetValue<object>() and then convert to string.
+            // When asking for "object" type, if scalarNode is JsonValueOfElement (internal type in STJ), we will get back
+            // a boxed JsonElement (paying the cost of unnecessary boxing allocation), and we then call JsonElement.ToString.
+            // So, we first check if we can get the string value directly, and only if that fails, we fallback to the expensive code.
+            if (scalarNode.TryGetValue<string>(out var stringValue))
+            {
+                return stringValue;
+            }
 
             return Convert.ToString(scalarNode.GetValue<object>(), CultureInfo.InvariantCulture);
         }

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiHeaderDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Text.Json.Nodes;
@@ -67,7 +67,7 @@ namespace Microsoft.OpenApi.Reader.V2
             },
             {
                 "exclusiveMaximum",
-                (o, n, _, _) => GetOrCreateSchema(o).IsExclusiveMaximum = bool.Parse(n.GetScalarValue()!)
+                (o, n, _, _) => GetOrCreateSchema(o).IsExclusiveMaximum = n.GetScalarBoolValue()
             },
             {
                 "minimum",
@@ -76,34 +76,26 @@ namespace Microsoft.OpenApi.Reader.V2
                     var min = n.GetScalarValue();
                     if (!string.IsNullOrEmpty(min))
                     {
-                        GetOrCreateSchema(o).Minimum = min; 
-                    } 
+                        GetOrCreateSchema(o).Minimum = min;
+                    }
                 }
             },
             {
                 "exclusiveMinimum",
-                (o, n, _, _) => GetOrCreateSchema(o).IsExclusiveMinimum = bool.Parse(n.GetScalarValue()!)
+                (o, n, _, _) => GetOrCreateSchema(o).IsExclusiveMinimum = n.GetScalarBoolValue()
             },
             {
                 "maxLength",
                 (o, n, _, _) =>
                 {
-                    var maxLength = n.GetScalarValue();
-                    if (maxLength != null)
-                    {
-                        GetOrCreateSchema(o).MaxLength = int.Parse(maxLength, CultureInfo.InvariantCulture);
-                    }
+                    GetOrCreateSchema(o).MaxLength = n.GetScalarIntValue();
                 }
             },
             {
                 "minLength",
                 (o, n, _, _) =>
                 {
-                    var minLength = n.GetScalarValue();
-                    if (minLength != null)
-                    {
-                        GetOrCreateSchema(o).MinLength = int.Parse(minLength, CultureInfo.InvariantCulture); 
-                    }
+                    GetOrCreateSchema(o).MinLength = n.GetScalarIntValue();
                 }
             },
             {
@@ -114,33 +106,21 @@ namespace Microsoft.OpenApi.Reader.V2
                 "maxItems",
                 (o, n, _, _) =>
                 {
-                    var maxItems = n.GetScalarValue();
-                    if (maxItems != null)
-                    {
-                        GetOrCreateSchema(o).MaxItems = int.Parse(maxItems, CultureInfo.InvariantCulture);
-                    }
+                    GetOrCreateSchema(o).MaxItems = n.GetScalarIntValue();
                 }
             },
             {
                 "minItems",
                 (o, n, _, _) =>
                 {
-                    var minItems = n.GetScalarValue();
-                    if (minItems != null)
-                    {
-                        GetOrCreateSchema(o).MinItems = int.Parse(minItems, CultureInfo.InvariantCulture);
-                    }
+                    GetOrCreateSchema(o).MinItems = n.GetScalarIntValue();
                 }
             },
             {
                 "uniqueItems",
                 (o, n, _, _) =>
                 {
-                    var uniqueItems = n.GetScalarValue();
-                    if (uniqueItems != null)
-                    {
-                        GetOrCreateSchema(o).UniqueItems = bool.Parse(uniqueItems);
-                    }
+                    GetOrCreateSchema(o).UniqueItems = n.GetScalarBoolValue();
                 }
             },
             {

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiOperationDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
@@ -82,11 +82,7 @@ namespace Microsoft.OpenApi.Reader.V2
                     "deprecated",
                     (o, n, _, _) =>
                     {
-                        var deprecated = n.GetScalarValue();
-                        if (deprecated != null)
-                        {
-                            o.Deprecated = bool.Parse(deprecated);
-                        }
+                        o.Deprecated = n.GetScalarBoolValue();
                     }
                 },
                 {

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiParameterDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Text.Json.Nodes;
@@ -34,33 +34,21 @@ namespace Microsoft.OpenApi.Reader.V2
                     "required",
                     (o, n, _, _) =>
                     {
-                        var required = n.GetScalarValue();
-                        if (required != null)
-                        {
-                            o.Required = bool.Parse(required);
-                        }
+                        o.Required = n.GetScalarBoolValue();
                     }
                 },
                 {
                     "deprecated",
                     (o, n, _, _) =>
                     {
-                        var deprecated = n.GetScalarValue();
-                        if (deprecated != null)
-                        {
-                            o.Deprecated = bool.Parse(deprecated);
-                        }
+                        o.Deprecated = n.GetScalarBoolValue();
                     }
                 },
                 {
                     "allowEmptyValue",
                     (o, n, _, _) =>
                     {
-                        var allowEmptyValue = n.GetScalarValue();
-                        if (allowEmptyValue != null)
-                        {
-                            o.AllowEmptyValue = bool.Parse(allowEmptyValue);
-                        }
+                        o.AllowEmptyValue = n.GetScalarBoolValue();
                     }
                 },
                 {
@@ -124,33 +112,21 @@ namespace Microsoft.OpenApi.Reader.V2
                     "maxLength",
                     (o, n, _, _) =>
                     {
-                        var maxLength = n.GetScalarValue();
-                        if (maxLength != null)
-                        {
-                            GetOrCreateSchema(o).MaxLength = int.Parse(maxLength, CultureInfo.InvariantCulture);
-                        }
+                        GetOrCreateSchema(o).MaxLength = n.GetScalarIntValue();
                     }
                 },
                 {
                     "minLength",
                     (o, n, _, _) =>
                     {
-                        var minLength = n.GetScalarValue();
-                        if (minLength != null)
-                        {
-                            GetOrCreateSchema(o).MinLength = int.Parse(minLength, CultureInfo.InvariantCulture);
-                        }
+                        GetOrCreateSchema(o).MinLength = n.GetScalarIntValue();
                     }
                 },
                 {
                     "readOnly",
                     (o, n, _, _) =>
                     {
-                        var readOnly = n.GetScalarValue();
-                        if (readOnly != null)
-                        {
-                            GetOrCreateSchema(o).ReadOnly = bool.Parse(readOnly);
-                        }
+                        GetOrCreateSchema(o).ReadOnly = n.GetScalarBoolValue();
                     }
                 },
                 {

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiSchemaDeserializer.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OpenApi.Reader.V2
             },
             {
                 "exclusiveMaximum",
-                (o, n, _, _) => o.IsExclusiveMaximum = bool.Parse(n.GetScalarValue()!)
+                (o, n, _, _) => o.IsExclusiveMaximum = n.GetScalarBoolValue()
             },
             {
                 "minimum",
@@ -63,7 +63,7 @@ namespace Microsoft.OpenApi.Reader.V2
             },
             {
                 "exclusiveMinimum",
-                (o, n, _, _) => o.IsExclusiveMinimum = bool.Parse(n.GetScalarValue()!)
+                (o, n, _, _) => o.IsExclusiveMinimum = n.GetScalarBoolValue()
             },
             {
                 "maxLength",
@@ -72,7 +72,7 @@ namespace Microsoft.OpenApi.Reader.V2
                     var maxLength = n.GetScalarValue();
                     if (maxLength != null)
                     {
-                        o.MaxLength = int.Parse(maxLength, CultureInfo.InvariantCulture);
+                        o.MaxLength = n.GetScalarIntValue();
                     }
                 }
             },
@@ -80,11 +80,7 @@ namespace Microsoft.OpenApi.Reader.V2
                 "minLength",
                 (o, n, _, _) =>
                 {
-                    var minLength = n.GetScalarValue();
-                    if (minLength != null)
-                    {
-                        o.MinLength = int.Parse(minLength, CultureInfo.InvariantCulture);
-                    }
+                    o.MinLength = n.GetScalarIntValue();
                 }
             },
             {
@@ -95,55 +91,35 @@ namespace Microsoft.OpenApi.Reader.V2
                 "maxItems",
                 (o, n, _, _) =>
                 {
-                    var maxItems = n.GetScalarValue();
-                    if (maxItems != null)
-                    {
-                        o.MaxItems = int.Parse(maxItems, CultureInfo.InvariantCulture);
-                    }
+                    o.MaxItems = n.GetScalarIntValue();
                 }
             },
             {
                 "minItems",
                 (o, n, _, _) =>
                 {
-                    var minItems = n.GetScalarValue();
-                    if (minItems != null)
-                    {
-                        o.MinItems = int.Parse(minItems, CultureInfo.InvariantCulture);
-                    }
+                    o.MinItems = n.GetScalarIntValue();
                 }
             },
             {
                 "uniqueItems",
                 (o, n, _, _) =>
                 {
-                    var uniqueItems = n.GetScalarValue();
-                    if (uniqueItems != null)
-                    {
-                        o.UniqueItems = bool.Parse(uniqueItems);
-                    }
+                    o.UniqueItems = n.GetScalarBoolValue();
                 }
             },
             {
                 "maxProperties",
                 (o, n, _, _) =>
                 {
-                    var maxProps = n.GetScalarValue();
-                    if (maxProps != null)
-                    {
-                        o.MaxProperties = int.Parse(maxProps, CultureInfo.InvariantCulture);
-                    }
+                    o.MaxProperties = n.GetScalarIntValue();
                 }
             },
             {
                 "minProperties",
                 (o, n, _, _) =>
                 {
-                    var minProps = n.GetScalarValue();
-                    if (minProps != null)
-                    {
-                        o.MinProperties = int.Parse(minProps, CultureInfo.InvariantCulture);
-                    }
+                    o.MinProperties = n.GetScalarIntValue();
                 }
             },
             {
@@ -188,11 +164,7 @@ namespace Microsoft.OpenApi.Reader.V2
                 {
                     if (n is JsonValue)
                     {
-                        var value = n.GetScalarValue();
-                        if (value is not null)
-                        {
-                            o.AdditionalPropertiesAllowed = bool.Parse(value);
-                        }
+                        o.AdditionalPropertiesAllowed = n.GetScalarBoolValue();
                     }
                     else
                     {
@@ -216,7 +188,7 @@ namespace Microsoft.OpenApi.Reader.V2
                 OpenApiConstants.NullableExtension,
                 (o, n, _, _) =>
                 {
-                    if (bool.TryParse(n.GetScalarValue(), out var parsed) && parsed)
+                    if (n.GetScalarBoolValue())
                     {
                         if (o.Type is not null && o.Type != 0)
                         {
@@ -248,11 +220,7 @@ namespace Microsoft.OpenApi.Reader.V2
                 "readOnly",
                 (o, n, _, _) =>
                 {
-                    var readOnly = n.GetScalarValue();
-                    if (readOnly is not null)
-                    {
-                        o.ReadOnly = bool.Parse(readOnly);
-                    }
+                    o.ReadOnly = n.GetScalarBoolValue();
                 }
             },
             {

--- a/src/Microsoft.OpenApi/Reader/V2/OpenApiXmlDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V2/OpenApiXmlDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Text.Json.Nodes;
@@ -41,26 +41,18 @@ namespace Microsoft.OpenApi.Reader.V2
                 "attribute",
                 (o, n, _, _) =>
                 {
-                    var attribute = n.GetScalarValue();
-                    if (attribute is not null)
-                    {
 #pragma warning disable CS0618 // Type or member is obsolete
-                        o.Attribute = bool.Parse(attribute);
+                    o.Attribute = n.GetScalarBoolValue();
 #pragma warning restore CS0618 // Type or member is obsolete
-                    }
                 }
             },
             {
                 "wrapped",
                 (o, n, _, _) =>
                 {
-                    var wrapped = n.GetScalarValue();
-                    if (wrapped is not null)
-                    {
 #pragma warning disable CS0618 // Type or member is obsolete
-                        o.Wrapped = bool.Parse(wrapped);
+                    o.Wrapped = n.GetScalarBoolValue();
 #pragma warning restore CS0618 // Type or member is obsolete
-                    }
                 }
             },
         };

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiEncodingDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiEncodingDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Text.Json.Nodes;
@@ -38,22 +38,14 @@ namespace Microsoft.OpenApi.Reader.V3
                 "explode",
                 (o, n, _, _) =>
                 {
-                    var explode = n.GetScalarValue();
-                    if (explode != null)
-                    {
-                        o.Explode = bool.Parse(explode);
-                    }
+                    o.Explode = n.GetScalarBoolValue();
                 }
             },
             {
                 "allowReserved", 
                 (o, n, _, _) =>
                 {
-                    var allowReserved = n.GetScalarValue();
-                    if (allowReserved != null)
-                    {
-                         o.AllowReserved = bool.Parse(allowReserved);
-                     }
+                    o.AllowReserved = n.GetScalarBoolValue();
                 }
             },
         };

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiHeaderDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Text.Json.Nodes;
@@ -23,44 +23,28 @@ namespace Microsoft.OpenApi.Reader.V3
                 "required",
                 (o, n, _, _) =>
                 {
-                    var required = n.GetScalarValue();
-                    if (required != null)
-                    {
-                        o.Required = bool.Parse(required);
-                    }
+                    o.Required = n.GetScalarBoolValue();
                 }
             },
             {
                 "deprecated",
                 (o, n, _, _) =>
                 {
-                    var deprecated = n.GetScalarValue();
-                    if (deprecated != null)
-                    {
-                        o.Deprecated = bool.Parse(deprecated);
-                    }
+                    o.Deprecated = n.GetScalarBoolValue();
                 }
             },
             {
                 "allowEmptyValue",
                 (o, n, _, _) =>
                 {
-                    var allowEmptyVal = n.GetScalarValue();
-                    if (allowEmptyVal != null)
-                    {
-                        o.AllowEmptyValue = bool.Parse(allowEmptyVal);
-                    }
+                    o.AllowEmptyValue = n.GetScalarBoolValue();
                 }
             },
             {
                 "allowReserved",
                 (o, n, _, _) =>
                 {
-                    var allowReserved = n.GetScalarValue();
-                    if (allowReserved != null)
-                    {
-                        o.AllowReserved = bool.Parse(allowReserved);
-                    }
+                    o.AllowReserved = n.GetScalarBoolValue();
                 }
             },
             {
@@ -78,11 +62,7 @@ namespace Microsoft.OpenApi.Reader.V3
                 "explode",
                 (o, n, _, _) =>
                 {
-                    var explode = n.GetScalarValue();
-                    if (explode != null)
-                    {
-                        o.Explode = bool.Parse(explode);
-                    }
+                    o.Explode = n.GetScalarBoolValue();
                 }
             },
             {

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiOperationDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System;
@@ -72,11 +72,7 @@ namespace Microsoft.OpenApi.Reader.V3
                     "deprecated",
                     (o, n, _, _) =>
                     {
-                        var deprecated = n.GetScalarValue();
-                        if (deprecated != null)
-                        {
-                            o.Deprecated = bool.Parse(deprecated);
-                        }
+                        o.Deprecated = n.GetScalarBoolValue();
                     }
                 },
                 {

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiParameterDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Text.Json.Nodes;
@@ -38,44 +38,28 @@ namespace Microsoft.OpenApi.Reader.V3
                     "required",
                     (o, n, _, _) =>
                     {
-                        var required = n.GetScalarValue();
-                        if (required != null)
-                        {
-                            o.Required = bool.Parse(required);
-                        }
+                        o.Required = n.GetScalarBoolValue();
                     }
                 },
                 {
                     "deprecated",
                     (o, n, _, _) =>
                     {
-                        var deprecated = n.GetScalarValue();
-                        if (deprecated != null)
-                        {
-                            o.Deprecated = bool.Parse(deprecated);
-                        }
+                        o.Deprecated = n.GetScalarBoolValue();
                     }
                 },
                 {
                     "allowEmptyValue",
                     (o, n, _, _) =>
                     {
-                        var allowEmptyValue = n.GetScalarValue();
-                        if (allowEmptyValue != null)
-                        {
-                            o.AllowEmptyValue = bool.Parse(allowEmptyValue);
-                        }
+                        o.AllowEmptyValue = n.GetScalarBoolValue();
                     }
                 },
                 {
                     "allowReserved",
                     (o, n, _, _) =>
                     {
-                        var allowReserved = n.GetScalarValue();
-                        if (allowReserved != null)
-                        {
-                            o.AllowReserved = bool.Parse(allowReserved);
-                        }
+                        o.AllowReserved = n.GetScalarBoolValue();
                     }
                 },
                 {
@@ -93,11 +77,7 @@ namespace Microsoft.OpenApi.Reader.V3
                     "explode",
                     (o, n, _, _) =>
                     {
-                        var explode = n.GetScalarValue();
-                        if (explode != null)
-                        {
-                            o.Explode = bool.Parse(explode);
-                        }
+                        o.Explode = n.GetScalarBoolValue();
                     }
                 },
                 {

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiRequestBodyDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiRequestBodyDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Text.Json.Nodes;
@@ -28,11 +28,7 @@ namespace Microsoft.OpenApi.Reader.V3
                     "required",
                     (o, n, _, _) =>
                     {
-                        var required = n.GetScalarValue();
-                        if (required != null)
-                        {
-                            o.Required = bool.Parse(required);
-                        }
+                        o.Required = n.GetScalarBoolValue();
                     }
                 },
             };

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSchemaDeserializer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.OpenApi.Reader.V3
             },
             {
                 "exclusiveMaximum",
-                (o, n, _, _) => o.IsExclusiveMaximum = bool.Parse(n.GetScalarValue()!)
+                (o, n, _, _) => o.IsExclusiveMaximum = n.GetScalarBoolValue()
             },
             {
                "minimum",
@@ -64,28 +64,20 @@ namespace Microsoft.OpenApi.Reader.V3
             },
             {
                 "exclusiveMinimum",
-                (o, n, _, _) => o.IsExclusiveMinimum = bool.Parse(n.GetScalarValue()!)
+                (o, n, _, _) => o.IsExclusiveMinimum = n.GetScalarBoolValue()
             },
             {
                 "maxLength",
                 (o, n, _, _) =>
                 {
-                    var maxLength = n.GetScalarValue();
-                    if (maxLength != null)
-                    {
-                        o.MaxLength = int.Parse(maxLength, CultureInfo.InvariantCulture);
-                    }
+                    o.MaxLength = n.GetScalarIntValue();
                 }
             },
             {
                 "minLength",
                 (o, n, _, _) =>
                 {
-                    var minLength = n.GetScalarValue();
-                    if (minLength != null)
-                    {
-                        o.MinLength = int.Parse(minLength, CultureInfo.InvariantCulture);
-                    }
+                    o.MinLength = n.GetScalarIntValue();
                 }
             },
             {
@@ -96,55 +88,35 @@ namespace Microsoft.OpenApi.Reader.V3
                 "maxItems",
                 (o, n, _, _) =>
                 {
-                    var maxItems = n.GetScalarValue();
-                    if (maxItems != null)
-                    {
-                        o.MaxItems = int.Parse(maxItems, CultureInfo.InvariantCulture);
-                    }
+                    o.MaxItems = n.GetScalarIntValue();
                 }
             },
             {
                 "minItems",
                 (o, n, _, _) =>
                 {
-                    var minItems = n.GetScalarValue();
-                    if (minItems != null)
-                    {
-                        o.MinItems = int.Parse(minItems, CultureInfo.InvariantCulture);
-                    }
+                    o.MinItems = n.GetScalarIntValue();
                 }
             },
             {
                 "uniqueItems",
                 (o, n, _, _) =>
                 {
-                    var uniqueItems = n.GetScalarValue();
-                    if (uniqueItems != null)
-                    {
-                        o.UniqueItems = bool.Parse(uniqueItems);
-                    }
+                    o.UniqueItems = n.GetScalarBoolValue();
                 }
             },
             {
                 "maxProperties",
                 (o, n, _, _) =>
                 {
-                    var maxProps = n.GetScalarValue();
-                    if (maxProps != null)
-                    {
-                        o.MaxProperties = int.Parse(maxProps, CultureInfo.InvariantCulture);
-                    }
+                    o.MaxProperties = n.GetScalarIntValue();
                 }
             },
             {
                 "minProperties",
                 (o, n, _, _) =>
                 {
-                    var minProps = n.GetScalarValue();
-                    if (minProps != null)
-                    {
-                        o.MinProperties = int.Parse(minProps, CultureInfo.InvariantCulture);
-                    }
+                    o.MinProperties = n.GetScalarIntValue();
                 }
             },
             {
@@ -195,11 +167,7 @@ namespace Microsoft.OpenApi.Reader.V3
                 {
                     if (n is JsonValue)
                     {
-                        var value = n.GetScalarValue();
-                        if (value is not null)
-                        {
-                            o.AdditionalPropertiesAllowed = bool.Parse(value);
-                        }
+                        o.AdditionalPropertiesAllowed = n.GetScalarBoolValue();
                     }
                     else
                     {
@@ -223,7 +191,7 @@ namespace Microsoft.OpenApi.Reader.V3
                 "nullable",
                 (o, n, _, _) =>
                 {
-                    if (bool.TryParse(n.GetScalarValue(), out var parsed) && parsed)
+                    if (n.GetScalarBoolValue())
                     {
                         if (o.Type is not null && o.Type != 0)
                         {
@@ -250,22 +218,14 @@ namespace Microsoft.OpenApi.Reader.V3
                 "readOnly",
                 (o, n, _, _) =>
                 {
-                    var readOnly = n.GetScalarValue();
-                    if (readOnly != null)
-                    {
-                        o.ReadOnly = bool.Parse(readOnly);
-                    }
+                    o.ReadOnly = n.GetScalarBoolValue();
                 }
             },
             {
                 "writeOnly",
                 (o, n, _, _) =>
                 {
-                    var writeOnly = n.GetScalarValue();
-                    if (writeOnly != null)
-                    {
-                        o.WriteOnly = bool.Parse(writeOnly);
-                    }
+                    o.WriteOnly = n.GetScalarBoolValue();
                 }
             },
             {
@@ -284,11 +244,7 @@ namespace Microsoft.OpenApi.Reader.V3
                 "deprecated",
                 (o, n, _, _) =>
                 {
-                    var deprecated = n.GetScalarValue();
-                    if (deprecated != null)
-                    {
-                        o.Deprecated = bool.Parse(deprecated);
-                    }
+                    o.Deprecated = n.GetScalarBoolValue();
                 }
             },
             {
@@ -301,11 +257,7 @@ namespace Microsoft.OpenApi.Reader.V3
                 {
                     if (n is JsonValue)
                     {
-                        var value = n.GetScalarValue();
-                        if (value is not null)
-                        {
-                            o.UnevaluatedProperties = bool.Parse(value);
-                        }
+                        o.UnevaluatedProperties = n.GetScalarBoolValue();
                     }
                     else
                     {
@@ -337,22 +289,14 @@ namespace Microsoft.OpenApi.Reader.V3
                 OpenApiConstants.MaxContainsExtension,
                 (o, n, _, _) =>
                 {
-                    var maxContains = n.GetScalarValue();
-                    if (maxContains != null)
-                    {
-                        o.MaxContains = uint.Parse(maxContains, CultureInfo.InvariantCulture);
-                    }
+                    o.MaxContains = n.GetScalarUIntValue();
                 }
             },
             {
                 OpenApiConstants.MinContainsExtension,
                 (o, n, _, _) =>
                 {
-                    var minContains = n.GetScalarValue();
-                    if (minContains != null)
-                    {
-                        o.MinContains = uint.Parse(minContains, CultureInfo.InvariantCulture);
-                    }
+                    o.MinContains = n.GetScalarUIntValue();
                 }
             },
             {

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiSecuritySchemeDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiSecuritySchemeDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Text.Json.Nodes;
@@ -78,11 +78,7 @@ namespace Microsoft.OpenApi.Reader.V3
                 {
                     if (p.Equals("x-oai-deprecated", StringComparison.OrdinalIgnoreCase))
                     {
-                        var deprecated = n.GetScalarValue();
-                        if (deprecated != null)
-                        {
-                            o.Deprecated = bool.Parse(deprecated);
-                        }
+                        o.Deprecated = n.GetScalarBoolValue();
                     }
                     else
                     {

--- a/src/Microsoft.OpenApi/Reader/V3/OpenApiXmlDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V3/OpenApiXmlDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Text.Json.Nodes;
@@ -38,26 +38,18 @@ namespace Microsoft.OpenApi.Reader.V3
                 "attribute",
                 (o, n, _, _) =>
                 {
-                    var attribute = n.GetScalarValue();
-                    if (attribute is not null)
-                    {
 #pragma warning disable CS0618 // Type or member is obsolete
-                        o.Attribute = bool.Parse(attribute);
+                    o.Attribute = n.GetScalarBoolValue();
 #pragma warning restore CS0618 // Type or member is obsolete
-                    }
                 }
             },
             {
                 "wrapped",
                 (o, n, _, _) =>
                 {
-                    var wrapped = n.GetScalarValue();
-                    if (wrapped is not null)
-                    {
 #pragma warning disable CS0618 // Type or member is obsolete
-                        o.Wrapped = bool.Parse(wrapped);
+                    o.Wrapped = n.GetScalarBoolValue();
 #pragma warning restore CS0618 // Type or member is obsolete
-                    }
                 }
             },
         };

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiEncodingDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiEncodingDeserializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.OpenApi.Reader.V31;
@@ -35,21 +35,13 @@ internal static partial class OpenApiV31Deserializer
         {
             "explode", (o, n, _, _) =>
             {
-                var explode = n.GetScalarValue();
-                if (explode is not null)
-                {
-                    o.Explode = bool.Parse(explode);
-                }                    
+                o.Explode = n.GetScalarBoolValue();
             }
         },
         {
             "allowReserved", (o, n, _, _) =>
             {
-                var allowReserved = n.GetScalarValue();
-                if (allowReserved is not null)
-                {
-                    o.AllowReserved = bool.Parse(allowReserved);
-                }
+                o.AllowReserved = n.GetScalarBoolValue();
             }
         },
     };

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiHeaderDeserializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.OpenApi.Reader.V31
@@ -21,44 +21,28 @@ namespace Microsoft.OpenApi.Reader.V31
                 "required",
                 (o, n, _, _) =>
                 {
-                    var required = n.GetScalarValue();
-                    if (required != null)
-                    {
-                        o.Required = bool.Parse(required);
-                    }
+                    o.Required = n.GetScalarBoolValue();
                 }
             },
             {
                 "deprecated",
                 (o, n, _, _) =>
                 {
-                    var deprecated = n.GetScalarValue();
-                    if (deprecated != null)
-                    {
-                        o.Deprecated = bool.Parse(deprecated);
-                    }
+                    o.Deprecated = n.GetScalarBoolValue();
                 }
             },
             {
                 "allowEmptyValue",
                 (o, n, _, _) =>
                 {
-                    var allowEmptyVal = n.GetScalarValue();
-                    if (allowEmptyVal != null)
-                    {
-                        o.AllowEmptyValue = bool.Parse(allowEmptyVal);
-                    }
+                    o.AllowEmptyValue = n.GetScalarBoolValue();
                 }
             },
             {
                 "allowReserved",
                 (o, n, _, _) =>
                 {
-                    var allowReserved = n.GetScalarValue();
-                    if (allowReserved != null)
-                    {
-                        o.AllowReserved = bool.Parse(allowReserved);
-                    }
+                    o.AllowReserved = n.GetScalarBoolValue();
                 }
             },
             {
@@ -75,11 +59,7 @@ namespace Microsoft.OpenApi.Reader.V31
                 "explode",
                 (o, n, _, _) =>
                 {
-                    var explode = n.GetScalarValue();
-                    if (explode != null)
-                    {
-                        o.Explode = bool.Parse(explode);
-                    }
+                    o.Explode = n.GetScalarBoolValue();
                 }
             },
             {

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiOAuthFlowDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiOAuthFlowDeserializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.Json.Nodes;
 using System.Linq;
 
@@ -10,7 +10,7 @@ namespace Microsoft.OpenApi.Reader.V31
     /// </summary>
     internal static partial class OpenApiV31Deserializer
     {
-        private static readonly FixedFieldMap<OpenApiOAuthFlow> _oAuthFlowFixedFileds =
+        private static readonly FixedFieldMap<OpenApiOAuthFlow> _oAuthFlowFixedFields =
             new()
             {
                 {
@@ -74,7 +74,7 @@ namespace Microsoft.OpenApi.Reader.V31
             var jsonObject = node.CheckMapNode("OAuthFlow", context);
 
             var oauthFlow = new OpenApiOAuthFlow();
-            ParseMap(jsonObject, oauthFlow, _oAuthFlowFixedFileds, _oAuthFlowPatternFields, hostDocument, context);
+            ParseMap(jsonObject, oauthFlow, _oAuthFlowFixedFields, _oAuthFlowPatternFields, hostDocument, context);
 
             return oauthFlow;
         }

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiOperationDeserializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
@@ -85,11 +85,7 @@ namespace Microsoft.OpenApi.Reader.V31
                     "deprecated",
                     (o, n, _, _) =>
                     {
-                        var deprecated = n.GetScalarValue();
-                        if (deprecated != null)
-                        {
-                            o.Deprecated = bool.Parse(deprecated);
-                        }
+                        o.Deprecated = n.GetScalarBoolValue();
                     }
                 },
                 {

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiParameterDeserializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.OpenApi.Reader.V31
@@ -38,44 +38,28 @@ namespace Microsoft.OpenApi.Reader.V31
                     "required",
                     (o, n, _, _) =>
                     {
-                        var required = n.GetScalarValue();
-                        if (required != null)
-                        {
-                            o.Required = bool.Parse(required);
-                        }
+                        o.Required = n.GetScalarBoolValue();
                     }
                 },
                 {
                     "deprecated",
                     (o, n, _, _) =>
                     {
-                        var deprecated = n.GetScalarValue();
-                        if (deprecated != null)
-                        {
-                            o.Deprecated = bool.Parse(deprecated);
-                        }
+                        o.Deprecated = n.GetScalarBoolValue();
                     }
                 },
                 {
                     "allowEmptyValue",
                     (o, n, _, _) =>
                     {
-                        var allowEmptyValue = n.GetScalarValue();
-                        if (allowEmptyValue != null)
-                        {
-                            o.AllowEmptyValue = bool.Parse(allowEmptyValue);
-                        }
+                        o.AllowEmptyValue = n.GetScalarBoolValue();
                     }
                 },
                 {
                     "allowReserved",
                     (o, n, _, _) =>
                     {
-                        var allowReserved = n.GetScalarValue();
-                        if (allowReserved != null)
-                        {
-                            o.AllowReserved = bool.Parse(allowReserved);
-                        }
+                        o.AllowReserved = n.GetScalarBoolValue();
                     }
                 },
                 {
@@ -91,11 +75,7 @@ namespace Microsoft.OpenApi.Reader.V31
                 {
                     "explode", (o, n, _, _) =>
                     {
-                        var explode = n.GetScalarValue();
-                        if (explode != null)
-                        {
-                            o.Explode = bool.Parse(explode);
-                        }
+                        o.Explode = n.GetScalarBoolValue();
                     }
                 },
                 {

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiRequestBodyDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiRequestBodyDeserializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.OpenApi.Reader.V31
@@ -27,11 +27,7 @@ namespace Microsoft.OpenApi.Reader.V31
                 {
                     "required", (o, n, _, _) =>
                     {
-                        var required = n.GetScalarValue();
-                        if (required != null)
-                        {
-                            o.Required = bool.Parse(required);
-                        }
+                        o.Required = n.GetScalarBoolValue();
                     }
                 },
             };

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
@@ -32,7 +32,7 @@ internal static partial class OpenApiV31Deserializer
         },
         {
             "$vocabulary",
-            (o, n, _, c) => o.Vocabulary = n.CreateSimpleMap(LoadBool, c).ToDictionary(kvp => kvp.Key, kvp => kvp.Value ?? false)
+            (o, n, _, c) => o.Vocabulary = n.CreateSimpleMap(LoadBool, c).ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
         },
         {
             "$dynamicRef",
@@ -95,22 +95,14 @@ internal static partial class OpenApiV31Deserializer
             "maxLength",
             (o, n, _, _) =>
             {
-                var maxLength = n.GetScalarValue();
-                if (maxLength != null)
-                {
-                    o.MaxLength = int.Parse(maxLength, CultureInfo.InvariantCulture);
-                }
+                o.MaxLength = n.GetScalarIntValue();
             }
         },
         {
             "minLength",
             (o, n, _, _) =>
             {
-                var minLength = n.GetScalarValue();
-                if (minLength != null)
-                {
-                    o.MinLength = int.Parse(minLength, CultureInfo.InvariantCulture);
-                }
+                o.MinLength = n.GetScalarIntValue();
             }
         },
         {
@@ -121,33 +113,21 @@ internal static partial class OpenApiV31Deserializer
             "maxItems",
             (o, n, _, _) =>
             {
-                var maxItems = n.GetScalarValue();
-                if (maxItems != null)
-                {
-                    o.MaxItems = int.Parse(maxItems, CultureInfo.InvariantCulture);
-                }
+                o.MaxItems = n.GetScalarIntValue();
             }
         },
         {
             "minItems",
             (o, n, _, _) =>
             {
-                var minItems = n.GetScalarValue();
-                if (minItems != null)
-                {
-                    o.MinItems = int.Parse(minItems, CultureInfo.InvariantCulture);
-                }
+                o.MinItems = n.GetScalarIntValue();
             }
         },
         {
             "uniqueItems",
             (o, n, _, _) =>
             {
-                var uniqueItems = n.GetScalarValue();
-                if (uniqueItems != null)
-                {
-                    o.UniqueItems = bool.Parse(uniqueItems);
-                }
+                o.UniqueItems = n.GetScalarBoolValue();
             }
         },
         {
@@ -158,22 +138,14 @@ internal static partial class OpenApiV31Deserializer
             OpenApiConstants.MaxContains,
             (o, n, _, _) =>
             {
-                var maxContains = n.GetScalarValue();
-                if (maxContains != null)
-                {
-                    o.MaxContains = uint.Parse(maxContains, CultureInfo.InvariantCulture);
-                }
+                o.MaxContains = n.GetScalarUIntValue();
             }
         },
         {
             OpenApiConstants.MinContains,
             (o, n, _, _) =>
             {
-                var minContains = n.GetScalarValue();
-                if (minContains != null)
-                {
-                    o.MinContains = uint.Parse(minContains, CultureInfo.InvariantCulture);
-                }
+                o.MinContains = n.GetScalarUIntValue();
             }
         },
         {
@@ -183,11 +155,7 @@ internal static partial class OpenApiV31Deserializer
                 // Handle both boolean (false/true) and schema object cases
                 if (n is JsonValue)
                 {
-                    var value = n.GetScalarValue();
-                    if (value is not null)
-                    {
-                        o.UnevaluatedProperties = bool.Parse(value);
-                    }
+                    o.UnevaluatedProperties = n.GetScalarBoolValue();
                 }
                 else
                 {
@@ -212,22 +180,14 @@ internal static partial class OpenApiV31Deserializer
             "maxProperties",
             (o, n, _, _) =>
             {
-                var maxProps = n.GetScalarValue();
-                if (maxProps != null)
-                {
-                    o.MaxProperties = int.Parse(maxProps, CultureInfo.InvariantCulture);
-                }
+                o.MaxProperties = n.GetScalarIntValue();
             }
         },
         {
             "minProperties",
             (o, n, _, _) =>
             {
-                var minProps = n.GetScalarValue();
-                if (minProps != null)
-                {
-                    o.MinProperties = int.Parse(minProps, CultureInfo.InvariantCulture);
-                }
+                o.MinProperties = n.GetScalarIntValue();
             }
         },
         {
@@ -302,11 +262,7 @@ internal static partial class OpenApiV31Deserializer
             {
                 if (n is JsonValue)
                 {
-                    var value = n.GetScalarValue();
-                    if (value is not null)
-                    {
-                        o.AdditionalPropertiesAllowed = bool.Parse(value);
-                    }
+                    o.AdditionalPropertiesAllowed = n.GetScalarBoolValue();
                 }
                 else
                 {
@@ -334,22 +290,14 @@ internal static partial class OpenApiV31Deserializer
             "readOnly",
             (o, n, _, _) =>
             {
-                var readOnly = n.GetScalarValue();
-                if (readOnly != null)
-                {
-                    o.ReadOnly = bool.Parse(readOnly);
-                }
+                o.ReadOnly = n.GetScalarBoolValue();
             }
         },
         {
             "writeOnly",
             (o, n, _, _) =>
             {
-                var writeOnly = n.GetScalarValue();
-                if (writeOnly != null)
-                {
-                    o.WriteOnly = bool.Parse(writeOnly);
-                }
+                o.WriteOnly = n.GetScalarBoolValue();
             }
         },
         {
@@ -372,11 +320,7 @@ internal static partial class OpenApiV31Deserializer
             "deprecated",
             (o, n, _, _) =>
             {
-                var deprecated = n.GetScalarValue();
-                if (deprecated != null)
-                {
-                    o.Deprecated = bool.Parse(deprecated);
-                }
+                o.Deprecated = n.GetScalarBoolValue();
             }
         },
         {

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiSchemaDeserializer.cs
@@ -32,7 +32,7 @@ internal static partial class OpenApiV31Deserializer
         },
         {
             "$vocabulary",
-            (o, n, _, c) => o.Vocabulary = n.CreateSimpleMap(LoadBool, c).ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
+            (o, n, _, c) => o.Vocabulary = n.CreateSimpleMap(LoadBool, c)
         },
         {
             "$dynamicRef",

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiSecuritySchemeDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiSecuritySchemeDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
 using System.Text.Json.Nodes;
@@ -85,11 +85,7 @@ namespace Microsoft.OpenApi.Reader.V31
                 {
                     if (p.Equals("x-oai-deprecated", StringComparison.OrdinalIgnoreCase))
                     {
-                        var deprecated = n.GetScalarValue();
-                        if (deprecated != null)
-                        {
-                            o.Deprecated = bool.Parse(deprecated);
-                        }
+                        o.Deprecated = n.GetScalarBoolValue();
                     }
                     else
                     {

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiV31Deserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiV31Deserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
 using System;
@@ -144,10 +144,9 @@ namespace Microsoft.OpenApi.Reader.V31
             return node.GetScalarValue();
         }
 
-        private static bool? LoadBool(JsonNode node)
+        private static bool LoadBool(JsonNode node)
         {
-            var value = node.GetScalarValue();
-            return value is not null ? bool.Parse(value) : null;
+            return node.GetScalarBoolValue();
         }
 
         private static (string, string?) GetReferenceIdAndExternalResource(string pointer)

--- a/src/Microsoft.OpenApi/Reader/V31/OpenApiXmlDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V31/OpenApiXmlDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
 using System.Text.Json.Nodes;
@@ -40,26 +40,18 @@ namespace Microsoft.OpenApi.Reader.V31
                 "attribute",
                 (o, n, _, _) =>
                 {
-                    var attribute = n.GetScalarValue();
-                    if (attribute is not null)
-                    {
 #pragma warning disable CS0618 // Type or member is obsolete
-                        o.Attribute = bool.Parse(attribute);
+                    o.Attribute = n.GetScalarBoolValue();
 #pragma warning restore CS0618 // Type or member is obsolete
-                    }
                 }
             },
             {
                 "wrapped",
                 (o, n, _, _) =>
                 {
-                    var wrapped = n.GetScalarValue();
-                    if (wrapped is not null)
-                    {
 #pragma warning disable CS0618 // Type or member is obsolete
-                        o.Wrapped = bool.Parse(wrapped);
+                    o.Wrapped = n.GetScalarBoolValue();
 #pragma warning restore CS0618 // Type or member is obsolete
-                    }
                 }
             }
         };

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiEncodingDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiEncodingDeserializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.OpenApi.Reader.V32
@@ -54,21 +54,13 @@ namespace Microsoft.OpenApi.Reader.V32
             {
                 "explode", (o, n, _, _) =>
                 {
-                    var explode = n.GetScalarValue();
-                    if (explode is not null)
-                    {
-                        o.Explode = bool.Parse(explode);
-                    }                    
+                    o.Explode = n.GetScalarBoolValue();
                 }
             },
             {
                 "allowReserved", (o, n, _, _) =>
                 {
-                    var allowReserved = n.GetScalarValue();
-                    if (allowReserved is not null)
-                    {
-                        o.AllowReserved = bool.Parse(allowReserved);
-                    }
+                    o.AllowReserved = n.GetScalarBoolValue();
                 }
             },
         };

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiHeaderDeserializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.OpenApi.Reader.V32
@@ -21,44 +21,28 @@ namespace Microsoft.OpenApi.Reader.V32
                 "required",
                 (o, n, _, _) =>
                 {
-                    var required = n.GetScalarValue();
-                    if (required != null)
-                    {
-                        o.Required = bool.Parse(required);
-                    }
+                    o.Required = n.GetScalarBoolValue();
                 }
             },
             {
                 "deprecated",
                 (o, n, _, _) =>
                 {
-                    var deprecated = n.GetScalarValue();
-                    if (deprecated != null)
-                    {
-                        o.Deprecated = bool.Parse(deprecated);
-                    }
+                    o.Deprecated = n.GetScalarBoolValue();
                 }
             },
             {
                 "allowEmptyValue",
                 (o, n, _, _) =>
                 {
-                    var allowEmptyVal = n.GetScalarValue();
-                    if (allowEmptyVal != null)
-                    {
-                        o.AllowEmptyValue = bool.Parse(allowEmptyVal);
-                    }
+                    o.AllowEmptyValue = n.GetScalarBoolValue();
                 }
             },
             {
                 "allowReserved",
                 (o, n, _, _) =>
                 {
-                    var allowReserved = n.GetScalarValue();
-                    if (allowReserved != null)
-                    {
-                        o.AllowReserved = bool.Parse(allowReserved);
-                    }
+                    o.AllowReserved = n.GetScalarBoolValue();
                 }
             },
             {
@@ -75,11 +59,7 @@ namespace Microsoft.OpenApi.Reader.V32
                 "explode",
                 (o, n, _, _) =>
                 {
-                    var explode = n.GetScalarValue();
-                    if (explode != null)
-                    {
-                        o.Explode = bool.Parse(explode);
-                    }
+                    o.Explode = n.GetScalarBoolValue();
                 }
             },
             {

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiOAuthFlowDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiOAuthFlowDeserializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.Json.Nodes;
 using System.Linq;
 
@@ -10,7 +10,7 @@ namespace Microsoft.OpenApi.Reader.V32
     /// </summary>
     internal static partial class OpenApiV32Deserializer
     {
-        private static readonly FixedFieldMap<OpenApiOAuthFlow> _oAuthFlowFixedFileds =
+        private static readonly FixedFieldMap<OpenApiOAuthFlow> _oAuthFlowFixedFields =
             new()
             {
                 {
@@ -71,7 +71,7 @@ namespace Microsoft.OpenApi.Reader.V32
             var jsonObject = node.CheckMapNode("OAuthFlow", context);
 
             var oauthFlow = new OpenApiOAuthFlow();
-            ParseMap(jsonObject, oauthFlow, _oAuthFlowFixedFileds, _oAuthFlowPatternFields, hostDocument, context);
+            ParseMap(jsonObject, oauthFlow, _oAuthFlowFixedFields, _oAuthFlowPatternFields, hostDocument, context);
 
             return oauthFlow;
         }

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiOperationDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiOperationDeserializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Nodes;
@@ -85,11 +85,7 @@ namespace Microsoft.OpenApi.Reader.V32
                     "deprecated",
                     (o, n, _, _) =>
                     {
-                        var deprecated = n.GetScalarValue();
-                        if (deprecated != null)
-                        {
-                            o.Deprecated = bool.Parse(deprecated);
-                        }
+                        o.Deprecated = n.GetScalarBoolValue();
                     }
                 },
                 {

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiParameterDeserializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.OpenApi.Reader.V32
@@ -38,44 +38,28 @@ namespace Microsoft.OpenApi.Reader.V32
                     "required",
                     (o, n, _, _) =>
                     {
-                        var required = n.GetScalarValue();
-                        if (required != null)
-                        {
-                            o.Required = bool.Parse(required);
-                        }
+                        o.Required = n.GetScalarBoolValue();
                     }
                 },
                 {
                     "deprecated",
                     (o, n, _, _) =>
                     {
-                        var deprecated = n.GetScalarValue();
-                        if (deprecated != null)
-                        {
-                            o.Deprecated = bool.Parse(deprecated);
-                        }
+                        o.Deprecated = n.GetScalarBoolValue();
                     }
                 },
                 {
                     "allowEmptyValue",
                     (o, n, _, _) =>
                     {
-                        var allowEmptyValue = n.GetScalarValue();
-                        if (allowEmptyValue != null)
-                        {
-                            o.AllowEmptyValue = bool.Parse(allowEmptyValue);
-                        }
+                        o.AllowEmptyValue = n.GetScalarBoolValue();
                     }
                 },
                 {
                     "allowReserved",
                     (o, n, _, _) =>
                     {
-                        var allowReserved = n.GetScalarValue();
-                        if (allowReserved != null)
-                        {
-                            o.AllowReserved = bool.Parse(allowReserved);
-                        }
+                        o.AllowReserved = n.GetScalarBoolValue();
                     }
                 },
                 {
@@ -91,11 +75,7 @@ namespace Microsoft.OpenApi.Reader.V32
                 {
                     "explode", (o, n, _, _) =>
                     {
-                        var explode = n.GetScalarValue();
-                        if (explode != null)
-                        {
-                            o.Explode = bool.Parse(explode);
-                        }
+                        o.Explode = n.GetScalarBoolValue();
                     }
                 },
                 {

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiRequestBodyDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiRequestBodyDeserializer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text.Json.Nodes;
 
 namespace Microsoft.OpenApi.Reader.V32
@@ -27,11 +27,7 @@ namespace Microsoft.OpenApi.Reader.V32
                 {
                     "required", (o, n, _, _) =>
                     {
-                        var required = n.GetScalarValue();
-                        if (required != null)
-                        {
-                            o.Required = bool.Parse(required);
-                        }
+                        o.Required = n.GetScalarBoolValue();
                     }
                 },
             };

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
@@ -32,7 +32,7 @@ internal static partial class OpenApiV32Deserializer
         },
         {
             "$vocabulary",
-            (o, n, _, c) => o.Vocabulary = n.CreateSimpleMap(LoadBool, c).ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
+            (o, n, _, c) => o.Vocabulary = n.CreateSimpleMap(LoadBool, c)
         },
         {
             "$dynamicRef",

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiSchemaDeserializer.cs
@@ -32,7 +32,7 @@ internal static partial class OpenApiV32Deserializer
         },
         {
             "$vocabulary",
-            (o, n, _, c) => o.Vocabulary = n.CreateSimpleMap(LoadBool, c).ToDictionary(kvp => kvp.Key, kvp => kvp.Value ?? false)
+            (o, n, _, c) => o.Vocabulary = n.CreateSimpleMap(LoadBool, c).ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
         },
         {
             "$dynamicRef",
@@ -95,22 +95,14 @@ internal static partial class OpenApiV32Deserializer
             "maxLength",
             (o, n, _, _) =>
             {
-                var maxLength = n.GetScalarValue();
-                if (maxLength != null)
-                {
-                    o.MaxLength = int.Parse(maxLength, CultureInfo.InvariantCulture);
-                }
+                o.MaxLength = n.GetScalarIntValue();
             }
         },
         {
             "minLength",
             (o, n, _, _) =>
             {
-                var minLength = n.GetScalarValue();
-                if (minLength != null)
-                {
-                    o.MinLength = int.Parse(minLength, CultureInfo.InvariantCulture);
-                }
+                o.MinLength = n.GetScalarIntValue();
             }
         },
         {
@@ -121,33 +113,21 @@ internal static partial class OpenApiV32Deserializer
             "maxItems",
             (o, n, _, _) =>
             {
-                var maxItems = n.GetScalarValue();
-                if (maxItems != null)
-                {
-                    o.MaxItems = int.Parse(maxItems, CultureInfo.InvariantCulture);
-                }
+                o.MaxItems = n.GetScalarIntValue();
             }
         },
         {
             "minItems",
             (o, n, _, _) =>
             {
-                var minItems = n.GetScalarValue();
-                if (minItems != null)
-                {
-                    o.MinItems = int.Parse(minItems, CultureInfo.InvariantCulture);
-                }
+                o.MinItems = n.GetScalarIntValue();
             }
         },
         {
             "uniqueItems",
             (o, n, _, _) =>
             {
-                var uniqueItems = n.GetScalarValue();
-                if (uniqueItems != null)
-                {
-                    o.UniqueItems = bool.Parse(uniqueItems);
-                }
+                o.UniqueItems = n.GetScalarBoolValue();
             }
         },
         {
@@ -158,22 +138,14 @@ internal static partial class OpenApiV32Deserializer
             OpenApiConstants.MaxContains,
             (o, n, _, _) =>
             {
-                var maxContains = n.GetScalarValue();
-                if (maxContains != null)
-                {
-                    o.MaxContains = uint.Parse(maxContains, CultureInfo.InvariantCulture);
-                }
+                o.MaxContains = n.GetScalarUIntValue();
             }
         },
         {
             OpenApiConstants.MinContains,
             (o, n, _, _) =>
             {
-                var minContains = n.GetScalarValue();
-                if (minContains != null)
-                {
-                    o.MinContains = uint.Parse(minContains, CultureInfo.InvariantCulture);
-                }
+                o.MinContains = n.GetScalarUIntValue();
             }
         },
         {
@@ -183,11 +155,7 @@ internal static partial class OpenApiV32Deserializer
                 // Handle both boolean (false/true) and schema object cases
                 if (n is JsonValue)
                 {
-                    var value = n.GetScalarValue();
-                    if (value is not null)
-                    {
-                        o.UnevaluatedProperties = bool.Parse(value);
-                    }
+                    o.UnevaluatedProperties = n.GetScalarBoolValue();
                 }
                 else
                 {
@@ -212,22 +180,14 @@ internal static partial class OpenApiV32Deserializer
             "maxProperties",
             (o, n, _, _) =>
             {
-                var maxProps = n.GetScalarValue();
-                if (maxProps != null)
-                {
-                    o.MaxProperties = int.Parse(maxProps, CultureInfo.InvariantCulture);
-                }
+                o.MaxProperties = n.GetScalarIntValue();
             }
         },
         {
             "minProperties",
             (o, n, _, _) =>
             {
-                var minProps = n.GetScalarValue();
-                if (minProps != null)
-                {
-                    o.MinProperties = int.Parse(minProps, CultureInfo.InvariantCulture);
-                }
+                o.MinProperties = n.GetScalarIntValue();
             }
         },
         {
@@ -302,11 +262,7 @@ internal static partial class OpenApiV32Deserializer
             {
                 if (n is JsonValue)
                 {
-                    var value = n.GetScalarValue();
-                    if (value is not null)
-                    {
-                        o.AdditionalPropertiesAllowed = bool.Parse(value);
-                    }
+                    o.AdditionalPropertiesAllowed = n.GetScalarBoolValue();
                 }
                 else
                 {
@@ -334,22 +290,14 @@ internal static partial class OpenApiV32Deserializer
             "readOnly",
             (o, n, _, _) =>
             {
-                var readOnly = n.GetScalarValue();
-                if (readOnly != null)
-                {
-                    o.ReadOnly = bool.Parse(readOnly);
-                }
+                o.ReadOnly = n.GetScalarBoolValue();
             }
         },
         {
             "writeOnly",
             (o, n, _, _) =>
             {
-                var writeOnly = n.GetScalarValue();
-                if (writeOnly != null)
-                {
-                    o.WriteOnly = bool.Parse(writeOnly);
-                }
+                o.WriteOnly = n.GetScalarBoolValue();
             }
         },
         {
@@ -372,11 +320,7 @@ internal static partial class OpenApiV32Deserializer
             "deprecated",
             (o, n, _, _) =>
             {
-                var deprecated = n.GetScalarValue();
-                if (deprecated != null)
-                {
-                    o.Deprecated = bool.Parse(deprecated);
-                }
+                o.Deprecated = n.GetScalarBoolValue();
             }
         },
         {

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiSecuritySchemeDeserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiSecuritySchemeDeserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
 using System.Text.Json.Nodes;
@@ -89,11 +89,7 @@ namespace Microsoft.OpenApi.Reader.V32
                 {
                     "deprecated", (o, n, _, _) =>
                     {
-                        var deprecated = n.GetScalarValue();
-                        if (deprecated != null)
-                        {
-                            o.Deprecated = bool.Parse(deprecated);
-                        }
+                        o.Deprecated = n.GetScalarBoolValue();
                     }
                 }
             };

--- a/src/Microsoft.OpenApi/Reader/V32/OpenApiV32Deserializer.cs
+++ b/src/Microsoft.OpenApi/Reader/V32/OpenApiV32Deserializer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
 using System;
@@ -144,10 +144,9 @@ namespace Microsoft.OpenApi.Reader.V32
             return node.GetScalarValue();
         }
 
-        private static bool? LoadBool(JsonNode node)
+        private static bool LoadBool(JsonNode node)
         {
-            var value = node.GetScalarValue();
-            return value is not null ? bool.Parse(value) : null;
+            return node.GetScalarBoolValue();
         }
 
         private static (string, string?) GetReferenceIdAndExternalResource(string pointer)

--- a/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiExampleTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V31Tests/OpenApiExampleTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.IO;
@@ -30,6 +30,9 @@ namespace Microsoft.OpenApi.Readers.Tests.V31Tests
             Assert.NotNull(example.DataValue);
             Assert.Equal("Jane Smith", example.DataValue["name"].GetValue<string>());
             Assert.Equal(25, example.DataValue["age"].GetValue<decimal>());
+            Assert.Equal(25, example.DataValue["age"].GetValue<int>());
+            Assert.Equal(25u, example.DataValue["age"].GetValue<uint>());
+            Assert.Equal((byte)25, example.DataValue["age"].GetValue<byte>());
         }
 
         [Fact]

--- a/test/Microsoft.OpenApi.Readers.Tests/V32Tests/OpenApiExampleTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V32Tests/OpenApiExampleTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.IO;
@@ -30,6 +30,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V32Tests
             Assert.NotNull(example.DataValue);
             Assert.Equal("John Doe", example.DataValue["name"].GetValue<string>());
             Assert.Equal(30, example.DataValue["age"].GetValue<decimal>());
+            Assert.Equal(30, example.DataValue["age"].GetValue<int>());
+            Assert.Equal(30u, example.DataValue["age"].GetValue<uint>());
+            Assert.Equal((byte)30, example.DataValue["age"].GetValue<byte>());
+
         }
 
         [Fact]

--- a/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiExampleTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/V3Tests/OpenApiExampleTests.cs
@@ -90,6 +90,10 @@ namespace Microsoft.OpenApi.Readers.Tests.V3Tests
             Assert.NotNull(example.DataValue);
             Assert.Equal("Alice Johnson", example.DataValue["name"].GetValue<string>());
             Assert.Equal(28, example.DataValue["age"].GetValue<decimal>());
+            Assert.Equal(28, example.DataValue["age"].GetValue<int>());
+            Assert.Equal(28u, example.DataValue["age"].GetValue<uint>());
+            Assert.Equal((byte)28, example.DataValue["age"].GetValue<byte>());
+
         }
 
         [Fact]


### PR DESCRIPTION
`GetScalarValue` can be dealing with a JsonNode that's wrapping a JsonElement. Doing `GetValue<object>` will return a boxed JsonElement, which is unnecessary allocation. Then we could also force creating a string when we deal with boolean in many cases.

This PR extracts a separate helper for bool values, which is more efficient and is more straightforward to use.

And for the string-based GetScalarValue, try to get the value as string right away first to avoid JsonElement boxing.