### PR TITLE
feat: serialize license identifier as extension for earlier versions

### DIFF
--- a/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiConstants.cs
@@ -231,6 +231,11 @@ namespace Microsoft.OpenApi
         public const string Identifier = "identifier";
 
         /// <summary>
+        /// Field: x-oai-license-identifier
+        /// </summary>
+        public const string OaiLicenseIdentifier = "x-oai-license-identifier";
+
+        /// <summary>
         /// Field: Namespace
         /// </summary>
         public const string Namespace = "namespace";

--- a/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
+++ b/src/Microsoft.OpenApi/Models/OpenApiLicense.cs
@@ -63,6 +63,7 @@ namespace Microsoft.OpenApi
         public virtual void SerializeAsV3(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi3_0);
+            writer.WriteProperty(OpenApiConstants.OaiLicenseIdentifier, Identifier);
             writer.WriteEndObject();
         }
 
@@ -72,6 +73,7 @@ namespace Microsoft.OpenApi
         public virtual void SerializeAsV2(IOpenApiWriter writer)
         {
             WriteInternal(writer, OpenApiSpecVersion.OpenApi2_0);
+            writer.WriteProperty(OpenApiConstants.OaiLicenseIdentifier, Identifier);
             writer.WriteEndObject();
         }
 

--- a/src/Microsoft.OpenApi/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+const Microsoft.OpenApi.OpenApiConstants.OaiLicenseIdentifier = "x-oai-license-identifier" -> string!

--- a/test/Microsoft.OpenApi.Tests/Models/OpenApiLicenseTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Models/OpenApiLicenseTests.cs
@@ -148,6 +148,25 @@ namespace Microsoft.OpenApi.Tests.Models
             Assert.Equal(expected.MakeLineBreaksEnvironmentNeutral(), actual.MakeLineBreaksEnvironmentNeutral());
         }
 
+        [Theory]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        public async Task SerializeLicenseWithIdentifierAsJsonWorksForV3AndV2(OpenApiSpecVersion version)
+        {
+            // Arrange
+            var expected =
+                @"{
+  ""name"": ""Apache 2.0"",
+  ""x-oai-license-identifier"": ""Apache-2.0""
+}";
+
+            // Act
+            var actual = await LicenseWithIdentifier.SerializeAsJsonAsync(version);
+
+            // Assert
+            Assert.Equal(expected.MakeLineBreaksEnvironmentNeutral(), actual.MakeLineBreaksEnvironmentNeutral());
+        }
+
         [Fact]
         public async Task SerializeLicenseWithIdentifierAsYamlWorks()
         {
@@ -157,6 +176,22 @@ identifier: Apache-2.0";
 
             // Act
             var actual = await LicenseWithIdentifier.SerializeAsYamlAsync(OpenApiSpecVersion.OpenApi3_1);
+
+            // Assert
+            Assert.Equal(expected.MakeLineBreaksEnvironmentNeutral(), actual.MakeLineBreaksEnvironmentNeutral());
+        }
+
+        [Theory]
+        [InlineData(OpenApiSpecVersion.OpenApi3_0)]
+        [InlineData(OpenApiSpecVersion.OpenApi2_0)]
+        public async Task SerializeLicenseWithIdentifierAsYamlWorksForV3AndV2(OpenApiSpecVersion version)
+        {
+            // Arrange
+            var expected = @"name: Apache 2.0
+x-oai-license-identifier: Apache-2.0";
+
+            // Act
+            var actual = await LicenseWithIdentifier.SerializeAsYamlAsync(version);
 
             // Assert
             Assert.Equal(expected.MakeLineBreaksEnvironmentNeutral(), actual.MakeLineBreaksEnvironmentNeutral());


### PR DESCRIPTION
port of #2968 to v2