### PR TITLE
Fix S360 open-source vulnerabilities (SFI-ES5.2)

### DIFF
--- a/src/Microsoft.OpenApi.Workbench/Microsoft.OpenApi.Workbench.csproj
+++ b/src/Microsoft.OpenApi.Workbench/Microsoft.OpenApi.Workbench.csproj
@@ -26,6 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="10.0.5" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
   </ItemGroup>
   
   <!-- Windows-specific resources -->


### PR DESCRIPTION
## Summary
- Bumps System.Security.Cryptography.Xml from 10.0.5 to 10.0.6 for Microsoft.OpenApi.Workbench.
- Addresses CVE-2026-33116 and CVE-2026-26171.
- Remediates S360 KPI [SFI-ES5.2] 1ES Open Source Vulnerabilities (Operational).

## Validation
- dotnet restore Microsoft.OpenApi.slnx
- dotnet build Microsoft.OpenApi.slnx --no-restore
- dotnet test Microsoft.OpenApi.slnx --no-build