### PR TITLE
ci(dependabot): add cooldown default delay

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,35 +1,41 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    # default location of `.github/workflows`
-    directory: "/"
-    open-pull-requests-limit: 10
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "nuget"
-    # location of package manifests
-    directory: "/"
-    open-pull-requests-limit: 10
-    schedule:
-      interval: "daily"
-    groups:
-      MicrosoftExtensions:
-        patterns:
-          - "Microsoft.Extensions.*"
-      coverlet:
-        patterns:
-          - "coverlet.*"
-  - package-ecosystem: dotnet-sdk
-    directory: /
-    schedule:
-      interval: "daily"
-    ignore:
-      - dependency-name: '*'
-        update-types:
-          - version-update:semver-major
-          - version-update:semver-minor
-  - package-ecosystem: "devcontainers"
-    directory: "/"
-    open-pull-requests-limit: 10
-    schedule:
-      interval: "daily"
+- package-ecosystem: github-actions
+  directory: /
+  open-pull-requests-limit: 10
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 7
+- package-ecosystem: nuget
+  directory: /
+  open-pull-requests-limit: 10
+  schedule:
+    interval: daily
+  groups:
+    MicrosoftExtensions:
+      patterns:
+      - Microsoft.Extensions.*
+    coverlet:
+      patterns:
+      - coverlet.*
+  cooldown:
+    default-days: 7
+- package-ecosystem: dotnet-sdk
+  directory: /
+  schedule:
+    interval: daily
+  ignore:
+  - dependency-name: '*'
+    update-types:
+    - version-update:semver-major
+    - version-update:semver-minor
+  cooldown:
+    default-days: 7
+- package-ecosystem: devcontainers
+  directory: /
+  open-pull-requests-limit: 10
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
Adds a 7-day default Dependabot cooldown so CIF deployment has time to complete before dependency update PRs are opened.

This helps avoid getting ahead with versions before they are fully available through deployment.