### PR TITLE
fix: bound YAML anchor/alias expansion to prevent OOM (billion laughs)

### DIFF
--- a/src/Microsoft.OpenApi.YamlReader/OpenApiYamlReader.cs
+++ b/src/Microsoft.OpenApi.YamlReader/OpenApiYamlReader.cs
@@ -74,6 +74,17 @@ namespace Microsoft.OpenApi.YamlReader
                     Diagnostic = diagnostic,
                 };
             }
+            catch (OpenApiReaderException ex)
+            {
+                var diagnostic = new OpenApiDiagnostic();
+                diagnostic.Errors.Add(new(ex));
+                diagnostic.Format = OpenApiConstants.Yaml;
+                return new()
+                {
+                    Document = null,
+                    Diagnostic = diagnostic,
+                };
+            }
 
             return UpdateFormat(Read(jsonNode, location, settings));
         }

--- a/src/Microsoft.OpenApi.YamlReader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.YamlReader/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
-const Microsoft.OpenApi.YamlReader.YamlConverter.DefaultMaxDepth = 64 -> int
-const Microsoft.OpenApi.YamlReader.YamlConverter.DefaultMaxNodeCount = 5000000 -> int
-static Microsoft.OpenApi.YamlReader.YamlConverter.MaxDepth.get -> int
+const Microsoft.OpenApi.YamlReader.YamlConverter.DefaultMaxDepth = 64 -> uint
+const Microsoft.OpenApi.YamlReader.YamlConverter.DefaultMaxNodeCount = 5000000 -> uint
+static Microsoft.OpenApi.YamlReader.YamlConverter.MaxDepth.get -> uint
 static Microsoft.OpenApi.YamlReader.YamlConverter.MaxDepth.set -> void
-static Microsoft.OpenApi.YamlReader.YamlConverter.MaxNodeCount.get -> int
+static Microsoft.OpenApi.YamlReader.YamlConverter.MaxNodeCount.get -> uint
 static Microsoft.OpenApi.YamlReader.YamlConverter.MaxNodeCount.set -> void

--- a/src/Microsoft.OpenApi.YamlReader/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OpenApi.YamlReader/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+const Microsoft.OpenApi.YamlReader.YamlConverter.DefaultMaxDepth = 64 -> int
+const Microsoft.OpenApi.YamlReader.YamlConverter.DefaultMaxNodeCount = 5000000 -> int
+static Microsoft.OpenApi.YamlReader.YamlConverter.MaxDepth.get -> int
+static Microsoft.OpenApi.YamlReader.YamlConverter.MaxDepth.set -> void
+static Microsoft.OpenApi.YamlReader.YamlConverter.MaxNodeCount.get -> int
+static Microsoft.OpenApi.YamlReader.YamlConverter.MaxNodeCount.set -> void

--- a/src/Microsoft.OpenApi.YamlReader/YamlConverter.cs
+++ b/src/Microsoft.OpenApi.YamlReader/YamlConverter.cs
@@ -19,15 +19,58 @@ namespace Microsoft.OpenApi.YamlReader
         /// Mirrors the default System.Text.Json depth limit (64) that already bounds the JSON reader path,
         /// protecting the recursive conversion from stack exhaustion on deeply nested documents.
         /// </summary>
-        internal const int DefaultMaxDepth = 64;
+        public const int DefaultMaxDepth = 64;
 
         /// <summary>
         /// Default maximum number of JSON nodes that may be materialized from a single YAML document.
         /// Guards against YAML anchor/alias expansion ("billion laughs") attacks, where a tiny document
         /// expands exponentially when its shared node graph is materialized into an independent JSON tree.
-        /// Increase this only if legitimate large documents are being rejected.
         /// </summary>
-        internal const int DefaultMaxNodeCount = 5_000_000;
+        public const int DefaultMaxNodeCount = 5_000_000;
+
+        private static int _maxDepth = DefaultMaxDepth;
+        private static int _maxNodeCount = DefaultMaxNodeCount;
+
+        /// <summary>
+        /// Gets or sets the maximum nesting depth allowed when converting a YAML node graph into JSON nodes.
+        /// Defaults to <see cref="DefaultMaxDepth"/>. Raise this if legitimate deeply nested documents are
+        /// being rejected, or lower it to fail faster when only shallow documents are expected.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when set to a value less than 1.</exception>
+        public static int MaxDepth
+        {
+            get => _maxDepth;
+            set
+            {
+                if (value < 1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "MaxDepth must be greater than zero.");
+                }
+
+                _maxDepth = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum number of JSON nodes that may be materialized from a single YAML document.
+        /// Defaults to <see cref="DefaultMaxNodeCount"/>, guarding against YAML anchor/alias expansion
+        /// ("billion laughs") attacks. Raise this if legitimate large documents are being rejected, or lower
+        /// it to fail faster when only small documents are expected.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when set to a value less than 1.</exception>
+        public static int MaxNodeCount
+        {
+            get => _maxNodeCount;
+            set
+            {
+                if (value < 1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "MaxNodeCount must be greater than zero.");
+                }
+
+                _maxNodeCount = value;
+            }
+        }
 
         /// <summary>
         /// Tracks and enforces resource limits while converting a YAML node graph into JSON nodes,
@@ -39,7 +82,7 @@ namespace Microsoft.OpenApi.YamlReader
             private readonly int _maxNodeCount;
             private int _nodeCount;
 
-            public YamlConversionBudget(int maxDepth = DefaultMaxDepth, int maxNodeCount = DefaultMaxNodeCount)
+            public YamlConversionBudget(int maxDepth, int maxNodeCount)
             {
                 _maxDepth = maxDepth;
                 _maxNodeCount = maxNodeCount;
@@ -87,7 +130,7 @@ namespace Microsoft.OpenApi.YamlReader
         /// <exception cref="NotSupportedException">Thrown for YAML that is not compatible with JSON.</exception>
         public static JsonNode ToJsonNode(this YamlNode yaml)
         {
-            return yaml.ToJsonNode(new YamlConversionBudget(), 0);
+            return yaml.ToJsonNode(new YamlConversionBudget(MaxDepth, MaxNodeCount), 0);
         }
 
         private static JsonNode ToJsonNode(this YamlNode yaml, YamlConversionBudget budget, int depth)
@@ -130,7 +173,7 @@ namespace Microsoft.OpenApi.YamlReader
         /// <returns></returns>
         public static JsonObject ToJsonObject(this YamlMappingNode yaml)
         {
-            return yaml.ToJsonObject(new YamlConversionBudget(), 0);
+            return yaml.ToJsonObject(new YamlConversionBudget(MaxDepth, MaxNodeCount), 0);
         }
 
         private static JsonObject ToJsonObject(this YamlMappingNode yaml, YamlConversionBudget budget, int depth)
@@ -160,7 +203,7 @@ namespace Microsoft.OpenApi.YamlReader
         /// <returns></returns>
         public static JsonArray ToJsonArray(this YamlSequenceNode yaml)
         {
-            return yaml.ToJsonArray(new YamlConversionBudget(), 0);
+            return yaml.ToJsonArray(new YamlConversionBudget(MaxDepth, MaxNodeCount), 0);
         }
 
         private static JsonArray ToJsonArray(this YamlSequenceNode yaml, YamlConversionBudget budget, int depth)

--- a/src/Microsoft.OpenApi.YamlReader/YamlConverter.cs
+++ b/src/Microsoft.OpenApi.YamlReader/YamlConverter.cs
@@ -19,30 +19,30 @@ namespace Microsoft.OpenApi.YamlReader
         /// Mirrors the default System.Text.Json depth limit (64) that already bounds the JSON reader path,
         /// protecting the recursive conversion from stack exhaustion on deeply nested documents.
         /// </summary>
-        public const int DefaultMaxDepth = 64;
+        public const uint DefaultMaxDepth = 64;
 
         /// <summary>
         /// Default maximum number of JSON nodes that may be materialized from a single YAML document.
         /// Guards against YAML anchor/alias expansion ("billion laughs") attacks, where a tiny document
         /// expands exponentially when its shared node graph is materialized into an independent JSON tree.
         /// </summary>
-        public const int DefaultMaxNodeCount = 5_000_000;
+        public const uint DefaultMaxNodeCount = 5_000_000;
 
-        private static int _maxDepth = DefaultMaxDepth;
-        private static int _maxNodeCount = DefaultMaxNodeCount;
+        private static uint _maxDepth = DefaultMaxDepth;
+        private static uint _maxNodeCount = DefaultMaxNodeCount;
 
         /// <summary>
         /// Gets or sets the maximum nesting depth allowed when converting a YAML node graph into JSON nodes.
         /// Defaults to <see cref="DefaultMaxDepth"/>. Raise this if legitimate deeply nested documents are
         /// being rejected, or lower it to fail faster when only shallow documents are expected.
         /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when set to a value less than 1.</exception>
-        public static int MaxDepth
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when set to zero.</exception>
+        public static uint MaxDepth
         {
             get => _maxDepth;
             set
             {
-                if (value < 1)
+                if (value == 0)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), "MaxDepth must be greater than zero.");
                 }
@@ -57,13 +57,13 @@ namespace Microsoft.OpenApi.YamlReader
         /// ("billion laughs") attacks. Raise this if legitimate large documents are being rejected, or lower
         /// it to fail faster when only small documents are expected.
         /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when set to a value less than 1.</exception>
-        public static int MaxNodeCount
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when set to zero.</exception>
+        public static uint MaxNodeCount
         {
             get => _maxNodeCount;
             set
             {
-                if (value < 1)
+                if (value == 0)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), "MaxNodeCount must be greater than zero.");
                 }
@@ -78,17 +78,17 @@ namespace Microsoft.OpenApi.YamlReader
         /// </summary>
         private sealed class YamlConversionBudget
         {
-            private readonly int _maxDepth;
-            private readonly int _maxNodeCount;
-            private int _nodeCount;
+            private readonly uint _maxDepth;
+            private readonly uint _maxNodeCount;
+            private uint _nodeCount;
 
-            public YamlConversionBudget(int maxDepth, int maxNodeCount)
+            public YamlConversionBudget(uint maxDepth, uint maxNodeCount)
             {
                 _maxDepth = maxDepth;
                 _maxNodeCount = maxNodeCount;
             }
 
-            public void EnterNode(int depth)
+            public void EnterNode(uint depth)
             {
                 if (depth > _maxDepth)
                 {
@@ -133,7 +133,7 @@ namespace Microsoft.OpenApi.YamlReader
             return yaml.ToJsonNode(new YamlConversionBudget(MaxDepth, MaxNodeCount), 0);
         }
 
-        private static JsonNode ToJsonNode(this YamlNode yaml, YamlConversionBudget budget, int depth)
+        private static JsonNode ToJsonNode(this YamlNode yaml, YamlConversionBudget budget, uint depth)
         {
             budget.EnterNode(depth);
             return yaml switch
@@ -176,7 +176,7 @@ namespace Microsoft.OpenApi.YamlReader
             return yaml.ToJsonObject(new YamlConversionBudget(MaxDepth, MaxNodeCount), 0);
         }
 
-        private static JsonObject ToJsonObject(this YamlMappingNode yaml, YamlConversionBudget budget, int depth)
+        private static JsonObject ToJsonObject(this YamlMappingNode yaml, YamlConversionBudget budget, uint depth)
         {
             var node = new JsonObject();
             foreach (var keyValuePair in yaml)
@@ -206,7 +206,7 @@ namespace Microsoft.OpenApi.YamlReader
             return yaml.ToJsonArray(new YamlConversionBudget(MaxDepth, MaxNodeCount), 0);
         }
 
-        private static JsonArray ToJsonArray(this YamlSequenceNode yaml, YamlConversionBudget budget, int depth)
+        private static JsonArray ToJsonArray(this YamlSequenceNode yaml, YamlConversionBudget budget, uint depth)
         {
             var node = new JsonArray();
             foreach (var value in yaml)

--- a/src/Microsoft.OpenApi.YamlReader/YamlConverter.cs
+++ b/src/Microsoft.OpenApi.YamlReader/YamlConverter.cs
@@ -15,6 +15,51 @@ namespace Microsoft.OpenApi.YamlReader
     public static class YamlConverter
     {
         /// <summary>
+        /// Default maximum nesting depth allowed when converting a YAML node graph into JSON nodes.
+        /// Mirrors the default System.Text.Json depth limit (64) that already bounds the JSON reader path,
+        /// protecting the recursive conversion from stack exhaustion on deeply nested documents.
+        /// </summary>
+        internal const int DefaultMaxDepth = 64;
+
+        /// <summary>
+        /// Default maximum number of JSON nodes that may be materialized from a single YAML document.
+        /// Guards against YAML anchor/alias expansion ("billion laughs") attacks, where a tiny document
+        /// expands exponentially when its shared node graph is materialized into an independent JSON tree.
+        /// Increase this only if legitimate large documents are being rejected.
+        /// </summary>
+        internal const int DefaultMaxNodeCount = 5_000_000;
+
+        /// <summary>
+        /// Tracks and enforces resource limits while converting a YAML node graph into JSON nodes,
+        /// failing fast when a hostile document would otherwise exhaust memory or the stack.
+        /// </summary>
+        private sealed class YamlConversionBudget
+        {
+            private readonly int _maxDepth;
+            private readonly int _maxNodeCount;
+            private int _nodeCount;
+
+            public YamlConversionBudget(int maxDepth = DefaultMaxDepth, int maxNodeCount = DefaultMaxNodeCount)
+            {
+                _maxDepth = maxDepth;
+                _maxNodeCount = maxNodeCount;
+            }
+
+            public void EnterNode(int depth)
+            {
+                if (depth > _maxDepth)
+                {
+                    throw new OpenApiReaderException($"The YAML document exceeds the maximum supported nesting depth of {_maxDepth}.");
+                }
+
+                if (++_nodeCount > _maxNodeCount)
+                {
+                    throw new OpenApiReaderException($"The YAML document expands to more than the maximum supported number of nodes ({_maxNodeCount}). This may indicate a YAML anchor/alias expansion (billion laughs) attack.");
+                }
+            }
+        }
+
+        /// <summary>
         /// Converts all of the documents in a YAML stream to <see cref="JsonNode"/>s.
         /// </summary>
         /// <param name="yaml">The YAML stream.</param>
@@ -42,10 +87,16 @@ namespace Microsoft.OpenApi.YamlReader
         /// <exception cref="NotSupportedException">Thrown for YAML that is not compatible with JSON.</exception>
         public static JsonNode ToJsonNode(this YamlNode yaml)
         {
+            return yaml.ToJsonNode(new YamlConversionBudget(), 0);
+        }
+
+        private static JsonNode ToJsonNode(this YamlNode yaml, YamlConversionBudget budget, int depth)
+        {
+            budget.EnterNode(depth);
             return yaml switch
             {
-                YamlMappingNode map => map.ToJsonObject(),
-                YamlSequenceNode seq => seq.ToJsonArray(),
+                YamlMappingNode map => map.ToJsonObject(budget, depth),
+                YamlSequenceNode seq => seq.ToJsonArray(budget, depth),
                 YamlScalarNode scalar => scalar.ToJsonValue(),
                 _ => throw new NotSupportedException("This yaml isn't convertible to JSON")
             };
@@ -79,11 +130,16 @@ namespace Microsoft.OpenApi.YamlReader
         /// <returns></returns>
         public static JsonObject ToJsonObject(this YamlMappingNode yaml)
         {
+            return yaml.ToJsonObject(new YamlConversionBudget(), 0);
+        }
+
+        private static JsonObject ToJsonObject(this YamlMappingNode yaml, YamlConversionBudget budget, int depth)
+        {
             var node = new JsonObject();
             foreach (var keyValuePair in yaml)
             {
                 var key = ((YamlScalarNode)keyValuePair.Key).Value!;
-                node[key] = keyValuePair.Value.ToJsonNode();
+                node[key] = keyValuePair.Value.ToJsonNode(budget, depth + 1);
             }
 
             return node;
@@ -104,10 +160,15 @@ namespace Microsoft.OpenApi.YamlReader
         /// <returns></returns>
         public static JsonArray ToJsonArray(this YamlSequenceNode yaml)
         {
+            return yaml.ToJsonArray(new YamlConversionBudget(), 0);
+        }
+
+        private static JsonArray ToJsonArray(this YamlSequenceNode yaml, YamlConversionBudget budget, int depth)
+        {
             var node = new JsonArray();
             foreach (var value in yaml)
             {
-                node.Add(value.ToJsonNode());
+                node.Add(value.ToJsonNode(budget, depth + 1));
             }
 
             return node;

--- a/test/Microsoft.OpenApi.Readers.Tests/OpenApiYamlReaderTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/OpenApiYamlReaderTests.cs
@@ -75,6 +75,32 @@ public class OpenApiYamlReaderTests
         Assert.Throws<ArgumentNullException>(() => reader.Read(stream, DocumentLocation, null!));
     }
 
+    [Fact]
+    public void ReadReturnsDiagnosticErrorForExponentialAliasExpansion()
+    {
+        // A "billion laughs" YAML bomb must surface as a diagnostic error with no document,
+        // rather than throwing or exhausting memory.
+        var reader = new OpenApiYamlReader();
+        using var stream = CreateStream(
+            """
+            a: &a ["x","x","x","x","x","x","x","x","x"]
+            b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]
+            c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+            d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]
+            e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]
+            f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]
+            g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]
+            h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]
+            i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]
+            """);
+
+        var result = reader.Read(stream, DocumentLocation, SettingsFixture.ReaderSettings);
+
+        Assert.Null(result.Document);
+        Assert.NotEmpty(result.Diagnostic.Errors);
+        Assert.Equal(OpenApiConstants.Yaml, result.Diagnostic.Format);
+    }
+
     private static MemoryStream CreateStream(string yaml)
     {
         return new MemoryStream(Encoding.UTF8.GetBytes(yaml));

--- a/test/Microsoft.OpenApi.Readers.Tests/YamlConverterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/YamlConverterTests.cs
@@ -384,28 +384,24 @@ public class YamlConverterTests
     [Fact]
     public void ConversionLimitsDefaultToDocumentedValues()
     {
-        Assert.Equal(64, YamlConverter.DefaultMaxDepth);
-        Assert.Equal(5_000_000, YamlConverter.DefaultMaxNodeCount);
+        Assert.Equal(64u, YamlConverter.DefaultMaxDepth);
+        Assert.Equal(5_000_000u, YamlConverter.DefaultMaxNodeCount);
         Assert.Equal(YamlConverter.DefaultMaxDepth, YamlConverter.MaxDepth);
         Assert.Equal(YamlConverter.DefaultMaxNodeCount, YamlConverter.MaxNodeCount);
     }
 
-    [Theory]
-    [InlineData(0)]
-    [InlineData(-1)]
-    public void SettingMaxDepthBelowOneThrows(int value)
+    [Fact]
+    public void SettingMaxDepthToZeroThrows()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => YamlConverter.MaxDepth = value);
+        Assert.Throws<ArgumentOutOfRangeException>(() => YamlConverter.MaxDepth = 0);
         // The invalid assignment must not have changed the effective limit.
         Assert.Equal(YamlConverter.DefaultMaxDepth, YamlConverter.MaxDepth);
     }
 
-    [Theory]
-    [InlineData(0)]
-    [InlineData(-1)]
-    public void SettingMaxNodeCountBelowOneThrows(int value)
+    [Fact]
+    public void SettingMaxNodeCountToZeroThrows()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => YamlConverter.MaxNodeCount = value);
+        Assert.Throws<ArgumentOutOfRangeException>(() => YamlConverter.MaxNodeCount = 0);
         // The invalid assignment must not have changed the effective limit.
         Assert.Equal(YamlConverter.DefaultMaxNodeCount, YamlConverter.MaxNodeCount);
     }

--- a/test/Microsoft.OpenApi.Readers.Tests/YamlConverterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/YamlConverterTests.cs
@@ -333,6 +333,54 @@ public class YamlConverterTests
         Assert.Equal(yamlInput.MakeLineBreaksEnvironmentNeutral(), convertedBackOutput.MakeLineBreaksEnvironmentNeutral());
     }
 
+    [Fact]
+    public void ExponentialAliasExpansionIsRejected()
+    {
+        // A "billion laughs" YAML bomb: each level references the previous one multiple times,
+        // so materializing the shared node graph into an independent JSON tree expands
+        // exponentially. The conversion must fail fast instead of exhausting memory.
+        var yamlBomb =
+        """
+        a: &a ["x","x","x","x","x","x","x","x","x"]
+        b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]
+        c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+        d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]
+        e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]
+        f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]
+        g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]
+        h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]
+        i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]
+        """;
+
+        Assert.Throws<OpenApiReaderException>(() => ConvertYamlStringToJsonNode(yamlBomb));
+    }
+
+    [Fact]
+    public void ExcessiveNestingDepthIsRejected()
+    {
+        // Deeper than the conversion depth limit (mirrors the System.Text.Json default of 64),
+        // which protects the recursive converter from stack exhaustion.
+        const int depth = 70;
+        var deeplyNested = new string('[', depth) + new string(']', depth);
+
+        Assert.Throws<OpenApiReaderException>(() => ConvertYamlStringToJsonNode(deeplyNested));
+    }
+
+    [Fact]
+    public void LegitimateAliasesStillConvert()
+    {
+        var yamlInput =
+        """
+        a: &val hello
+        b: *val
+        """;
+
+        var jsonNode = Assert.IsType<JsonObject>(ConvertYamlStringToJsonNode(yamlInput));
+
+        Assert.Equal("hello", jsonNode["a"]?.GetValue<string>());
+        Assert.Equal("hello", jsonNode["b"]?.GetValue<string>());
+    }
+
     private static JsonNode ConvertYamlStringToJsonNode(string yamlInput)
     {
         var yamlDocument = new YamlStream();

--- a/test/Microsoft.OpenApi.Readers.Tests/YamlConverterTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/YamlConverterTests.cs
@@ -381,6 +381,55 @@ public class YamlConverterTests
         Assert.Equal("hello", jsonNode["b"]?.GetValue<string>());
     }
 
+    [Fact]
+    public void ConversionLimitsDefaultToDocumentedValues()
+    {
+        Assert.Equal(64, YamlConverter.DefaultMaxDepth);
+        Assert.Equal(5_000_000, YamlConverter.DefaultMaxNodeCount);
+        Assert.Equal(YamlConverter.DefaultMaxDepth, YamlConverter.MaxDepth);
+        Assert.Equal(YamlConverter.DefaultMaxNodeCount, YamlConverter.MaxNodeCount);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void SettingMaxDepthBelowOneThrows(int value)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => YamlConverter.MaxDepth = value);
+        // The invalid assignment must not have changed the effective limit.
+        Assert.Equal(YamlConverter.DefaultMaxDepth, YamlConverter.MaxDepth);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void SettingMaxNodeCountBelowOneThrows(int value)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => YamlConverter.MaxNodeCount = value);
+        // The invalid assignment must not have changed the effective limit.
+        Assert.Equal(YamlConverter.DefaultMaxNodeCount, YamlConverter.MaxNodeCount);
+    }
+
+    [Fact]
+    public void RaisingMaxDepthAllowsDocumentsDeeperThanTheDefault()
+    {
+        // A document nested deeper than the default depth limit (64) is rejected by default
+        // but can be permitted by a consumer that opts into a higher limit.
+        const int depth = 70;
+        var deeplyNested = new string('[', depth) + new string(']', depth);
+
+        try
+        {
+            YamlConverter.MaxDepth = depth + 10;
+            var jsonNode = ConvertYamlStringToJsonNode(deeplyNested);
+            Assert.IsType<JsonArray>(jsonNode);
+        }
+        finally
+        {
+            YamlConverter.MaxDepth = YamlConverter.DefaultMaxDepth;
+        }
+    }
+
     private static JsonNode ConvertYamlStringToJsonNode(string yamlInput)
     {
         var yamlDocument = new YamlStream();


### PR DESCRIPTION
## Problem

The YAML reader is exposed to an uncontrolled-resource-consumption ("billion laughs") denial of service (CWE-400). A tiny YAML document (well under 1 KB) using nested anchors/aliases can force the process to allocate many gigabytes and be OOM-killed. See https://portal.microsofticm.com/imp/v5/incidents/details/31000000667626/summary 

### Root cause

`OpenApiYamlReader` parses YAML via SharpYaml's `YamlStream.Load`, which produces a **DAG** where an alias (`*a`) resolves to the **same shared `YamlNode` instance** — so the parsed graph stays small. The explosion happens in `YamlConverter.ToJsonNode`, which converts that DAG into a `System.Text.Json` `JsonNode` tree. Because `JsonNode` is **single-parent** (a node cannot be attached to two parents), every alias occurrence must be materialized as an **independent copy**. With no bound, `N` nested anchors each referenced `k` times expand to `k^N` nodes → exponential memory → OOM.

Deduplication/sharing is not possible (single-parent constraint), so the only viable fix is to **bound the work and fail fast**.

## Fix

Add a conversion budget threaded through `YamlConverter.ToJsonNode` that enforces two limits:

| Limit | Default | Protects against |
|---|---|---|
| Max materialized node count | 5,000,000 | Exponential anchor/alias expansion — the counter measures *expanded* nodes, so it trips well before OOM |
| Max nesting depth | 64 | Deep-nesting stack overflow in the recursive converter |

Rationale for the values:
- **Depth 64** mirrors the default `System.Text.Json` `MaxDepth` already enforced on the JSON reader path (`JsonNode.Parse`), so this brings YAML to parity — any document deeper than 64 already fails today when supplied as JSON.
- **Node count 5,000,000** is comfortably above legitimate specs (whose node count is linear in document size when they don't rely on alias fan-out), while a bomb trips almost immediately because the counter measures the *expansion*.

On breach the budget throws `OpenApiReaderException`, which `OpenApiYamlReader.Read` converts into an `OpenApiDiagnostic` **error** (`Document = null`) — consistent with the existing `JsonException` handling — instead of allowing an OOM.

### Configurable limits

The two limits are exposed as public static `uint` properties on `YamlConverter` so consumers are never blocked by the defaults:

- `YamlConverter.MaxDepth` (default `YamlConverter.DefaultMaxDepth` = 64)
- `YamlConverter.MaxNodeCount` (default `YamlConverter.DefaultMaxNodeCount` = 5,000,000)

A consumer that must ingest an unusually large/deep-but-trusted document can **raise** the limits; a consumer that only ever parses small documents can **lower** them to fail faster. `uint` makes the non-negative intent explicit at the type level (negative literals fail to compile), and the setters reject `0`. These are the only additions to the public API (recorded in `PublicAPI.Unshipped.txt`).

Note the limits are **process-wide static** state, best configured once at startup. They are an escape hatch for the defaults, not per-parse/per-thread configuration.

## Tests

- `YamlConverterTests.ExponentialAliasExpansionIsRejected` — a nested anchor/alias bomb is rejected instead of exhausting memory.
- `YamlConverterTests.ExcessiveNestingDepthIsRejected` — nesting beyond the depth limit is rejected.
- `YamlConverterTests.LegitimateAliasesStillConvert` — normal alias usage still converts correctly.
- `YamlConverterTests.ConversionLimitsDefaultToDocumentedValues` — the properties expose the documented defaults.
- `YamlConverterTests.SettingMaxDepthToZeroThrows` / `SettingMaxNodeCountToZeroThrows` — zero limits are rejected and leave the effective limit unchanged.
- `YamlConverterTests.RaisingMaxDepthAllowsDocumentsDeeperThanTheDefault` — raising the limit permits a document deeper than the default.
- `OpenApiYamlReaderTests.ReadReturnsDiagnosticErrorForExponentialAliasExpansion` — the reader surfaces a diagnostic error (no document), not a throw/OOM.

Full `Microsoft.OpenApi.Readers.Tests` suite passes.

## Validation on a large real-world spec (no false positives)

To confirm the limits do not reject legitimately large production descriptions, the **Microsoft Graph beta** OpenAPI document was loaded end-to-end through the patched reader.

| Property | Value |
|---|---|
| Source | `microsoftgraph/msgraph-metadata` @ `73fc270c924975a98f8f9d93d61fd4cff2297084`, path `openapi/beta/openapi.yaml` |
| SHA-256 | `830108DDB021845583F0C9F6D185BCE465CA4CB1E673E50B2F98DB05E54C21AD` |
| Size | 66.4 MB (69,627,334 bytes), OpenAPI 3.0.4 |
| Content | 18,485 paths, 10,368 component schemas |

Result under the patched build (with default limits):

| Metric | Measured | Limit | Utilization |
|---|---|---|---|
| Materialized JSON nodes | **1,735,855** | 5,000,000 | ~35% (≈2.9× headroom) |
| Max nesting depth | **14** | 64 | ~22% (≈4.5× headroom) |
| `OpenApiDocument.LoadAsync` | **success, 0 diagnostics** | — | — |

The largest realistic production spec sits well below both caps, while the exponential bomb (theoretical ~387M nodes) is rejected almost immediately. The limits target the *exponential* pathology, not document size.

## Notes / scope

- This is distinct from CVE-2026-49451 (circular `$ref` stack overflow), which was already fixed in 3.5.4.
- `ReadFragment` is still protected by the budget (it throws rather than OOM) but does not convert the exception to a diagnostic — left out of scope intentionally; happy to extend if preferred.
- The same fix applies byte-for-byte to `support/v2`; a companion PR will follow. `support/v1` uses a different YAML parsing path and needs a separate assessment.
