### PR TITLE
ci(pipeline): pin .NET 10 SDK to global.json version

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -69,7 +69,7 @@ extends:
         - task: UseDotNet@2
           displayName: 'Use .NET 10'
           inputs:
-            version: 10.x
+            useGlobalJson: true
         
         # Install the nuget tool.
         - task: NuGetToolInstaller@1


### PR DESCRIPTION
## Summary

Updates the "Use .NET 10" task in the ADO pipeline (`.azure-pipelines/ci-build.yml`) to install the exact .NET SDK version requested by `global.json` (`10.0.302`) instead of the floating `10.x`.

## Changes

- Replaced `version: 10.x` with `useGlobalJson: true` on the `UseDotNet@2` task. The task now resolves the SDK version from the repo's `global.json`, keeping the pipeline aligned with the pinned SDK automatically.