### PR TITLE
Simplify Microsoft.OpenApi package references

### DIFF
--- a/src/Microsoft.OpenApi.YamlReader/Microsoft.OpenApi.YamlReader.csproj
+++ b/src/Microsoft.OpenApi.YamlReader/Microsoft.OpenApi.YamlReader.csproj
@@ -33,7 +33,7 @@
         <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" PrivateAssets="all" />
 
         <PackageReference Include="SharpYaml" Version="2.1.5" />
-        <PackageReference Include="System.Text.Json" Version="[8.0.5,)" Condition="'$(TargetFramework)' != 'net8.0'" />
+        <PackageReference Include="System.Text.Json" Version="[8.0.5,)" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.OpenApi.YamlReader/Microsoft.OpenApi.YamlReader.csproj
+++ b/src/Microsoft.OpenApi.YamlReader/Microsoft.OpenApi.YamlReader.csproj
@@ -28,20 +28,12 @@
 
     <ItemGroup>
 
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0">
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-          <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
+        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" PrivateAssets="all" />
 
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23">
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-          <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23" PrivateAssets="all" />
 
         <PackageReference Include="SharpYaml" Version="2.1.5" />
-        <PackageReference Include="System.Text.Json" Version="[8.0.5,)" />
-        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hh2w-p6rv-4g7w" />
-        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
+        <PackageReference Include="System.Text.Json" Version="[8.0.5,)" Condition="'$(TargetFramework)' != 'net8.0'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -24,13 +24,10 @@
         <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     </PropertyGroup>
     <ItemGroup>        
-        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0">
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-          <PrivateAssets>all</PrivateAssets>
-        </PackageReference>        
-        <PackageReference Include="System.Text.Json" Version="[8.0.5,)" />
-        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-hh2w-p6rv-4g7w" />
-        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
+        <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" PrivateAssets="all" />
+
+        <!-- We don't need the package reference under .NET 8. We get STJ from the BCL. -->
+        <PackageReference Include="System.Text.Json" Version="[8.0.5,)" Condition="'$(TargetFramework)' != 'net8.0'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -27,7 +27,7 @@
         <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" PrivateAssets="all" />
 
         <!-- We don't need the package reference under .NET 8. We get STJ from the BCL. -->
-        <PackageReference Include="System.Text.Json" Version="[8.0.5,)" Condition="'$(TargetFramework)' != 'net8.0'" />
+        <PackageReference Include="System.Text.Json" Version="[8.0.5,)" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))"  />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- We don't need the explicit `IncludeAssets`. `PrivateAssets="all"` does the needed job.
- We don't need to include STJ in the dependency graph for .NET 8. We get that via the BCL automatically when targeting net8.0 or later.