### PR TITLE
ci: migrate MTP reporting

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -105,19 +105,11 @@ extends:
               --configuration $(BuildConfiguration) `
               --no-build `
               -- `
-              --report-xunit-trx `
-              --results-directory "$(Agent.TempDirectory)\TestResults" `
+              --report-azdo `
+              --publish-azdo-test-results `
+              --results-directory="$(Agent.TempDirectory)\TestResults" `
               --minimum-expected-tests 1
           displayName: 'test'
-
-        - task: PublishTestResults@2
-          displayName: 'Publish test results'
-          condition: succeededOrFailed()
-          inputs:
-            testResultsFormat: VSTest
-            testResultsFiles: '$(Agent.TempDirectory)\TestResults\*.trx'
-            failTaskOnMissingResultsFile: true
-            failTaskOnFailedTests: true
 
         - task: EsrpCodeSigning@6
           displayName: 'ESRP CodeSigning binaries'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,12 @@ updates:
     MicrosoftExtensions:
       patterns:
       - Microsoft.Extensions.*
-    coverlet:
+    testing:
       patterns:
       - coverlet.*
+      - Microsoft.NET.Test.Sdk
+      - Microsoft.Testing.*
+      - xunit.*
   cooldown:
     default-days: 7
 - package-ecosystem: dotnet-sdk

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,7 +45,7 @@ jobs:
         id: run_unit_tests
         shell: pwsh
         run: |
-          dotnet test --solution Microsoft.OpenApi.slnx -c Release -v n --coverlet --coverlet-output-format cobertura
+          dotnet test --solution Microsoft.OpenApi.slnx -c Release -v n --results-directory=./TestResults --coverlet --coverlet-output-format cobertura --report-gh
 
       - name: Install report generator
         shell: pwsh
@@ -55,7 +55,7 @@ jobs:
       - name: Generate coverage report
         shell: pwsh
         run: |
-          reportgenerator -reports:**/coverage.cobertura*.xml -targetdir:./reports/coverage -reporttypes:"Html;MarkdownSummaryGithub;Cobertura"
+          reportgenerator -reports:./TestResults/**/coverage.cobertura.*.xml -targetdir:./reports/coverage -reporttypes:"Html;MarkdownSummaryGithub;Cobertura"
 
       - name: Add coverage to job summary
         shell: bash

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -66,5 +66,5 @@ jobs:
           dotnet tool run dotnet-sonarscanner begin /k:"microsoft_OpenAPI.NET" /o:"microsoft" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover*.xml"
           dotnet workload restore
           dotnet build
-          dotnet test --solution Microsoft.OpenApi.slnx --verbosity normal --coverlet --coverlet-output-format opencover
+          dotnet test --solution Microsoft.OpenApi.slnx --verbosity normal --coverlet --coverlet-output-format opencover --report-gh
           dotnet tool run dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/test/Microsoft.OpenApi.Hidi.Tests/Microsoft.OpenApi.Hidi.Tests.csproj
+++ b/test/Microsoft.OpenApi.Hidi.Tests/Microsoft.OpenApi.Hidi.Tests.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.MTP" Version="10.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.AzureDevOpsReport" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" Version="2.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>

--- a/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
+++ b/test/Microsoft.OpenApi.Readers.Tests/Microsoft.OpenApi.Readers.Tests.csproj
@@ -18,6 +18,8 @@
     <ItemGroup>
         <PackageReference Include="coverlet.MTP" Version="10.0.1" PrivateAssets="all" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+        <PackageReference Include="Microsoft.Testing.Extensions.AzureDevOpsReport" Version="2.4.0" />
+        <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" Version="2.4.0" />
         <PackageReference Include="xunit.v3" Version="4.0.0" />
     </ItemGroup>
 

--- a/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
+++ b/test/Microsoft.OpenApi.Tests/Microsoft.OpenApi.Tests.csproj
@@ -11,6 +11,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.MTP" Version="10.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.AzureDevOpsReport" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" Version="2.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Verify.XunitV3" Version="32.0.0" />
     <PackageReference Include="xunit.v3" Version="4.0.0" />


### PR DESCRIPTION
## Summary
- Port Kiota's MTP reporting updates to GitHub Actions and Azure Pipelines
- Add GitHub Actions/Azure DevOps MTP reporter package references to test projects
- Update coverage and Dependabot testing dependency grouping

## Validation
- dotnet restore D:\github\OpenAPI.NET\Microsoft.OpenApi.slnx
- dotnet test D:\github\OpenAPI.NET\test\Microsoft.OpenApi.Readers.Tests\Microsoft.OpenApi.Readers.Tests.csproj -c Release --no-restore --verbosity minimal --minimum-expected-tests 1